### PR TITLE
feat: service layer, dynamic navbar, tasks & members pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,35 @@ All routes are prefixed with `/api`. Each route notes the minimum permission req
 ```text
 app/
   (app)/          # Authenticated app shell (navbar + sidebar layout)
+    orgs/
+      new/        # Create org page
+      [orgId]/
+        page.tsx         # Org overview
+        tasks/           # Task list + create task form
+        memberships/     # Members list
   (auth)/         # Unauthenticated pages (sign in)
-  api/            # REST API route handlers
+  actions/        # Server Actions (web UI mutations)
+    orgs.ts       # createOrg action
+    tasks.ts      # createTaskAction
+  api/            # REST API route handlers (external/mobile clients)
 components/
-  layout/         # App shell components (navbar, sidebar, org-switcher)
+  layout/
+    navbar.tsx              # Top bar (server component)
+    navbar-context-actions.tsx  # Route-aware action buttons (client boundary)
+    actions/                # Per-page action button components
+      tasks-actions.tsx
+      members-actions.tsx
+    sidebar.tsx             # Dynamic sidebar nav (client component)
+    org-switcher.tsx        # Org selector dropdown
   ui/             # shadcn/ui primitives
 lib/
+  services/       # Business logic layer — called by both API routes and Server Actions
+    types.ts      # ServiceResult<T> discriminated union
+    orgs.ts
+    memberships.ts
+    tasks.ts
+    task-instances.ts
+    assignees.ts
   authz.ts        # Server-side auth guard helpers
   rbac.ts         # Predefined role key constants
   prisma.ts       # Prisma client singleton
@@ -194,6 +217,33 @@ prisma/
   seed.ts         # Dev seed data
 ```
 
+## Server Actions vs API Routes
+
+The app uses two mutation paths depending on the caller:
+
+| Path               | Used by                                | Location       |
+| ------------------ | -------------------------------------- | -------------- |
+| **Server Actions** | Web UI forms                           | `app/actions/` |
+| **API Routes**     | External clients (mobile, third-party) | `app/api/`     |
+
+Both are thin wrappers — they handle auth, validate input, then delegate to `lib/services/`. The service layer holds all database logic and is shared between both paths.
+
+Server Actions use `revalidatePath` to invalidate the Next.js cache so server-rendered pages reflect the latest data without a full page reload.
+
+## Pages
+
+| Route                       | Description                    |
+| --------------------------- | ------------------------------ |
+| `/`                         | Home — authenticated app shell |
+| `/signin`                   | Google OAuth sign-in           |
+| `/orgs/new`                 | Create a new organization      |
+| `/orgs/[orgId]`             | Org overview                   |
+| `/orgs/[orgId]/tasks`       | Task list for the org          |
+| `/orgs/[orgId]/tasks/new`   | Create a new task template     |
+| `/orgs/[orgId]/memberships` | Member list for the org        |
+
+All `/orgs/[orgId]/*` pages are guarded by `requireOrgMember` — users not in the org are redirected to `/`.
+
 ## Status
 
-Work in progress — initial scaffolding and planning.
+Work in progress — service layer, task management, and member views implemented.

--- a/app/(app)/orgs/[orgId]/memberships/page.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/page.tsx
@@ -1,0 +1,34 @@
+import { getMemberships } from "@/lib/services/memberships";
+import { requireOrgMember } from "@/lib/authz";
+import { redirect } from "next/navigation";
+
+const MembersPage = async ({ params }: { params: Promise<{ orgId: string }> }) => {
+  const { orgId } = await params;
+
+  const authz = await requireOrgMember(orgId);
+  if (!authz.ok) redirect("/");
+
+  const memberships = await getMemberships(orgId);
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <h1 className="text-xl font-semibold mb-6">Members</h1>
+      {memberships.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No members yet.</p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {memberships.map((m) => (
+            <li key={m.userId} className="border rounded-lg p-4 flex items-center justify-between">
+              <div className="flex flex-col gap-0.5">
+                <span className="font-medium">{m.user.name ?? "Unnamed user"}</span>
+                <span className="text-xs text-muted-foreground">{m.role.title}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default MembersPage;

--- a/app/(app)/orgs/[orgId]/memberships/page.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/page.tsx
@@ -2,7 +2,11 @@ import { getMemberships } from "@/lib/services/memberships";
 import { requireOrgMember } from "@/lib/authz";
 import { redirect } from "next/navigation";
 
-const MembersPage = async ({ params }: { params: Promise<{ orgId: string }> }) => {
+const MembersPage = async ({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) => {
   const { orgId } = await params;
 
   const authz = await requireOrgMember(orgId);
@@ -18,10 +22,17 @@ const MembersPage = async ({ params }: { params: Promise<{ orgId: string }> }) =
       ) : (
         <ul className="flex flex-col gap-3">
           {memberships.map((m) => (
-            <li key={m.userId} className="border rounded-lg p-4 flex items-center justify-between">
+            <li
+              key={m.userId}
+              className="border rounded-lg p-4 flex items-center justify-between"
+            >
               <div className="flex flex-col gap-0.5">
-                <span className="font-medium">{m.user.name ?? "Unnamed user"}</span>
-                <span className="text-xs text-muted-foreground">{m.role.title}</span>
+                <span className="font-medium">
+                  {m.user.name ?? "Unnamed user"}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {m.role.title}
+                </span>
               </div>
             </li>
           ))}

--- a/app/(app)/orgs/[orgId]/page.tsx
+++ b/app/(app)/orgs/[orgId]/page.tsx
@@ -1,0 +1,8 @@
+const Page = async ({ params }: { params: Promise<{ orgId: string }> }) => {
+  const { orgId } = await params;
+  return (
+    <div>org id: {orgId}</div>
+  )
+}
+
+export default Page

--- a/app/(app)/orgs/[orgId]/page.tsx
+++ b/app/(app)/orgs/[orgId]/page.tsx
@@ -1,8 +1,6 @@
 const Page = async ({ params }: { params: Promise<{ orgId: string }> }) => {
   const { orgId } = await params;
-  return (
-    <div>org id: {orgId}</div>
-  )
-}
+  return <div>org id: {orgId}</div>;
+};
 
-export default Page
+export default Page;

--- a/app/(app)/orgs/[orgId]/tasks/new/create-task-form.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/new/create-task-form.tsx
@@ -8,108 +8,161 @@ import { Input } from "@/components/ui/input";
 
 export const CreateTaskForm = ({ orgId }: { orgId: string }) => {
   const boundAction = createTaskAction.bind(null, orgId);
-  const [state, action, pending] = useActionState<CreateTaskFormState, FormData>(
-    boundAction,
-    null,
-  );
+  const [state, action, pending] = useActionState<
+    CreateTaskFormState,
+    FormData
+  >(boundAction, null);
 
   const err = (field: string) =>
     state && !state.ok ? (state.errors[field]?.[0] ?? null) : null;
-
+  const formError = err("_");
   return (
     <form action={action} className="flex flex-col gap-5">
+      {formError && (
+        <p role="alert" className="text-sm text-destructive">
+          {formError}
+        </p>
+      )}
       <div className="flex flex-col gap-1.5">
-        <label className="text-sm font-medium">
+        <label htmlFor="title" className="text-sm font-medium">
           Title <span className="text-destructive">*</span>
         </label>
-        <Input name="title" type="text" placeholder="e.g. Deep clean kitchen" />
-        {err("title") && <p className="text-xs text-destructive">{err("title")}</p>}
-      </div>
-
-      <div className="flex flex-col gap-1.5">
-        <label className="text-sm font-medium">Description</label>
-        <textarea
-          name="description"
-          rows={3}
-          placeholder="Optional details..."
-          className="border rounded-md px-3 py-2 text-sm bg-background resize-none focus:outline-none focus:ring-2 focus:ring-ring"
+        <Input
+          id="title"
+          name="title"
+          type="text"
+          placeholder="e.g. Deep clean kitchen"
+          aria-describedby={err("title") ? "title-error" : undefined}
         />
-        {err("description") && (
-          <p className="text-xs text-destructive">{err("description")}</p>
+        {err("title") && (
+          <p id="title-error" className="text-xs text-destructive">
+            {err("title")}
+          </p>
         )}
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <label className="text-sm font-medium">
+        <label htmlFor="description" className="text-sm font-medium">
+          Description
+        </label>
+        <textarea
+          id="description"
+          name="description"
+          rows={3}
+          placeholder="Optional details..."
+          aria-describedby={err("description") ? "description-error" : undefined}
+          className="border rounded-md px-3 py-2 text-sm bg-background resize-none focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        {err("description") && (
+          <p id="description-error" className="text-xs text-destructive">
+            {err("description")}
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="durationMin" className="text-sm font-medium">
           Duration (minutes) <span className="text-destructive">*</span>
         </label>
         <Input
+          id="durationMin"
           name="durationMin"
           type="number"
           min={1}
           max={1440}
           placeholder="e.g. 60"
+          aria-describedby={err("durationMin") ? "durationMin-error" : undefined}
         />
         {err("durationMin") && (
-          <p className="text-xs text-destructive">{err("durationMin")}</p>
+          <p id="durationMin-error" className="text-xs text-destructive">
+            {err("durationMin")}
+          </p>
         )}
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <label className="text-sm font-medium">
+        <label htmlFor="preferredStartTimeMin" className="text-sm font-medium">
           Preferred start time (minutes since midnight)
         </label>
         <Input
+          id="preferredStartTimeMin"
           name="preferredStartTimeMin"
           type="number"
           min={0}
           max={1439}
           placeholder="e.g. 480 = 8:00 am"
+          aria-describedby={
+            err("preferredStartTimeMin")
+              ? "preferredStartTimeMin-error"
+              : undefined
+          }
         />
         {err("preferredStartTimeMin") && (
-          <p className="text-xs text-destructive">{err("preferredStartTimeMin")}</p>
+          <p id="preferredStartTimeMin-error" className="text-xs text-destructive">
+            {err("preferredStartTimeMin")}
+          </p>
         )}
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <label className="text-sm font-medium">People required</label>
+        <label htmlFor="peopleRequired" className="text-sm font-medium">
+          People required
+        </label>
         <Input
+          id="peopleRequired"
           name="peopleRequired"
           type="number"
           min={1}
           max={50}
           defaultValue={1}
+          aria-describedby={
+            err("peopleRequired") ? "peopleRequired-error" : undefined
+          }
         />
         {err("peopleRequired") && (
-          <p className="text-xs text-destructive">{err("peopleRequired")}</p>
+          <p id="peopleRequired-error" className="text-xs text-destructive">
+            {err("peopleRequired")}
+          </p>
         )}
       </div>
 
       <div className="grid grid-cols-2 gap-4">
         <div className="flex flex-col gap-1.5">
-          <label className="text-sm font-medium">Min wait days</label>
+          <label htmlFor="minWaitDays" className="text-sm font-medium">
+            Min wait days
+          </label>
           <Input
+            id="minWaitDays"
             name="minWaitDays"
             type="number"
             min={0}
             max={3650}
             placeholder="e.g. 7"
+            aria-describedby={err("minWaitDays") ? "minWaitDays-error" : undefined}
           />
           {err("minWaitDays") && (
-            <p className="text-xs text-destructive">{err("minWaitDays")}</p>
+            <p id="minWaitDays-error" className="text-xs text-destructive">
+              {err("minWaitDays")}
+            </p>
           )}
         </div>
         <div className="flex flex-col gap-1.5">
-          <label className="text-sm font-medium">Max wait days</label>
+          <label htmlFor="maxWaitDays" className="text-sm font-medium">
+            Max wait days
+          </label>
           <Input
+            id="maxWaitDays"
             name="maxWaitDays"
             type="number"
             min={1}
             max={3650}
             placeholder="e.g. 14"
+            aria-describedby={err("maxWaitDays") ? "maxWaitDays-error" : undefined}
           />
           {err("maxWaitDays") && (
-            <p className="text-xs text-destructive">{err("maxWaitDays")}</p>
+            <p id="maxWaitDays-error" className="text-xs text-destructive">
+              {err("maxWaitDays")}
+            </p>
           )}
         </div>
       </div>

--- a/app/(app)/orgs/[orgId]/tasks/new/create-task-form.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/new/create-task-form.tsx
@@ -31,6 +31,7 @@ export const CreateTaskForm = ({ orgId }: { orgId: string }) => {
           id="title"
           name="title"
           type="text"
+          required
           placeholder="e.g. Deep clean kitchen"
           aria-describedby={err("title") ? "title-error" : undefined}
         />
@@ -50,7 +51,9 @@ export const CreateTaskForm = ({ orgId }: { orgId: string }) => {
           name="description"
           rows={3}
           placeholder="Optional details..."
-          aria-describedby={err("description") ? "description-error" : undefined}
+          aria-describedby={
+            err("description") ? "description-error" : undefined
+          }
           className="border rounded-md px-3 py-2 text-sm bg-background resize-none focus:outline-none focus:ring-2 focus:ring-ring"
         />
         {err("description") && (
@@ -68,10 +71,13 @@ export const CreateTaskForm = ({ orgId }: { orgId: string }) => {
           id="durationMin"
           name="durationMin"
           type="number"
+          required
           min={1}
           max={1440}
           placeholder="e.g. 60"
-          aria-describedby={err("durationMin") ? "durationMin-error" : undefined}
+          aria-describedby={
+            err("durationMin") ? "durationMin-error" : undefined
+          }
         />
         {err("durationMin") && (
           <p id="durationMin-error" className="text-xs text-destructive">
@@ -98,7 +104,10 @@ export const CreateTaskForm = ({ orgId }: { orgId: string }) => {
           }
         />
         {err("preferredStartTimeMin") && (
-          <p id="preferredStartTimeMin-error" className="text-xs text-destructive">
+          <p
+            id="preferredStartTimeMin-error"
+            className="text-xs text-destructive"
+          >
             {err("preferredStartTimeMin")}
           </p>
         )}
@@ -138,7 +147,9 @@ export const CreateTaskForm = ({ orgId }: { orgId: string }) => {
             min={0}
             max={3650}
             placeholder="e.g. 7"
-            aria-describedby={err("minWaitDays") ? "minWaitDays-error" : undefined}
+            aria-describedby={
+              err("minWaitDays") ? "minWaitDays-error" : undefined
+            }
           />
           {err("minWaitDays") && (
             <p id="minWaitDays-error" className="text-xs text-destructive">
@@ -157,7 +168,9 @@ export const CreateTaskForm = ({ orgId }: { orgId: string }) => {
             min={1}
             max={3650}
             placeholder="e.g. 14"
-            aria-describedby={err("maxWaitDays") ? "maxWaitDays-error" : undefined}
+            aria-describedby={
+              err("maxWaitDays") ? "maxWaitDays-error" : undefined
+            }
           />
           {err("maxWaitDays") && (
             <p id="maxWaitDays-error" className="text-xs text-destructive">

--- a/app/(app)/orgs/[orgId]/tasks/new/create-task-form.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/new/create-task-form.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useActionState } from "react";
+import { createTaskAction } from "@/app/actions/tasks";
+import type { CreateTaskFormState } from "@/app/actions/tasks";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export const CreateTaskForm = ({ orgId }: { orgId: string }) => {
+  const boundAction = createTaskAction.bind(null, orgId);
+  const [state, action, pending] = useActionState<CreateTaskFormState, FormData>(
+    boundAction,
+    null,
+  );
+
+  const err = (field: string) =>
+    state && !state.ok ? (state.errors[field]?.[0] ?? null) : null;
+
+  return (
+    <form action={action} className="flex flex-col gap-5">
+      <div className="flex flex-col gap-1.5">
+        <label className="text-sm font-medium">
+          Title <span className="text-destructive">*</span>
+        </label>
+        <Input name="title" type="text" placeholder="e.g. Deep clean kitchen" />
+        {err("title") && <p className="text-xs text-destructive">{err("title")}</p>}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-sm font-medium">Description</label>
+        <textarea
+          name="description"
+          rows={3}
+          placeholder="Optional details..."
+          className="border rounded-md px-3 py-2 text-sm bg-background resize-none focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        {err("description") && (
+          <p className="text-xs text-destructive">{err("description")}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-sm font-medium">
+          Duration (minutes) <span className="text-destructive">*</span>
+        </label>
+        <Input
+          name="durationMin"
+          type="number"
+          min={1}
+          max={1440}
+          placeholder="e.g. 60"
+        />
+        {err("durationMin") && (
+          <p className="text-xs text-destructive">{err("durationMin")}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-sm font-medium">
+          Preferred start time (minutes since midnight)
+        </label>
+        <Input
+          name="preferredStartTimeMin"
+          type="number"
+          min={0}
+          max={1439}
+          placeholder="e.g. 480 = 8:00 am"
+        />
+        {err("preferredStartTimeMin") && (
+          <p className="text-xs text-destructive">{err("preferredStartTimeMin")}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-sm font-medium">People required</label>
+        <Input
+          name="peopleRequired"
+          type="number"
+          min={1}
+          max={50}
+          defaultValue={1}
+        />
+        {err("peopleRequired") && (
+          <p className="text-xs text-destructive">{err("peopleRequired")}</p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-medium">Min wait days</label>
+          <Input
+            name="minWaitDays"
+            type="number"
+            min={0}
+            max={3650}
+            placeholder="e.g. 7"
+          />
+          {err("minWaitDays") && (
+            <p className="text-xs text-destructive">{err("minWaitDays")}</p>
+          )}
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-medium">Max wait days</label>
+          <Input
+            name="maxWaitDays"
+            type="number"
+            min={1}
+            max={3650}
+            placeholder="e.g. 14"
+          />
+          {err("maxWaitDays") && (
+            <p className="text-xs text-destructive">{err("maxWaitDays")}</p>
+          )}
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground -mt-3">
+        At least one of min or max wait days is required.
+      </p>
+
+      <Button type="submit" disabled={pending}>
+        {pending ? "Creating..." : "Create Task"}
+      </Button>
+    </form>
+  );
+};

--- a/app/(app)/orgs/[orgId]/tasks/new/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/new/page.tsx
@@ -1,0 +1,20 @@
+
+import { requireOrgMember } from "@/lib/authz";
+import { redirect } from "next/navigation";
+import { CreateTaskForm } from "./create-task-form";
+
+const NewTaskPage = async ({ params }: { params: Promise<{ orgId: string }> }) => {
+  const { orgId } = await params;
+
+  const authz = await requireOrgMember(orgId);
+  if (!authz.ok) redirect("/");
+
+  return (
+    <div className="max-w-lg mx-auto">
+      <h1 className="text-xl font-semibold mb-6">Create Task</h1>
+      <CreateTaskForm orgId={orgId} />
+    </div>
+  );
+};
+
+export default NewTaskPage;

--- a/app/(app)/orgs/[orgId]/tasks/new/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/new/page.tsx
@@ -1,4 +1,5 @@
-import { requireOrgMember } from "@/lib/authz";
+import { requireOrgPermission } from "@/lib/authz";
+import { OrgPermission } from "@prisma/client";
 import { redirect } from "next/navigation";
 import { CreateTaskForm } from "./create-task-form";
 
@@ -9,7 +10,7 @@ const NewTaskPage = async ({
 }) => {
   const { orgId } = await params;
 
-  const authz = await requireOrgMember(orgId);
+  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_CREATE);
   if (!authz.ok) redirect("/");
 
   return (

--- a/app/(app)/orgs/[orgId]/tasks/new/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/new/page.tsx
@@ -1,9 +1,12 @@
-
 import { requireOrgMember } from "@/lib/authz";
 import { redirect } from "next/navigation";
 import { CreateTaskForm } from "./create-task-form";
 
-const NewTaskPage = async ({ params }: { params: Promise<{ orgId: string }> }) => {
+const NewTaskPage = async ({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) => {
   const { orgId } = await params;
 
   const authz = await requireOrgMember(orgId);

--- a/app/(app)/orgs/[orgId]/tasks/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/page.tsx
@@ -1,0 +1,40 @@
+import { getTasks } from "@/lib/services/tasks";
+import { requireOrgMember } from "@/lib/authz";
+import { redirect } from "next/navigation";
+
+const TasksPage = async ({ params }: { params: Promise<{ orgId: string }> }) => {
+  const { orgId } = await params;
+
+  const authz = await requireOrgMember(orgId);
+  if (!authz.ok) redirect("/");
+
+  const tasks = await getTasks(orgId);
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <h1 className="text-xl font-semibold mb-6">Tasks</h1>
+      {tasks.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No tasks yet.</p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {tasks.map((task) => (
+            <li key={task.id} className="border rounded-lg p-4 flex flex-col gap-1">
+              <span className="font-medium">{task.title}</span>
+              {task.description && (
+                <span className="text-sm text-muted-foreground">{task.description}</span>
+              )}
+              <div className="flex gap-4 mt-1 text-xs text-muted-foreground">
+                <span>Duration: {task.durationMin} min</span>
+                <span>People required: {task.peopleRequired}</span>
+                {task.minWaitDays != null && <span>Min wait: {task.minWaitDays}d</span>}
+                {task.maxWaitDays != null && <span>Max wait: {task.maxWaitDays}d</span>}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default TasksPage;

--- a/app/(app)/orgs/[orgId]/tasks/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/page.tsx
@@ -2,7 +2,11 @@ import { getTasks } from "@/lib/services/tasks";
 import { requireOrgMember } from "@/lib/authz";
 import { redirect } from "next/navigation";
 
-const TasksPage = async ({ params }: { params: Promise<{ orgId: string }> }) => {
+const TasksPage = async ({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) => {
   const { orgId } = await params;
 
   const authz = await requireOrgMember(orgId);
@@ -18,16 +22,25 @@ const TasksPage = async ({ params }: { params: Promise<{ orgId: string }> }) => 
       ) : (
         <ul className="flex flex-col gap-3">
           {tasks.map((task) => (
-            <li key={task.id} className="border rounded-lg p-4 flex flex-col gap-1">
+            <li
+              key={task.id}
+              className="border rounded-lg p-4 flex flex-col gap-1"
+            >
               <span className="font-medium">{task.title}</span>
               {task.description && (
-                <span className="text-sm text-muted-foreground">{task.description}</span>
+                <span className="text-sm text-muted-foreground">
+                  {task.description}
+                </span>
               )}
               <div className="flex gap-4 mt-1 text-xs text-muted-foreground">
                 <span>Duration: {task.durationMin} min</span>
                 <span>People required: {task.peopleRequired}</span>
-                {task.minWaitDays != null && <span>Min wait: {task.minWaitDays}d</span>}
-                {task.maxWaitDays != null && <span>Max wait: {task.maxWaitDays}d</span>}
+                {task.minWaitDays != null && (
+                  <span>Min wait: {task.minWaitDays}d</span>
+                )}
+                {task.maxWaitDays != null && (
+                  <span>Max wait: {task.maxWaitDays}d</span>
+                )}
               </div>
             </li>
           ))}

--- a/app/(app)/orgs/new/page.tsx
+++ b/app/(app)/orgs/new/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { createOrg } from "@/app/actions/orgs";
 
 function timeToMinutes(time: string) {
   const [h, m] = time.split(":").map(Number);
@@ -28,21 +29,14 @@ export default function NewOrgPage() {
     if (closeTime) body.closeTimeMin = timeToMinutes(closeTime);
 
     try {
-      const res = await fetch("/api/orgs", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
-      const data = (await res.json().catch(() => null)) as {
-        error?: string;
-      } | null;
+      const result = await createOrg(body);
 
-      if (!res.ok) {
-        setError(data?.error ?? "Something went wrong");
+      if (!result.ok) {
+        setError(result.error);
         return;
       }
 
-      router.push("/");
+      router.push(`/orgs/${result.orgId}`);
     } catch {
       setError("Something went wrong");
     } finally {

--- a/app/actions/orgs.ts
+++ b/app/actions/orgs.ts
@@ -1,0 +1,25 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { auth } from "@/auth";
+import { createOrgSchema } from "@/lib/validators/org";
+import { createOrg as createOrgService } from "@/lib/services/orgs";
+
+type CreateOrgResult =
+  | { ok: true; orgId: string }
+  | { ok: false; error: string };
+
+export async function createOrg(raw: unknown): Promise<CreateOrgResult> {
+  const session = await auth();
+  const userId = session?.user?.id as string | undefined;
+  if (!userId) return { ok: false, error: "Unauthorized" };
+
+  const parsed = createOrgSchema.safeParse(raw);
+  if (!parsed.success) return { ok: false, error: "Validation failed" };
+
+  const { org } = await createOrgService(userId, parsed.data);
+
+  revalidatePath("/", "layout");
+
+  return { ok: true, orgId: org.id };
+}

--- a/app/actions/orgs.ts
+++ b/app/actions/orgs.ts
@@ -1,5 +1,11 @@
 "use server";
 
+/**
+ * Server Actions for org management.
+ * Used by the web UI — validates input, calls the org service,
+ * then revalidates the layout so the sidebar org list updates immediately.
+ */
+
 import { revalidatePath } from "next/cache";
 import { auth } from "@/auth";
 import { createOrgSchema } from "@/lib/validators/org";

--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { requireOrgMember } from "@/lib/authz";
+import { createTask } from "@/lib/services/tasks";
+import { createTaskSchema } from "@/lib/validators/task";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+export type CreateTaskFormState =
+  | { ok: false; errors: Record<string, string[]> }
+  | { ok: true }
+  | null;
+
+export async function createTaskAction(
+  orgId: string,
+  _prev: CreateTaskFormState,
+  formData: FormData,
+): Promise<CreateTaskFormState> {
+  const authz = await requireOrgMember(orgId);
+  if (!authz.ok) return { ok: false, errors: { _: ["Unauthorized"] } };
+
+  const num = (key: string) => {
+    const v = formData.get(key);
+    if (v === null || v === "") return undefined;
+    const n = Number(v);
+    return isNaN(n) ? undefined : n;
+  };
+
+  const raw = {
+    title: String(formData.get("title") ?? ""),
+    description: formData.get("description") || undefined,
+    durationMin: num("durationMin"),
+    preferredStartTimeMin: num("preferredStartTimeMin"),
+    peopleRequired: num("peopleRequired") ?? 1,
+    minWaitDays: num("minWaitDays"),
+    maxWaitDays: num("maxWaitDays"),
+  };
+
+  const parsed = createTaskSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      errors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  await createTask(orgId, parsed.data);
+  revalidatePath(`/orgs/${orgId}/tasks`);
+  redirect(`/orgs/${orgId}/tasks`);
+}
+

--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -1,6 +1,13 @@
 "use server";
 
-import { requireOrgMember } from "@/lib/authz";
+/**
+ * Server Actions for task management.
+ * Used by the create task form — parses FormData, delegates to the task service,
+ * then revalidates the tasks list and redirects back to it.
+ */
+
+import { OrgPermission } from "@prisma/client";
+import { requireOrgPermission } from "@/lib/authz";
 import { createTask } from "@/lib/services/tasks";
 import { createTaskSchema } from "@/lib/validators/task";
 import { revalidatePath } from "next/cache";
@@ -16,9 +23,11 @@ export async function createTaskAction(
   _prev: CreateTaskFormState,
   formData: FormData,
 ): Promise<CreateTaskFormState> {
-  const authz = await requireOrgMember(orgId);
+  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_CREATE);
   if (!authz.ok) return { ok: false, errors: { _: ["Unauthorized"] } };
 
+  // FormData values are always strings; convert numeric fields to numbers
+  // before passing to the Zod schema which expects `number`.
   const num = (key: string) => {
     const v = formData.get(key);
     if (v === null || v === "") return undefined;
@@ -48,4 +57,3 @@ export async function createTaskAction(
   revalidatePath(`/orgs/${orgId}/tasks`);
   redirect(`/orgs/${orgId}/tasks`);
 }
-

--- a/app/api/orgs/[orgId]/memberships/route.ts
+++ b/app/api/orgs/[orgId]/memberships/route.ts
@@ -1,11 +1,15 @@
 import { NextResponse } from "next/server";
-import { Prisma, OrgPermission } from "@prisma/client";
-import { prisma } from "@/lib/prisma";
+import { OrgPermission } from "@prisma/client";
 import { requireOrgPermission } from "@/lib/authz";
 import {
   createMembershipSchema,
   deleteMembershipSchema,
 } from "@/lib/validators/membership";
+import {
+  createMembership,
+  deleteMembership,
+  getMemberships,
+} from "@/lib/services/memberships";
 
 export async function POST(
   req: Request,
@@ -31,62 +35,12 @@ export async function POST(
     );
   }
 
-  const data = parsed.data;
-
-  if (data.roleId) {
-    // Verify the role exists and belongs to this org
-    const role = await prisma.role.findFirst({
-      where: { id: data.roleId, orgId },
-    });
-    if (!role) {
-      return NextResponse.json(
-        { error: "Invalid roleId: not found or does not belong to this org" },
-        { status: 400 },
-      );
-    }
+  const result = await createMembership(orgId, parsed.data);
+  if (!result.ok) {
+    const status = result.code === "CONFLICT" ? 409 : 400;
+    return NextResponse.json({ error: result.error }, { status });
   }
-
-  const user = await prisma.user.findFirst({
-    where: { id: data.userId },
-    select: { id: true },
-  });
-  if (!user) {
-    return NextResponse.json(
-      { error: "Invalid userId: not found" },
-      { status: 400 },
-    );
-  }
-
-  try {
-    const membership = await prisma.membership.create({
-      data: {
-        orgId,
-        userId: data.userId,
-        roleId: data.roleId,
-      },
-    });
-
-    return NextResponse.json(membership, { status: 201 });
-  } catch (e: unknown) {
-    if (e instanceof Prisma.PrismaClientKnownRequestError) {
-      if (e.code === "P2002") {
-        return NextResponse.json(
-          { error: "Membership already exists" },
-          { status: 409 },
-        );
-      }
-      if (e.code === "P2003") {
-        return NextResponse.json(
-          { error: "Invalid foreign key reference" },
-          { status: 400 },
-        );
-      }
-    }
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
-  }
+  return NextResponse.json(result.data, { status: 201 });
 }
 
 export async function DELETE(
@@ -107,33 +61,10 @@ export async function DELETE(
     );
   }
 
-  const { userId } = parsed.data;
-
-  // Ensure the user being deleted is not the org owner (which would orphan the org)
-  const org = await prisma.organization.findUnique({
-    where: { id: orgId },
-    select: { ownerUserId: true },
-  });
-  if (!org)
-    return NextResponse.json({ error: "Org not found" }, { status: 404 });
-
-  if (userId === org.ownerUserId) {
-    return NextResponse.json(
-      { error: "Cannot remove the organization owner" },
-      { status: 400 },
-    );
-  }
-
-  // Ensure scoped to org (prevents cross-org deletes)
-  const { count } = await prisma.membership.deleteMany({
-    where: { userId, orgId },
-  });
-
-  if (count === 0) {
-    return NextResponse.json(
-      { error: "Membership not found" },
-      { status: 404 },
-    );
+  const result = await deleteMembership(orgId, parsed.data.userId);
+  if (!result.ok) {
+    const status = result.code === "NOT_FOUND" ? 404 : 400;
+    return NextResponse.json({ error: result.error }, { status });
   }
   return NextResponse.json({ ok: true });
 }
@@ -147,19 +78,6 @@ export async function GET(
   const authz = await requireOrgPermission(orgId, OrgPermission.ORG_MANAGE);
   if (!authz.ok) return authz.response;
 
-  const memberships = await prisma.membership.findMany({
-    where: { orgId },
-    include: {
-      user: {
-        select: {
-          id: true,
-          name: true,
-        },
-      },
-      role: true,
-    },
-    orderBy: { createdAt: "desc" },
-  });
-
+  const memberships = await getMemberships(orgId);
   return NextResponse.json(memberships);
 }

--- a/app/api/orgs/[orgId]/task-instances/[taskInstanceId]/assignees/route.ts
+++ b/app/api/orgs/[orgId]/task-instances/[taskInstanceId]/assignees/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { Prisma, OrgPermission } from "@prisma/client";
-import { prisma } from "@/lib/prisma";
+import { OrgPermission } from "@prisma/client";
 import { requireOrgMember, requireOrgPermission } from "@/lib/authz";
 import {
   CreateAssigneeSchema,
   DeleteAssigneeSchema,
 } from "@/lib/validators/assignee";
+import { createAssignee, deleteAssignee, getAssignees } from "@/lib/services/assignees";
 
 export async function POST(
   req: Request,
@@ -31,52 +31,12 @@ export async function POST(
     );
   }
 
-  const { membershipId } = parsed.data;
-
-  // task instance must exist in this org
-  const taskInstance = await prisma.taskInstance.findFirst({
-    where: { id: taskInstanceId, orgId },
-    select: { id: true },
-  });
-  if (!taskInstance) {
-    return NextResponse.json(
-      { error: "Task instance not found in this org" },
-      { status: 404 },
-    );
+  const result = await createAssignee(orgId, taskInstanceId, parsed.data.membershipId);
+  if (!result.ok) {
+    const status = result.code === "CONFLICT" ? 409 : 404;
+    return NextResponse.json({ error: result.error }, { status });
   }
-
-  // membership must exist in this org
-  const membership = await prisma.membership.findFirst({
-    where: { id: membershipId, orgId },
-    select: { id: true },
-  });
-  if (!membership) {
-    return NextResponse.json(
-      { error: "Membership not found in this org" },
-      { status: 404 },
-    );
-  }
-
-  try {
-    const assignee = await prisma.taskInstanceAssignee.create({
-      data: { taskInstanceId, membershipId },
-    });
-    return NextResponse.json(assignee, { status: 201 });
-  } catch (e: unknown) {
-    if (
-      e instanceof Prisma.PrismaClientKnownRequestError &&
-      e.code === "P2002"
-    ) {
-      return NextResponse.json(
-        { error: "Assignee already exists" },
-        { status: 409 },
-      );
-    }
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
-  }
+  return NextResponse.json(result.data, { status: 201 });
 }
 
 export async function GET(
@@ -88,26 +48,7 @@ export async function GET(
   const authz = await requireOrgMember(orgId);
   if (!authz.ok) return authz.response;
 
-  const assignees = await prisma.taskInstanceAssignee.findMany({
-    where: {
-      taskInstanceId,
-      taskInstance: { is: { orgId } },
-    },
-    include: {
-      membership: {
-        include: {
-          user: {
-            select: { id: true, name: true },
-          },
-          role: {
-            select: { id: true, title: true },
-          },
-        },
-      },
-    },
-    orderBy: { createdAt: "desc" },
-  });
-
+  const assignees = await getAssignees(orgId, taskInstanceId);
   return NextResponse.json(assignees);
 }
 
@@ -129,23 +70,9 @@ export async function DELETE(
     );
   }
 
-  const { membershipId } = parsed.data;
-
-  // Ensure scoped to org (prevents cross-org deletes)
-  const link = await prisma.taskInstanceAssignee.findFirst({
-    where: {
-      taskInstanceId,
-      membershipId,
-      taskInstance: { is: { orgId } },
-      membership: { is: { orgId } },
-    },
-    select: { id: true },
-  });
-
-  if (!link) {
-    return NextResponse.json({ error: "Assignee not found" }, { status: 404 });
+  const result = await deleteAssignee(orgId, taskInstanceId, parsed.data.membershipId);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: 404 });
   }
-
-  await prisma.taskInstanceAssignee.delete({ where: { id: link.id } });
   return NextResponse.json({ ok: true });
 }

--- a/app/api/orgs/[orgId]/task-instances/[taskInstanceId]/assignees/route.ts
+++ b/app/api/orgs/[orgId]/task-instances/[taskInstanceId]/assignees/route.ts
@@ -5,7 +5,11 @@ import {
   CreateAssigneeSchema,
   DeleteAssigneeSchema,
 } from "@/lib/validators/assignee";
-import { createAssignee, deleteAssignee, getAssignees } from "@/lib/services/assignees";
+import {
+  createAssignee,
+  deleteAssignee,
+  getAssignees,
+} from "@/lib/services/assignees";
 
 export async function POST(
   req: Request,
@@ -31,7 +35,11 @@ export async function POST(
     );
   }
 
-  const result = await createAssignee(orgId, taskInstanceId, parsed.data.membershipId);
+  const result = await createAssignee(
+    orgId,
+    taskInstanceId,
+    parsed.data.membershipId,
+  );
   if (!result.ok) {
     const status = result.code === "CONFLICT" ? 409 : 404;
     return NextResponse.json({ error: result.error }, { status });
@@ -70,7 +78,11 @@ export async function DELETE(
     );
   }
 
-  const result = await deleteAssignee(orgId, taskInstanceId, parsed.data.membershipId);
+  const result = await deleteAssignee(
+    orgId,
+    taskInstanceId,
+    parsed.data.membershipId,
+  );
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 404 });
   }

--- a/app/api/orgs/[orgId]/task-instances/[taskInstanceId]/route.ts
+++ b/app/api/orgs/[orgId]/task-instances/[taskInstanceId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
 import { requireOrgMember } from "@/lib/authz";
+import { getTaskInstance } from "@/lib/services/task-instances";
 
 export async function GET(
   _req: Request,
@@ -11,16 +11,9 @@ export async function GET(
   const authz = await requireOrgMember(orgId);
   if (!authz.ok) return authz.response;
 
-  const item = await prisma.taskInstance.findFirst({
-    where: { orgId, id: taskInstanceId },
-  });
-
-  if (!item) {
-    return NextResponse.json(
-      { error: "Task instance not found in this org" },
-      { status: 404 },
-    );
+  const result = await getTaskInstance(orgId, taskInstanceId);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: 404 });
   }
-
-  return NextResponse.json(item, { status: 200 });
+  return NextResponse.json(result.data, { status: 200 });
 }

--- a/app/api/orgs/[orgId]/task-instances/[taskInstanceId]/status/route.ts
+++ b/app/api/orgs/[orgId]/task-instances/[taskInstanceId]/status/route.ts
@@ -31,7 +31,11 @@ export async function PATCH(
     );
   }
 
-  const result = await updateTaskInstanceStatus(orgId, taskInstanceId, parsed.data.status);
+  const result = await updateTaskInstanceStatus(
+    orgId,
+    taskInstanceId,
+    parsed.data.status,
+  );
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 404 });
   }

--- a/app/api/orgs/[orgId]/task-instances/[taskInstanceId]/status/route.ts
+++ b/app/api/orgs/[orgId]/task-instances/[taskInstanceId]/status/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { OrgPermission } from "@prisma/client";
-import { prisma } from "@/lib/prisma";
 import { updateTaskInstanceStatusSchema } from "@/lib/validators/task";
 import { requireOrgPermission } from "@/lib/authz";
+import { updateTaskInstanceStatus } from "@/lib/services/task-instances";
 
 export async function PATCH(
   req: Request,
@@ -31,24 +31,9 @@ export async function PATCH(
     );
   }
 
-  const { status } = parsed.data;
-
-  const updated = await prisma.taskInstance.updateMany({
-    where: { id: taskInstanceId, orgId },
-    data: { status },
-  });
-
-  if (updated.count === 0) {
-    return NextResponse.json(
-      { error: "Task instance not found in this org" },
-      { status: 404 },
-    );
+  const result = await updateTaskInstanceStatus(orgId, taskInstanceId, parsed.data.status);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: 404 });
   }
-
-  // If you want to return the updated row, fetch it:
-  const taskInstance = await prisma.taskInstance.findUnique({
-    where: { id: taskInstanceId },
-  });
-
-  return NextResponse.json(taskInstance, { status: 200 });
+  return NextResponse.json(result.data, { status: 200 });
 }

--- a/app/api/orgs/[orgId]/task-instances/route.ts
+++ b/app/api/orgs/[orgId]/task-instances/route.ts
@@ -64,7 +64,9 @@ export async function GET(
   const options: GetTaskInstancesOptions = {};
 
   if (statusParam) {
-    const parsedStatus = updateTaskInstanceStatusSchema.safeParse({ status: statusParam });
+    const parsedStatus = updateTaskInstanceStatusSchema.safeParse({
+      status: statusParam,
+    });
     if (!parsedStatus.success) {
       return NextResponse.json(
         { error: "Validation failed", issues: parsedStatus.error.issues },

--- a/app/api/orgs/[orgId]/task-instances/route.ts
+++ b/app/api/orgs/[orgId]/task-instances/route.ts
@@ -1,9 +1,13 @@
 import { NextResponse } from "next/server";
-import { OrgPermission, Prisma, TaskInstanceStatus } from "@prisma/client";
-import { prisma } from "@/lib/prisma";
+import { OrgPermission } from "@prisma/client";
 import { updateTaskInstanceStatusSchema } from "@/lib/validators/task";
 import { requireOrgMember, requireOrgPermission } from "@/lib/authz";
 import { createTaskInstanceSchema } from "@/lib/validators/task-instance";
+import {
+  createTaskInstance,
+  getTaskInstances,
+  type GetTaskInstancesOptions,
+} from "@/lib/services/task-instances";
 
 export async function POST(
   req: Request,
@@ -29,40 +33,12 @@ export async function POST(
     );
   }
 
-  const { taskId } = parsed.data;
-
-  const task = await prisma.task.findFirst({
-    where: { id: taskId, orgId },
-    select: { id: true },
-  });
-
-  if (!task) {
-    return NextResponse.json(
-      { error: "Invalid taskId: not found or does not belong to this org" },
-      { status: 400 },
-    );
+  const result = await createTaskInstance(orgId, parsed.data.taskId);
+  if (!result.ok) {
+    const status = result.code === "CONFLICT" ? 409 : 400;
+    return NextResponse.json({ error: result.error }, { status });
   }
-
-  try {
-    const taskInstance = await prisma.taskInstance.create({
-      data: { orgId, taskId },
-    });
-    return NextResponse.json(taskInstance, { status: 201 });
-  } catch (e: unknown) {
-    if (
-      e instanceof Prisma.PrismaClientKnownRequestError &&
-      e.code === "P2002"
-    ) {
-      return NextResponse.json(
-        { error: "Task instance already exists" },
-        { status: 409 },
-      );
-    }
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
-  }
+  return NextResponse.json(result.data, { status: 201 });
 }
 
 export async function GET(
@@ -76,10 +52,7 @@ export async function GET(
 
   const url = new URL(req.url);
   const statusParam = url.searchParams.get("status");
-  const completedParam = url.searchParams.get("completed"); // "true" | "false" | null
-
-  // Build filter
-  const where: Prisma.TaskInstanceWhereInput = { orgId };
+  const completedParam = url.searchParams.get("completed");
 
   if (statusParam && completedParam !== null) {
     return NextResponse.json(
@@ -88,25 +61,21 @@ export async function GET(
     );
   }
 
+  const options: GetTaskInstancesOptions = {};
+
   if (statusParam) {
-    const parsed = updateTaskInstanceStatusSchema.safeParse({
-      status: statusParam,
-    });
-    if (!parsed.success) {
+    const parsedStatus = updateTaskInstanceStatusSchema.safeParse({ status: statusParam });
+    if (!parsedStatus.success) {
       return NextResponse.json(
-        { error: "Validation failed", issues: parsed.error.issues },
+        { error: "Validation failed", issues: parsedStatus.error.issues },
         { status: 400 },
       );
     }
-    where.status = parsed.data.status;
+    options.status = parsedStatus.data.status;
   } else if (completedParam === "false") {
-    where.status = {
-      notIn: [TaskInstanceStatus.DONE, TaskInstanceStatus.SKIPPED],
-    };
+    options.completed = false;
   } else if (completedParam === "true") {
-    where.status = {
-      in: [TaskInstanceStatus.DONE, TaskInstanceStatus.SKIPPED],
-    };
+    options.completed = true;
   } else if (completedParam !== null) {
     return NextResponse.json(
       { error: "'completed' must be 'true' or 'false'" },
@@ -114,10 +83,6 @@ export async function GET(
     );
   }
 
-  const items = await prisma.taskInstance.findMany({
-    where: where,
-    orderBy: { createdAt: "desc" },
-  });
-
+  const items = await getTaskInstances(orgId, options);
   return NextResponse.json(items, { status: 200 });
 }

--- a/app/api/orgs/[orgId]/tasks/route.ts
+++ b/app/api/orgs/[orgId]/tasks/route.ts
@@ -63,7 +63,10 @@ export async function DELETE(
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 404 });
   }
-  return NextResponse.json({ message: "Task deleted successfully" }, { status: 200 });
+  return NextResponse.json(
+    { message: "Task deleted successfully" },
+    { status: 200 },
+  );
 }
 
 export async function GET(

--- a/app/api/orgs/[orgId]/tasks/route.ts
+++ b/app/api/orgs/[orgId]/tasks/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
 import { createTaskSchema } from "@/lib/validators/task";
-import { prisma } from "@/lib/prisma";
 import { requireOrgMember, requireOrgPermission } from "@/lib/authz";
-import z from "zod";
 import { OrgPermission } from "@prisma/client";
+import z from "zod";
+import { createTask, deleteTask, getTasks } from "@/lib/services/tasks";
 
 export async function POST(
   req: Request,
@@ -24,35 +24,16 @@ export async function POST(
   const parsed = createTaskSchema.safeParse(json);
   if (!parsed.success) {
     return NextResponse.json(
-      {
-        error: "Validation failed",
-        issues: parsed.error.issues,
-      },
+      { error: "Validation failed", issues: parsed.error.issues },
       { status: 400 },
     );
   }
 
-  const data = parsed.data;
-
-  const task = await prisma.task.create({
-    data: {
-      orgId,
-      title: data.title,
-      description: data.description ?? null,
-      durationMin: data.durationMin,
-      preferredStartTimeMin: data.preferredStartTimeMin ?? null,
-      peopleRequired: data.peopleRequired ?? 1,
-      minWaitDays: data.minWaitDays ?? null,
-      maxWaitDays: data.maxWaitDays ?? null,
-    },
-  });
-
+  const task = await createTask(orgId, parsed.data);
   return NextResponse.json(task, { status: 201 });
 }
 
-const deleteTaskSchema = z.object({
-  id: z.string(),
-});
+const deleteTaskSchema = z.object({ id: z.string() });
 
 export async function DELETE(
   req: Request,
@@ -73,40 +54,20 @@ export async function DELETE(
   const parsed = deleteTaskSchema.safeParse(json);
   if (!parsed.success) {
     return NextResponse.json(
-      {
-        error: "Validation failed",
-        issues: parsed.error.issues,
-      },
+      { error: "Validation failed", issues: parsed.error.issues },
       { status: 400 },
     );
   }
 
-  const { id } = parsed.data;
-
-  const link = await prisma.task.findFirst({
-    where: {
-      id,
-      orgId,
-    },
-    select: { id: true },
-  });
-
-  if (!link) {
-    return NextResponse.json({ error: "Task not found" }, { status: 404 });
+  const result = await deleteTask(orgId, parsed.data.id);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: 404 });
   }
-
-  await prisma.task.delete({
-    where: { id: link.id },
-  });
-
-  return NextResponse.json(
-    { message: "Task deleted successfully" },
-    { status: 200 },
-  );
+  return NextResponse.json({ message: "Task deleted successfully" }, { status: 200 });
 }
 
 export async function GET(
-  req: Request,
+  _req: Request,
   { params }: { params: Promise<{ orgId: string }> },
 ) {
   const { orgId } = await params;
@@ -114,9 +75,6 @@ export async function GET(
   const authz = await requireOrgMember(orgId);
   if (!authz.ok) return authz.response;
 
-  const tasks = await prisma.task.findMany({
-    where: { orgId },
-    orderBy: { createdAt: "desc" },
-  });
+  const tasks = await getTasks(orgId);
   return NextResponse.json(tasks);
 }

--- a/app/api/orgs/route.ts
+++ b/app/api/orgs/route.ts
@@ -1,9 +1,7 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
 import { requireUser } from "@/lib/authz";
-import { OrgPermission } from "@prisma/client";
-import { ROLE_KEYS } from "@/lib/rbac";
 import { createOrgSchema } from "@/lib/validators/org";
+import { createOrg } from "@/lib/services/orgs";
 
 export async function POST(req: Request) {
   const authz = await requireUser();
@@ -24,76 +22,6 @@ export async function POST(req: Request) {
     );
   }
 
-  const data = parsed.data;
-
-  if (
-    data.openTimeMin != null &&
-    data.closeTimeMin != null &&
-    data.openTimeMin >= data.closeTimeMin
-  ) {
-    return NextResponse.json(
-      { error: "openTimeMin must be less than closeTimeMin" },
-      { status: 400 },
-    );
-  }
-
-  const ownerPermissions: OrgPermission[] = [
-    OrgPermission.ORG_MANAGE,
-    OrgPermission.ROLE_MANAGE,
-    OrgPermission.TASK_CREATE,
-    OrgPermission.TASK_UPDATE,
-    OrgPermission.TASK_DELETE,
-    OrgPermission.TASK_ASSIGN,
-    OrgPermission.TASKINSTANCE_COMPLETE,
-  ];
-
-  const workerPermissions: OrgPermission[] = [
-    OrgPermission.TASKINSTANCE_COMPLETE,
-  ];
-
-  const result = await prisma.$transaction(async (tx) => {
-    const org = await tx.organization.create({
-      data: {
-        title: data.title,
-        ownerUserId: authz.userId,
-        openTimeMin: data.openTimeMin ?? null,
-        closeTimeMin: data.closeTimeMin ?? null,
-      },
-    });
-
-    const [ownerRole, memberRole] = await Promise.all([
-      tx.role.create({
-        data: { orgId: org.id, title: "Owner", key: ROLE_KEYS.OWNER },
-      }),
-      tx.role.create({
-        data: { orgId: org.id, title: "Member", key: ROLE_KEYS.DEFAULT_MEMBER },
-      }),
-    ]);
-
-    await tx.rolePermission.createMany({
-      data: [
-        ...ownerPermissions.map((permission) => ({
-          roleId: ownerRole.id,
-          permission,
-        })),
-        ...workerPermissions.map((permission) => ({
-          roleId: memberRole.id,
-          permission,
-        })),
-      ],
-      skipDuplicates: true,
-    });
-
-    const membership = await tx.membership.create({
-      data: {
-        orgId: org.id,
-        userId: authz.userId,
-        roleId: ownerRole.id,
-      },
-    });
-
-    return { org, ownerRole, memberRole, membership };
-  });
-
+  const result = await createOrg(authz.userId, parsed.data);
   return NextResponse.json(result, { status: 201 });
 }

--- a/components/layout/actions/members-actions.tsx
+++ b/components/layout/actions/members-actions.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export const MembersActions = ({ orgId }: { orgId: string }) => {
+  return (
+    <Button asChild size="sm" variant="outline">
+      <Link href={`/orgs/${orgId}/members/new`}>+ Add Member</Link>
+    </Button>
+  );
+};

--- a/components/layout/actions/tasks-actions.tsx
+++ b/components/layout/actions/tasks-actions.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export const TasksActions = ({ orgId }: { orgId: string }) => {
+  return (
+    <Button asChild size="sm" variant="outline">
+      <Link href={`/orgs/${orgId}/tasks/new`}>+ Create Task</Link>
+    </Button>
+  );
+};

--- a/components/layout/navbar-context-actions.tsx
+++ b/components/layout/navbar-context-actions.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { usePathname, useParams } from "next/navigation";
+import { TasksActions } from "@/components/layout/actions/tasks-actions";
+import { MembersActions } from "@/components/layout/actions/members-actions";
+
+export const NavbarContextActions = () => {
+  const pathname = usePathname();
+  const { orgId } = useParams<{ orgId?: string }>();
+
+  if (orgId && pathname === `/orgs/${orgId}/tasks`) {
+    return <TasksActions orgId={orgId} />;
+  }
+
+  if (orgId && pathname === `/orgs/${orgId}/memberships`) {
+    return <MembersActions orgId={orgId} />;
+  }
+
+  return null;
+};

--- a/components/layout/navbar-context-actions.tsx
+++ b/components/layout/navbar-context-actions.tsx
@@ -1,5 +1,16 @@
 "use client";
 
+/**
+ * Client boundary for route-aware navbar actions.
+ *
+ * NavBar is a server component (it fetches session + orgs), so it cannot use
+ * client hooks. This component is the minimal client slice that reads the
+ * current URL and renders the appropriate action button for the active page.
+ *
+ * To add actions for a new page, create a file in components/layout/actions/
+ * and add an `if` branch here.
+ */
+
 import { usePathname, useParams } from "next/navigation";
 import { TasksActions } from "@/components/layout/actions/tasks-actions";
 import { MembersActions } from "@/components/layout/actions/members-actions";

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma";
 import { Button } from "@/components/ui/button";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { OrgSwitcher } from "@/components/layout/org-switcher";
+import { NavbarContextActions } from "@/components/layout/navbar-context-actions";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -34,51 +35,54 @@ export const NavBar = async () => {
       <div className="flex items-center gap-2">
         <SidebarTrigger />
         <OrgSwitcher orgs={orgs} />
+        <NavbarContextActions />
+      </div>
+
+      <div className="flex items-center gap-2">
         <Button asChild size="sm" variant="outline">
           <Link href="/orgs/new">+ New Org</Link>
         </Button>
+        {user && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="gap-2">
+                {user.image ? (
+                  <Image
+                    src={user.image}
+                    alt={user.name ?? "User"}
+                    width={24}
+                    height={24}
+                    className="rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="h-6 w-6 rounded-full bg-muted flex items-center justify-center text-xs font-medium">
+                    {user.name?.[0]?.toUpperCase() ?? "?"}
+                  </div>
+                )}
+                <span className="hidden sm:inline">{user.name}</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuLabel className="text-xs text-muted-foreground font-normal truncate">
+                {user.email}
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <form
+                action={async () => {
+                  "use server";
+                  await signOut({ redirectTo: "/signin" });
+                }}
+              >
+                <DropdownMenuItem asChild>
+                  <button type="submit" className="w-full text-left">
+                    Sign out
+                  </button>
+                </DropdownMenuItem>
+              </form>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
-
-      {user && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="sm" className="gap-2">
-              {user.image ? (
-                <Image
-                  src={user.image}
-                  alt={user.name ?? "User"}
-                  width={24}
-                  height={24}
-                  className="rounded-full object-cover"
-                />
-              ) : (
-                <div className="h-6 w-6 rounded-full bg-muted flex items-center justify-center text-xs font-medium">
-                  {user.name?.[0]?.toUpperCase() ?? "?"}
-                </div>
-              )}
-              <span className="hidden sm:inline">{user.name}</span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-48">
-            <DropdownMenuLabel className="text-xs text-muted-foreground font-normal truncate">
-              {user.email}
-            </DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <form
-              action={async () => {
-                "use server";
-                await signOut({ redirectTo: "/signin" });
-              }}
-            >
-              <DropdownMenuItem asChild>
-                <button type="submit" className="w-full text-left">
-                  Sign out
-                </button>
-              </DropdownMenuItem>
-            </form>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
     </header>
   );
 };

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -37,7 +37,9 @@ export function AppSidebar() {
   return (
     <Sidebar collapsible="offcanvas">
       <SidebarHeader className="px-4 py-3">
-        <Link href="/" className="font-semibold text-sm">Management App</Link>
+        <Link href="/" className="font-semibold text-sm">
+          Management App
+        </Link>
       </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Link from "next/link";
-import { LayoutDashboard, Building2 } from "lucide-react";
+import { useParams } from "next/navigation";
+import { LayoutDashboard, Building2, ListTodo, Users } from "lucide-react";
 import {
   Sidebar,
   SidebarContent,
@@ -12,20 +15,33 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 
-const navItems = [
+const baseNavItems = [
   { title: "Dashboard", url: "/", icon: LayoutDashboard },
   { title: "Organizations", url: "/orgs", icon: Building2 },
 ];
 
+function getOrgNavItems(orgId: string) {
+  return [
+    { title: "Overview", url: `/orgs/${orgId}`, icon: Building2 },
+    { title: "Tasks", url: `/orgs/${orgId}/tasks`, icon: ListTodo },
+    { title: "Members", url: `/orgs/${orgId}/memberships`, icon: Users },
+  ];
+}
+
 export function AppSidebar() {
+  const { orgId } = useParams<{ orgId?: string }>();
+
+  const navItems = orgId ? getOrgNavItems(orgId) : baseNavItems;
+  const groupLabel = orgId ? "Organization" : "Navigation";
+
   return (
     <Sidebar collapsible="offcanvas">
       <SidebarHeader className="px-4 py-3">
-        <span className="font-semibold text-sm">Management App</span>
+        <Link href="/" className="font-semibold text-sm">Management App</Link>
       </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>
-          <SidebarGroupLabel>Navigation</SidebarGroupLabel>
+          <SidebarGroupLabel>{groupLabel}</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               {navItems.map((item) => (

--- a/lib/services/assignees.ts
+++ b/lib/services/assignees.ts
@@ -1,0 +1,76 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import type { ServiceResult } from "./types";
+
+export async function createAssignee(
+  orgId: string,
+  taskInstanceId: string,
+  membershipId: string,
+): Promise<ServiceResult<Prisma.TaskInstanceAssigneeGetPayload<Record<string, never>>>> {
+  const taskInstance = await prisma.taskInstance.findFirst({
+    where: { id: taskInstanceId, orgId },
+    select: { id: true },
+  });
+  if (!taskInstance) {
+    return { ok: false, error: "Task instance not found in this org", code: "NOT_FOUND" };
+  }
+
+  const membership = await prisma.membership.findFirst({
+    where: { id: membershipId, orgId },
+    select: { id: true },
+  });
+  if (!membership) {
+    return { ok: false, error: "Membership not found in this org", code: "NOT_FOUND" };
+  }
+
+  try {
+    const assignee = await prisma.taskInstanceAssignee.create({
+      data: { taskInstanceId, membershipId },
+    });
+    return { ok: true, data: assignee };
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+      return { ok: false, error: "Assignee already exists", code: "CONFLICT" };
+    }
+    throw e;
+  }
+}
+
+export async function deleteAssignee(
+  orgId: string,
+  taskInstanceId: string,
+  membershipId: string,
+): Promise<ServiceResult<null>> {
+  const link = await prisma.taskInstanceAssignee.findFirst({
+    where: {
+      taskInstanceId,
+      membershipId,
+      taskInstance: { is: { orgId } },
+      membership: { is: { orgId } },
+    },
+    select: { id: true },
+  });
+
+  if (!link) return { ok: false, error: "Assignee not found", code: "NOT_FOUND" };
+
+  await prisma.taskInstanceAssignee.delete({ where: { id: link.id } });
+  return { ok: true, data: null };
+}
+
+export async function getAssignees(orgId: string, taskInstanceId: string) {
+  return prisma.taskInstanceAssignee.findMany({
+    where: {
+      taskInstanceId,
+      taskInstance: { is: { orgId } },
+    },
+    include: {
+      membership: {
+        include: {
+          user: { select: { id: true, name: true } },
+          role: { select: { id: true, title: true } },
+        },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+}

--- a/lib/services/assignees.ts
+++ b/lib/services/assignees.ts
@@ -2,17 +2,28 @@ import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import type { ServiceResult } from "./types";
 
+/**
+ * Assigns a member to a task instance. Validates that both the task instance
+ * and the membership belong to the same org before creating the link,
+ * preventing cross-org assignment via crafted IDs.
+ */
 export async function createAssignee(
   orgId: string,
   taskInstanceId: string,
   membershipId: string,
-): Promise<ServiceResult<Prisma.TaskInstanceAssigneeGetPayload<Record<string, never>>>> {
+): Promise<
+  ServiceResult<Prisma.TaskInstanceAssigneeGetPayload<Record<string, never>>>
+> {
   const taskInstance = await prisma.taskInstance.findFirst({
     where: { id: taskInstanceId, orgId },
     select: { id: true },
   });
   if (!taskInstance) {
-    return { ok: false, error: "Task instance not found in this org", code: "NOT_FOUND" };
+    return {
+      ok: false,
+      error: "Task instance not found in this org",
+      code: "NOT_FOUND",
+    };
   }
 
   const membership = await prisma.membership.findFirst({
@@ -20,7 +31,11 @@ export async function createAssignee(
     select: { id: true },
   });
   if (!membership) {
-    return { ok: false, error: "Membership not found in this org", code: "NOT_FOUND" };
+    return {
+      ok: false,
+      error: "Membership not found in this org",
+      code: "NOT_FOUND",
+    };
   }
 
   try {
@@ -29,7 +44,10 @@ export async function createAssignee(
     });
     return { ok: true, data: assignee };
   } catch (e) {
-    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+    if (
+      e instanceof Prisma.PrismaClientKnownRequestError &&
+      e.code === "P2002"
+    ) {
       return { ok: false, error: "Assignee already exists", code: "CONFLICT" };
     }
     throw e;
@@ -51,7 +69,8 @@ export async function deleteAssignee(
     select: { id: true },
   });
 
-  if (!link) return { ok: false, error: "Assignee not found", code: "NOT_FOUND" };
+  if (!link)
+    return { ok: false, error: "Assignee not found", code: "NOT_FOUND" };
 
   await prisma.taskInstanceAssignee.delete({ where: { id: link.id } });
   return { ok: true, data: null };

--- a/lib/services/memberships.ts
+++ b/lib/services/memberships.ts
@@ -1,0 +1,63 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import type { CreateMembershipInput } from "@/lib/validators/membership";
+import type { ServiceResult } from "./types";
+
+export async function createMembership(
+  orgId: string,
+  data: CreateMembershipInput,
+): Promise<ServiceResult<Prisma.MembershipGetPayload<Record<string, never>>>> {
+  const role = await prisma.role.findFirst({ where: { id: data.roleId, orgId } });
+  if (!role) {
+    return { ok: false, error: "Invalid roleId: not found or does not belong to this org", code: "INVALID" };
+  }
+
+  const user = await prisma.user.findFirst({ where: { id: data.userId }, select: { id: true } });
+  if (!user) {
+    return { ok: false, error: "Invalid userId: not found", code: "INVALID" };
+  }
+
+  try {
+    const membership = await prisma.membership.create({
+      data: { orgId, userId: data.userId, roleId: data.roleId },
+    });
+    return { ok: true, data: membership };
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError) {
+      if (e.code === "P2002") return { ok: false, error: "Membership already exists", code: "CONFLICT" };
+      if (e.code === "P2003") return { ok: false, error: "Invalid foreign key reference", code: "INVALID" };
+    }
+    throw e;
+  }
+}
+
+export async function deleteMembership(
+  orgId: string,
+  userId: string,
+): Promise<ServiceResult<null>> {
+  const org = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: { ownerUserId: true },
+  });
+  if (!org) return { ok: false, error: "Org not found", code: "NOT_FOUND" };
+
+  if (userId === org.ownerUserId) {
+    return { ok: false, error: "Cannot remove the organization owner", code: "INVALID" };
+  }
+
+  const { count } = await prisma.membership.deleteMany({ where: { userId, orgId } });
+  if (count === 0) return { ok: false, error: "Membership not found", code: "NOT_FOUND" };
+
+  return { ok: true, data: null };
+}
+
+export async function getMemberships(orgId: string) {
+  return prisma.membership.findMany({
+    where: { orgId },
+    include: {
+      user: { select: { id: true, name: true } },
+      role: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+}

--- a/lib/services/memberships.ts
+++ b/lib/services/memberships.ts
@@ -7,12 +7,21 @@ export async function createMembership(
   orgId: string,
   data: CreateMembershipInput,
 ): Promise<ServiceResult<Prisma.MembershipGetPayload<Record<string, never>>>> {
-  const role = await prisma.role.findFirst({ where: { id: data.roleId, orgId } });
+  const role = await prisma.role.findFirst({
+    where: { id: data.roleId, orgId },
+  });
   if (!role) {
-    return { ok: false, error: "Invalid roleId: not found or does not belong to this org", code: "INVALID" };
+    return {
+      ok: false,
+      error: "Invalid roleId: not found or does not belong to this org",
+      code: "INVALID",
+    };
   }
 
-  const user = await prisma.user.findFirst({ where: { id: data.userId }, select: { id: true } });
+  const user = await prisma.user.findFirst({
+    where: { id: data.userId },
+    select: { id: true },
+  });
   if (!user) {
     return { ok: false, error: "Invalid userId: not found", code: "INVALID" };
   }
@@ -24,13 +33,27 @@ export async function createMembership(
     return { ok: true, data: membership };
   } catch (e) {
     if (e instanceof Prisma.PrismaClientKnownRequestError) {
-      if (e.code === "P2002") return { ok: false, error: "Membership already exists", code: "CONFLICT" };
-      if (e.code === "P2003") return { ok: false, error: "Invalid foreign key reference", code: "INVALID" };
+      if (e.code === "P2002")
+        return {
+          ok: false,
+          error: "Membership already exists",
+          code: "CONFLICT",
+        };
+      if (e.code === "P2003")
+        return {
+          ok: false,
+          error: "Invalid foreign key reference",
+          code: "INVALID",
+        };
     }
     throw e;
   }
 }
 
+/**
+ * Removes a user from an org. Guards against removing the org owner,
+ * which would leave the org with no owner and break invariants.
+ */
 export async function deleteMembership(
   orgId: string,
   userId: string,
@@ -42,11 +65,18 @@ export async function deleteMembership(
   if (!org) return { ok: false, error: "Org not found", code: "NOT_FOUND" };
 
   if (userId === org.ownerUserId) {
-    return { ok: false, error: "Cannot remove the organization owner", code: "INVALID" };
+    return {
+      ok: false,
+      error: "Cannot remove the organization owner",
+      code: "INVALID",
+    };
   }
 
-  const { count } = await prisma.membership.deleteMany({ where: { userId, orgId } });
-  if (count === 0) return { ok: false, error: "Membership not found", code: "NOT_FOUND" };
+  const { count } = await prisma.membership.deleteMany({
+    where: { userId, orgId },
+  });
+  if (count === 0)
+    return { ok: false, error: "Membership not found", code: "NOT_FOUND" };
 
   return { ok: true, data: null };
 }

--- a/lib/services/orgs.ts
+++ b/lib/services/orgs.ts
@@ -1,0 +1,54 @@
+import { prisma } from "@/lib/prisma";
+import { OrgPermission } from "@prisma/client";
+import { ROLE_KEYS } from "@/lib/rbac";
+import type { CreateOrgInput } from "@/lib/validators/org";
+
+const ownerPermissions: OrgPermission[] = [
+  OrgPermission.ORG_MANAGE,
+  OrgPermission.ROLE_MANAGE,
+  OrgPermission.TASK_CREATE,
+  OrgPermission.TASK_UPDATE,
+  OrgPermission.TASK_DELETE,
+  OrgPermission.TASK_ASSIGN,
+  OrgPermission.TASKINSTANCE_COMPLETE,
+];
+
+const workerPermissions: OrgPermission[] = [
+  OrgPermission.TASKINSTANCE_COMPLETE,
+];
+
+export async function createOrg(userId: string, data: CreateOrgInput) {
+  return prisma.$transaction(async (tx) => {
+    const org = await tx.organization.create({
+      data: {
+        title: data.title,
+        ownerUserId: userId,
+        openTimeMin: data.openTimeMin ?? null,
+        closeTimeMin: data.closeTimeMin ?? null,
+      },
+    });
+
+    const [ownerRole, memberRole] = await Promise.all([
+      tx.role.create({
+        data: { orgId: org.id, title: "Owner", key: ROLE_KEYS.OWNER },
+      }),
+      tx.role.create({
+        data: { orgId: org.id, title: "Member", key: ROLE_KEYS.DEFAULT_MEMBER },
+      }),
+    ]);
+
+    await tx.rolePermission.createMany({
+      data: [
+        ...ownerPermissions.map((permission) => ({ roleId: ownerRole.id, permission })),
+        ...workerPermissions.map((permission) => ({ roleId: memberRole.id, permission })),
+      ],
+      skipDuplicates: true,
+    });
+
+    const membership = await tx.membership.create({
+      data: { orgId: org.id, userId, roleId: ownerRole.id },
+    });
+
+    return { org, ownerRole, memberRole, membership };
+  });
+}

--- a/lib/services/orgs.ts
+++ b/lib/services/orgs.ts
@@ -3,6 +3,8 @@ import { OrgPermission } from "@prisma/client";
 import { ROLE_KEYS } from "@/lib/rbac";
 import type { CreateOrgInput } from "@/lib/validators/org";
 
+// Permissions granted to the Owner role on every new org.
+// Owners have full control over the org, its members, roles, and tasks.
 const ownerPermissions: OrgPermission[] = [
   OrgPermission.ORG_MANAGE,
   OrgPermission.ROLE_MANAGE,
@@ -13,10 +15,20 @@ const ownerPermissions: OrgPermission[] = [
   OrgPermission.TASKINSTANCE_COMPLETE,
 ];
 
+// Permissions granted to the default Member role — enough to complete tasks,
+// but not to manage the org, create tasks, or assign others.
 const workerPermissions: OrgPermission[] = [
   OrgPermission.TASKINSTANCE_COMPLETE,
 ];
 
+/**
+ * Creates a new org and bootstraps it inside a single transaction:
+ *   1. Creates the Organization record
+ *   2. Creates Owner and Member roles with their respective permissions
+ *   3. Creates a Membership linking the creator to the Owner role
+ *
+ * All steps are atomic — if any step fails, nothing is persisted.
+ */
 export async function createOrg(userId: string, data: CreateOrgInput) {
   return prisma.$transaction(async (tx) => {
     const org = await tx.organization.create({
@@ -39,8 +51,14 @@ export async function createOrg(userId: string, data: CreateOrgInput) {
 
     await tx.rolePermission.createMany({
       data: [
-        ...ownerPermissions.map((permission) => ({ roleId: ownerRole.id, permission })),
-        ...workerPermissions.map((permission) => ({ roleId: memberRole.id, permission })),
+        ...ownerPermissions.map((permission) => ({
+          roleId: ownerRole.id,
+          permission,
+        })),
+        ...workerPermissions.map((permission) => ({
+          roleId: memberRole.id,
+          permission,
+        })),
       ],
       skipDuplicates: true,
     });

--- a/lib/services/task-instances.ts
+++ b/lib/services/task-instances.ts
@@ -1,0 +1,69 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma, TaskInstanceStatus } from "@prisma/client";
+import type { ServiceResult } from "./types";
+
+export type GetTaskInstancesOptions = {
+  status?: TaskInstanceStatus;
+  completed?: boolean;
+};
+
+export async function createTaskInstance(
+  orgId: string,
+  taskId: string,
+): Promise<ServiceResult<Prisma.TaskInstanceGetPayload<Record<string, never>>>> {
+  const task = await prisma.task.findFirst({ where: { id: taskId, orgId }, select: { id: true } });
+  if (!task) {
+    return { ok: false, error: "Invalid taskId: not found or does not belong to this org", code: "INVALID" };
+  }
+
+  try {
+    const taskInstance = await prisma.taskInstance.create({ data: { orgId, taskId } });
+    return { ok: true, data: taskInstance };
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+      return { ok: false, error: "Task instance already exists", code: "CONFLICT" };
+    }
+    throw e;
+  }
+}
+
+export async function getTaskInstances(orgId: string, options: GetTaskInstancesOptions = {}) {
+  const where: Prisma.TaskInstanceWhereInput = { orgId };
+
+  if (options.status != null) {
+    where.status = options.status;
+  } else if (options.completed === false) {
+    where.status = { notIn: [TaskInstanceStatus.DONE, TaskInstanceStatus.SKIPPED] };
+  } else if (options.completed === true) {
+    where.status = { in: [TaskInstanceStatus.DONE, TaskInstanceStatus.SKIPPED] };
+  }
+
+  return prisma.taskInstance.findMany({ where, orderBy: { createdAt: "desc" } });
+}
+
+export async function getTaskInstance(
+  orgId: string,
+  taskInstanceId: string,
+): Promise<ServiceResult<Prisma.TaskInstanceGetPayload<Record<string, never>>>> {
+  const item = await prisma.taskInstance.findFirst({ where: { orgId, id: taskInstanceId } });
+  if (!item) return { ok: false, error: "Task instance not found in this org", code: "NOT_FOUND" };
+  return { ok: true, data: item };
+}
+
+export async function updateTaskInstanceStatus(
+  orgId: string,
+  taskInstanceId: string,
+  status: TaskInstanceStatus,
+): Promise<ServiceResult<Prisma.TaskInstanceGetPayload<Record<string, never>>>> {
+  const updated = await prisma.taskInstance.updateMany({
+    where: { id: taskInstanceId, orgId },
+    data: { status },
+  });
+
+  if (updated.count === 0) {
+    return { ok: false, error: "Task instance not found in this org", code: "NOT_FOUND" };
+  }
+
+  const taskInstance = await prisma.taskInstance.findUnique({ where: { id: taskInstanceId } });
+  return { ok: true, data: taskInstance! };
+}

--- a/lib/services/task-instances.ts
+++ b/lib/services/task-instances.ts
@@ -10,43 +10,87 @@ export type GetTaskInstancesOptions = {
 export async function createTaskInstance(
   orgId: string,
   taskId: string,
-): Promise<ServiceResult<Prisma.TaskInstanceGetPayload<Record<string, never>>>> {
-  const task = await prisma.task.findFirst({ where: { id: taskId, orgId }, select: { id: true } });
+): Promise<
+  ServiceResult<Prisma.TaskInstanceGetPayload<Record<string, never>>>
+> {
+  const task = await prisma.task.findFirst({
+    where: { id: taskId, orgId },
+    select: { id: true },
+  });
   if (!task) {
-    return { ok: false, error: "Invalid taskId: not found or does not belong to this org", code: "INVALID" };
+    return {
+      ok: false,
+      error: "Invalid taskId: not found or does not belong to this org",
+      code: "INVALID",
+    };
   }
 
   try {
-    const taskInstance = await prisma.taskInstance.create({ data: { orgId, taskId } });
+    const taskInstance = await prisma.taskInstance.create({
+      data: { orgId, taskId },
+    });
     return { ok: true, data: taskInstance };
   } catch (e) {
-    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
-      return { ok: false, error: "Task instance already exists", code: "CONFLICT" };
+    if (
+      e instanceof Prisma.PrismaClientKnownRequestError &&
+      e.code === "P2002"
+    ) {
+      return {
+        ok: false,
+        error: "Task instance already exists",
+        code: "CONFLICT",
+      };
     }
     throw e;
   }
 }
 
-export async function getTaskInstances(orgId: string, options: GetTaskInstancesOptions = {}) {
+/**
+ * Lists task instances for an org with optional status filtering.
+ * `status` and `completed` are mutually exclusive:
+ *   - `status`: filter to an exact TaskInstanceStatus value
+ *   - `completed: true`:  only DONE or SKIPPED
+ *   - `completed: false`: exclude DONE and SKIPPED
+ */
+export async function getTaskInstances(
+  orgId: string,
+  options: GetTaskInstancesOptions = {},
+) {
   const where: Prisma.TaskInstanceWhereInput = { orgId };
 
   if (options.status != null) {
     where.status = options.status;
   } else if (options.completed === false) {
-    where.status = { notIn: [TaskInstanceStatus.DONE, TaskInstanceStatus.SKIPPED] };
+    where.status = {
+      notIn: [TaskInstanceStatus.DONE, TaskInstanceStatus.SKIPPED],
+    };
   } else if (options.completed === true) {
-    where.status = { in: [TaskInstanceStatus.DONE, TaskInstanceStatus.SKIPPED] };
+    where.status = {
+      in: [TaskInstanceStatus.DONE, TaskInstanceStatus.SKIPPED],
+    };
   }
 
-  return prisma.taskInstance.findMany({ where, orderBy: { createdAt: "desc" } });
+  return prisma.taskInstance.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+  });
 }
 
 export async function getTaskInstance(
   orgId: string,
   taskInstanceId: string,
-): Promise<ServiceResult<Prisma.TaskInstanceGetPayload<Record<string, never>>>> {
-  const item = await prisma.taskInstance.findFirst({ where: { orgId, id: taskInstanceId } });
-  if (!item) return { ok: false, error: "Task instance not found in this org", code: "NOT_FOUND" };
+): Promise<
+  ServiceResult<Prisma.TaskInstanceGetPayload<Record<string, never>>>
+> {
+  const item = await prisma.taskInstance.findFirst({
+    where: { orgId, id: taskInstanceId },
+  });
+  if (!item)
+    return {
+      ok: false,
+      error: "Task instance not found in this org",
+      code: "NOT_FOUND",
+    };
   return { ok: true, data: item };
 }
 
@@ -55,15 +99,30 @@ export async function updateTaskInstanceStatus(
   taskInstanceId: string,
   status: TaskInstanceStatus,
 ): Promise<ServiceResult<Prisma.TaskInstanceGetPayload<Record<string, never>>>> {
-  const updated = await prisma.taskInstance.updateMany({
-    where: { id: taskInstanceId, orgId },
-    data: { status },
-  });
+  try {
+    const taskInstance = await prisma.$transaction(async (tx) => {
+      const updated = await tx.taskInstance.updateMany({
+        where: { id: taskInstanceId, orgId },
+        data: { status },
+      });
 
-  if (updated.count === 0) {
-    return { ok: false, error: "Task instance not found in this org", code: "NOT_FOUND" };
+      if (updated.count === 0) {
+        throw Object.assign(new Error("Task instance not found in this org"), { code: "NOT_FOUND" });
+      }
+
+      const instance = await tx.taskInstance.findUnique({ where: { id: taskInstanceId } });
+      if (!instance) {
+        throw Object.assign(new Error("Task instance not found in this org"), { code: "NOT_FOUND" });
+      }
+
+      return instance;
+    });
+
+    return { ok: true, data: taskInstance };
+  } catch (e) {
+    if (e instanceof Error && (e as { code?: string }).code === "NOT_FOUND") {
+      return { ok: false, error: e.message, code: "NOT_FOUND" };
+    }
+    throw e;
   }
-
-  const taskInstance = await prisma.taskInstance.findUnique({ where: { id: taskInstanceId } });
-  return { ok: true, data: taskInstance! };
 }

--- a/lib/services/task-instances.ts
+++ b/lib/services/task-instances.ts
@@ -98,7 +98,9 @@ export async function updateTaskInstanceStatus(
   orgId: string,
   taskInstanceId: string,
   status: TaskInstanceStatus,
-): Promise<ServiceResult<Prisma.TaskInstanceGetPayload<Record<string, never>>>> {
+): Promise<
+  ServiceResult<Prisma.TaskInstanceGetPayload<Record<string, never>>>
+> {
   try {
     const taskInstance = await prisma.$transaction(async (tx) => {
       const updated = await tx.taskInstance.updateMany({
@@ -107,12 +109,18 @@ export async function updateTaskInstanceStatus(
       });
 
       if (updated.count === 0) {
-        throw Object.assign(new Error("Task instance not found in this org"), { code: "NOT_FOUND" });
+        throw Object.assign(new Error("Task instance not found in this org"), {
+          code: "NOT_FOUND",
+        });
       }
 
-      const instance = await tx.taskInstance.findUnique({ where: { id: taskInstanceId } });
+      const instance = await tx.taskInstance.findUnique({
+        where: { id: taskInstanceId },
+      });
       if (!instance) {
-        throw Object.assign(new Error("Task instance not found in this org"), { code: "NOT_FOUND" });
+        throw Object.assign(new Error("Task instance not found in this org"), {
+          code: "NOT_FOUND",
+        });
       }
 
       return instance;

--- a/lib/services/task-instances.ts
+++ b/lib/services/task-instances.ts
@@ -31,15 +31,23 @@ export async function createTaskInstance(
     });
     return { ok: true, data: taskInstance };
   } catch (e) {
-    if (
-      e instanceof Prisma.PrismaClientKnownRequestError &&
-      e.code === "P2002"
-    ) {
-      return {
-        ok: false,
-        error: "Task instance already exists",
-        code: "CONFLICT",
-      };
+    if (e instanceof Prisma.PrismaClientKnownRequestError) {
+      // Task removed (or relation invalid) between pre-check and create
+      if (e.code === "P2003") {
+        return {
+          ok: false,
+          error: "Invalid taskId: not found or does not belong to this org",
+          code: "INVALID",
+        };
+      }
+      // Keep this only if a corresponding unique constraint is added in schema.
+      if (e.code === "P2002") {
+        return {
+          ok: false,
+          error: "Task instance already exists",
+          code: "CONFLICT",
+        };
+      }
     }
     throw e;
   }

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -1,0 +1,33 @@
+import { prisma } from "@/lib/prisma";
+import type { ServiceResult } from "./types";
+import type { CreateTaskInput } from "@/lib/validators/task";
+
+export async function createTask(orgId: string, data: CreateTaskInput) {
+  return prisma.task.create({
+    data: {
+      orgId,
+      title: data.title,
+      description: data.description ?? null,
+      durationMin: data.durationMin,
+      preferredStartTimeMin: data.preferredStartTimeMin ?? null,
+      peopleRequired: data.peopleRequired ?? 1,
+      minWaitDays: data.minWaitDays ?? null,
+      maxWaitDays: data.maxWaitDays ?? null,
+    },
+  });
+}
+
+export async function deleteTask(orgId: string, id: string): Promise<ServiceResult<null>> {
+  const task = await prisma.task.findFirst({ where: { id, orgId }, select: { id: true } });
+  if (!task) return { ok: false, error: "Task not found", code: "NOT_FOUND" };
+
+  await prisma.task.delete({ where: { id: task.id } });
+  return { ok: true, data: null };
+}
+
+export async function getTasks(orgId: string) {
+  return prisma.task.findMany({
+    where: { orgId },
+    orderBy: { createdAt: "desc" },
+  });
+}

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -22,7 +22,8 @@ export async function deleteTask(
   id: string,
 ): Promise<ServiceResult<null>> {
   const { count } = await prisma.task.deleteMany({ where: { id, orgId } });
-  if (count === 0) return { ok: false, error: "Task not found", code: "NOT_FOUND" };
+  if (count === 0)
+    return { ok: false, error: "Task not found", code: "NOT_FOUND" };
   return { ok: true, data: null };
 }
 

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -17,11 +17,12 @@ export async function createTask(orgId: string, data: CreateTaskInput) {
   });
 }
 
-export async function deleteTask(orgId: string, id: string): Promise<ServiceResult<null>> {
-  const task = await prisma.task.findFirst({ where: { id, orgId }, select: { id: true } });
-  if (!task) return { ok: false, error: "Task not found", code: "NOT_FOUND" };
-
-  await prisma.task.delete({ where: { id: task.id } });
+export async function deleteTask(
+  orgId: string,
+  id: string,
+): Promise<ServiceResult<null>> {
+  const { count } = await prisma.task.deleteMany({ where: { id, orgId } });
+  if (count === 0) return { ok: false, error: "Task not found", code: "NOT_FOUND" };
   return { ok: true, data: null };
 }
 

--- a/lib/services/types.ts
+++ b/lib/services/types.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared return types for all service functions.
+ *
+ * Service functions return a `ServiceResult<T>` discriminated union so callers
+ * can handle errors by checking `result.ok` before accessing `result.data`.
+ * Errors carry a `code` to allow callers to map to HTTP status codes:
+ *   NOT_FOUND → 404, CONFLICT → 409, INVALID → 400
+ */
 export type ServiceError = {
   ok: false;
   error: string;

--- a/lib/services/types.ts
+++ b/lib/services/types.ts
@@ -1,0 +1,7 @@
+export type ServiceError = {
+  ok: false;
+  error: string;
+  code: "NOT_FOUND" | "CONFLICT" | "INVALID";
+};
+
+export type ServiceResult<T> = { ok: true; data: T } | ServiceError;

--- a/lib/validators/task.ts
+++ b/lib/validators/task.ts
@@ -48,4 +48,5 @@ export const updateTaskInstanceStatusSchema = z.object({
 export type UpdateTaskStatusInput = z.infer<
   typeof updateTaskInstanceStatusSchema
 >;
+
 export type CreateTaskInput = z.infer<typeof createTaskSchema>;


### PR DESCRIPTION
- Extract lib/services/ (orgs, memberships, tasks, task-instances, assignees)
- Refactor all API routes to use service layer
- Add Server Actions (app/actions/orgs, tasks)
- Dynamic sidebar with useParams-based org nav
- Dynamic navbar context actions (tasks, members)
- Tasks list + create task form (/orgs/[orgId]/tasks)
- Members list (/orgs/[orgId]/memberships)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Members page to view organization members and roles
  * Task creation UI with a full task form and submission flow
  * Tasks overview page listing tasks with details
  * Contextual sidebar navigation for organization (Overview, Tasks, Members)
  * Header quick-actions for "+ Create Task" and "+ Add Member"
* **Documentation**
  * Updated README with architecture, routes, and service‑layer notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->