### PR TITLE
feat(sidebar): add collapsible global nav sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,17 +236,17 @@ Server Actions use `revalidatePath` to invalidate the Next.js cache so server-re
 
 ## Pages
 
-| Route                              | Guard                          | Description                           |
-| ---------------------------------- | ------------------------------ | ------------------------------------- |
-| `/`                                | Signed in                      | Home — authenticated app shell        |
-| `/signin`                          | —                              | Google OAuth sign-in                  |
-| `/orgs/new`                        | Signed in                      | Create a new organization             |
-| `/orgs/[orgId]`                    | `requireOrgMember`             | Org overview (placeholder)            |
-| `/orgs/[orgId]/tasks`              | `requireOrgMember`             | Task template list                    |
-| `/orgs/[orgId]/tasks/new`          | `requireOrgPermission TASK_CREATE` | Create a new task template        |
-| `/orgs/[orgId]/memberships`        | `requireOrgMember`             | Member list                           |
-| `/orgs/[orgId]/memberships/new`    | `requireOrgPermission ORG_MANAGE` | Invite a new member by email       |
-| `/orgs/[orgId]/timetable`          | —                              | Timetable view (placeholder)          |
+| Route                           | Guard                              | Description                    |
+| ------------------------------- | ---------------------------------- | ------------------------------ |
+| `/`                             | Signed in                          | Home — authenticated app shell |
+| `/signin`                       | —                                  | Google OAuth sign-in           |
+| `/orgs/new`                     | Signed in                          | Create a new organization      |
+| `/orgs/[orgId]`                 | `requireOrgMember`                 | Org overview (placeholder)     |
+| `/orgs/[orgId]/tasks`           | `requireOrgMember`                 | Task template list             |
+| `/orgs/[orgId]/tasks/new`       | `requireOrgPermission TASK_CREATE` | Create a new task template     |
+| `/orgs/[orgId]/memberships`     | `requireOrgMember`                 | Member list                    |
+| `/orgs/[orgId]/memberships/new` | `requireOrgPermission ORG_MANAGE`  | Invite a new member by email   |
+| `/orgs/[orgId]/timetable`       | —                                  | Timetable view (placeholder)   |
 
 All `/orgs/[orgId]/*` pages are guarded by at least `requireOrgMember` — users not in the org are redirected to `/`.
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Server Actions use `revalidatePath` to invalidate the Next.js cache so server-re
 | `/orgs/[orgId]/tasks/new`       | `requireOrgPermission TASK_CREATE` | Create a new task template     |
 | `/orgs/[orgId]/memberships`     | `requireOrgMember`                 | Member list                    |
 | `/orgs/[orgId]/memberships/new` | `requireOrgPermission ORG_MANAGE`  | Invite a new member by email   |
-| `/orgs/[orgId]/timetable`       | —                                  | Timetable view (placeholder)   |
+| `/orgs/[orgId]/timetable`       | `requireOrgMember`                 | Timetable view (placeholder)   |
 
 All `/orgs/[orgId]/*` pages are guarded by at least `requireOrgMember` — users not in the org are redirected to `/`.
 

--- a/components/layout/page-header.tsx
+++ b/components/layout/page-header.tsx
@@ -43,7 +43,7 @@ export function PageHeader() {
   if (!orgId) {
     // Non-org pages — only add a crumb for known standalone routes
     if (pathname === "/orgs/new") {
-      breadcrumbs.push({ label: "New Organization" });
+      breadcrumbs.push({ label: "Create Organization" });
     }
   } else {
     const base = `/orgs/${orgId}`;

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -52,9 +52,14 @@ function NavCollapsible({
   children: React.ReactNode;
 }) {
   const [open, setOpen] = useState(defaultOpen);
+  const subMenuId = `sidebar-section-${label.toLowerCase().replace(/\s+/g, "-")}`;
   return (
     <SidebarMenuItem>
-      <SidebarMenuButton onClick={() => setOpen((v) => !v)}>
+      <SidebarMenuButton
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={subMenuId}
+      >
         <Icon />
         <span>{label}</span>
         <ChevronRight
@@ -64,7 +69,7 @@ function NavCollapsible({
           )}
         />
       </SidebarMenuButton>
-      {open && <SidebarMenuSub>{children}</SidebarMenuSub>}
+      {open && <SidebarMenuSub id={subMenuId}>{children}</SidebarMenuSub>}
     </SidebarMenuItem>
   );
 }

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import {
@@ -10,6 +11,13 @@ import {
   Calendar,
   BarChart2,
   Settings,
+  PlusCircle,
+  Mail,
+  HelpCircle,
+  BookOpen,
+  Info,
+  Phone,
+  ChevronRight,
 } from "lucide-react";
 import {
   Sidebar,
@@ -21,17 +29,45 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
   SidebarSeparator,
 } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
 
 /**
- * Nav items shown when the user is not inside a specific org (e.g. on the home page).
- * To add a global page, append an entry here.
+ * A collapsible nav section with a chevron toggle.
+ * Used in the global (no-org) sidebar for the Organizations and Help groups.
  */
-const baseNavItems = [
-  { title: "Dashboard", url: "/", icon: LayoutDashboard },
-  { title: "Organizations", url: "/orgs", icon: Building2 },
-];
+function NavCollapsible({
+  icon: Icon,
+  label,
+  defaultOpen = false,
+  children,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton onClick={() => setOpen((v) => !v)}>
+        <Icon />
+        <span>{label}</span>
+        <ChevronRight
+          className={cn(
+            "ml-auto transition-transform duration-200",
+            open && "rotate-90",
+          )}
+        />
+      </SidebarMenuButton>
+      {open && <SidebarMenuSub>{children}</SidebarMenuSub>}
+    </SidebarMenuItem>
+  );
+}
 
 /**
  * Nav items shown when the user is inside an org (any /orgs/[orgId]/... route).
@@ -63,7 +99,8 @@ function getOrgFooterItems(orgId: string) {
  * Collapsible sidebar rendered in the app layout.
  *
  * Behaviour:
- * - Outside an org: shows global nav (Dashboard, Organizations).
+ * - Outside an org: shows the global workspace nav with collapsible sections
+ *   (Organizations with Create + Invitations, and Help with sub-links).
  * - Inside an org: switches to org-scoped nav and shows footer items (e.g. Settings).
  * - Active page is highlighted via `isActive`, derived from the current pathname.
  */
@@ -73,7 +110,7 @@ export function AppSidebar() {
   // Used to determine which nav item should be marked active
   const pathname = usePathname();
 
-  const navItems = orgId ? getOrgNavItems(orgId) : baseNavItems;
+  const orgNavItems = orgId ? getOrgNavItems(orgId) : [];
   const footerItems = orgId ? getOrgFooterItems(orgId) : [];
 
   /**
@@ -99,16 +136,83 @@ export function AppSidebar() {
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
-              {navItems.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild isActive={isActiveItem(item.url)}>
-                    <Link href={item.url}>
-                      <item.icon />
-                      <span>{item.title}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
+              {orgId ? (
+                // ── Org-scoped nav ──────────────────────────────────────
+                orgNavItems.map((item) => (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton
+                      asChild
+                      isActive={isActiveItem(item.url)}
+                    >
+                      <Link href={item.url}>
+                        <item.icon />
+                        <span>{item.title}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))
+              ) : (
+                // ── Global workspace nav ─────────────────────────────────
+                <>
+                  {/* Workspace */}
+                  <SidebarMenuItem>
+                    <SidebarMenuButton asChild isActive={pathname === "/"}>
+                      <Link href="/">
+                        <LayoutDashboard />
+                        <span>Workspace</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+
+                  {/* Organizations — collapsible, open by default */}
+                  <NavCollapsible
+                    icon={Building2}
+                    label="Organizations"
+                    defaultOpen
+                  >
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton
+                        asChild
+                        isActive={isActiveItem("/orgs/new")}
+                      >
+                        <Link href="/orgs/new">
+                          <PlusCircle />
+                          <span>Create</span>
+                        </Link>
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                    <SidebarMenuSubItem>
+                      {/* Invitations — stub until feature is implemented */}
+                      <SidebarMenuSubButton title="Coming soon">
+                        <Mail />
+                        <span>Invitations</span>
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                  </NavCollapsible>
+
+                  {/* Help — collapsible, closed by default */}
+                  <NavCollapsible icon={HelpCircle} label="Help">
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton title="Coming soon">
+                        <BookOpen />
+                        <span>Instructions</span>
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton title="Coming soon">
+                        <Info />
+                        <span>About</span>
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton title="Coming soon">
+                        <Phone />
+                        <span>Contact</span>
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                  </NavCollapsible>
+                </>
+              )}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible sidebar sections for Organizations and Help in the global workspace view.
  * Added a Workspace top-level item and a "Create" option to set up new organizations.

* **UI/UX Improvements**
  * Breadcrumb label changed from "New Organization" to "Create Organization" for clarity.

* **Documentation**
  * Pages route table reformatted and clarified that all /orgs/[orgId]/* pages require org membership (redirect to /).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->