### PR TITLE
feat: implement timetable page with calendar and simple views

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A role-based chore/practice management system to rotate recurring tasks fairly a
 - [x] Member management — invite by email, assign roles
 - [x] Assignee tracking on task instances
 - [x] Task instance status updates (`TODO` → `IN_PROGRESS` → `DONE` / `SKIPPED`)
+- [x] Timetable view — weekly calendar and simple (list) modes with task instance blocks
 - [ ] Weekly schedule generation (fair rotation)
 - [ ] Worker "Today" checklist
 - [ ] Completion tracking + basic stats
@@ -189,6 +190,7 @@ app/
         page.tsx         # Org overview
         tasks/           # Task list + create task form
         memberships/     # Members list
+        timetable/       # Weekly timetable (calendar + simple modes)
   (auth)/         # Unauthenticated pages (sign in)
   actions/        # Server Actions (web UI mutations)
     orgs.ts       # createOrg action
@@ -246,7 +248,8 @@ Server Actions use `revalidatePath` to invalidate the Next.js cache so server-re
 | `/orgs/[orgId]/tasks/new`       | `requireOrgPermission TASK_CREATE` | Create a new task template     |
 | `/orgs/[orgId]/memberships`     | `requireOrgMember`                 | Member list                    |
 | `/orgs/[orgId]/memberships/new` | `requireOrgPermission ORG_MANAGE`  | Invite a new member by email   |
-| `/orgs/[orgId]/timetable`       | `requireOrgMember`                 | Timetable view (placeholder)   |
+| `/orgs/[orgId]/timetable`       | `requireOrgMember`                 | Timetable — calendar or simple mode, week navigation |
+| `/orgs/[orgId]/timetable/templates` | `requireOrgMember`             | Timetable templates (coming soon) |
 
 All `/orgs/[orgId]/*` pages are guarded by at least `requireOrgMember` — users not in the org are redirected to `/`.
 
@@ -254,7 +257,8 @@ All `/orgs/[orgId]/*` pages are guarded by at least `requireOrgMember` — users
 
 - **Sidebar active state** — uses prefix matching so nested pages (e.g. `/tasks/new`) correctly highlight the parent nav item. The Org Overview item uses exact matching to avoid lighting up on every org page.
 - **Form validation** — server-action errors are rendered inline next to each field with `aria-invalid` / `aria-describedby` for accessibility, plus a Sonner toast summary.
+- **Timetable** — server component fetches the week's instances (scoped to `scheduledStartAt` in `[monday, monday+7)`); a client component handles the Calendar/Simple toggle and Prev/Next week navigation via `?week=` and `?mode=` search params. Calendar view uses absolute positioning to render task blocks by time; overlapping tasks are assigned side-by-side columns. Status colours: gray = TODO, amber = IN\_PROGRESS, green = DONE, red = SKIPPED.
 
 ## Status
 
-Work in progress — service layer, REST API, task management, member management, and auth fully implemented. Schedule generation and completion stats not yet started.
+Work in progress — service layer, REST API, task management, member management, auth, and timetable view fully implemented. Schedule generation (automatic cycle-based rotation) and completion stats not yet started.

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ All `/orgs/[orgId]/*` pages are guarded by at least `requireOrgMember` — users
 
 - **Sidebar active state** — uses prefix matching so nested pages (e.g. `/tasks/new`) correctly highlight the parent nav item. The Org Overview item uses exact matching to avoid lighting up on every org page.
 - **Form validation** — server-action errors are rendered inline next to each field with `aria-invalid` / `aria-describedby` for accessibility, plus a Sonner toast summary.
-- **Timetable** — server component fetches the week's instances (scoped to `scheduledStartAt` in `[monday, monday+7)`); a client component handles the Calendar/Simple toggle and Prev/Next week navigation via `?week=` and `?mode=` search params. Calendar view uses absolute positioning to render task blocks by time; overlapping tasks are assigned side-by-side columns. Status colours: gray = TODO, amber = IN\_PROGRESS, green = DONE, red = SKIPPED.
+- **Timetable** — the server page fetches the week's instances (scoped to `scheduledStartAt` in `[monday, monday+7)`) and renders the Calendar/Simple mode links; the client component handles the interactive timetable UI plus Prev/Next week navigation via `?week=` and `?mode=` search params. Calendar view uses absolute positioning to render task blocks by time; overlapping tasks are assigned side-by-side columns. Status colours: gray = TODO, amber = IN\_PROGRESS, green = DONE, red = SKIPPED.
 
 ## Status
 

--- a/app/(app)/orgs/[orgId]/timetable/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/page.tsx
@@ -1,7 +1,11 @@
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import { requireOrgMember } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { getTaskInstancesForTimetable } from "@/lib/services/task-instances";
+import { Toolbar } from "@/components/layout/toolbar";
+import { Button } from "@/components/ui/button";
+import { ChevronDown } from "lucide-react";
 import {
   TimetableClient,
   type ClientTimetableInstance,
@@ -29,9 +33,15 @@ export default async function TimetablePage({
   const authz = await requireOrgMember(orgId);
   if (!authz.ok) redirect("/");
 
-  const weekStart = weekParam
-    ? getMondayDateStr(new Date(weekParam + "T00:00:00Z"))
-    : getMondayDateStr(new Date());
+  let weekStart: string;
+  if (weekParam && /^\d{4}-\d{2}-\d{2}$/.test(weekParam)) {
+    const parsed = new Date(weekParam + "T00:00:00Z");
+    weekStart = Number.isNaN(parsed.getTime())
+      ? getMondayDateStr(new Date())
+      : getMondayDateStr(parsed);
+  } else {
+    weekStart = getMondayDateStr(new Date());
+  }
 
   const from = new Date(weekStart + "T00:00:00Z");
   const to = new Date(from);
@@ -73,14 +83,54 @@ export default async function TimetablePage({
     })),
   }));
 
+  const timetableHref = (m: string) =>
+    `/orgs/${orgId}/timetable?week=${weekStart}&mode=${m}`;
+
   return (
-    <TimetableClient
-      orgId={orgId}
-      instances={instances}
-      weekStart={weekStart}
-      openTimeMin={org?.openTimeMin ?? 360}
-      closeTimeMin={org?.closeTimeMin ?? 1320}
-      mode={mode}
-    />
+    <>
+      <Toolbar actions={[{ label: "Templates", href: `/orgs/${orgId}/timetable/templates` }]}>
+        {/* Week-view type (placeholder) */}
+        <Button variant="outline" size="sm" className="gap-1.5" disabled>
+          Week <ChevronDown className="h-3.5 w-3.5" />
+        </Button>
+
+        {/* Filter (placeholder) */}
+        <Button variant="outline" size="sm" className="gap-1.5" disabled>
+          Filter <ChevronDown className="h-3.5 w-3.5" />
+        </Button>
+
+        {/* Calendar / Simple toggle */}
+        <div className="flex rounded-md overflow-hidden border text-sm font-medium">
+          <Link
+            href={timetableHref("calendar")}
+            className={`px-3 py-1 transition-colors ${
+              mode === "calendar"
+                ? "bg-primary text-primary-foreground"
+                : "hover:bg-muted text-muted-foreground"
+            }`}
+          >
+            Calendar
+          </Link>
+          <Link
+            href={timetableHref("simple")}
+            className={`px-3 py-1 border-l transition-colors ${
+              mode === "simple"
+                ? "bg-primary text-primary-foreground"
+                : "hover:bg-muted text-muted-foreground"
+            }`}
+          >
+            Simple
+          </Link>
+        </div>
+      </Toolbar>
+      <TimetableClient
+        orgId={orgId}
+        instances={instances}
+        weekStart={weekStart}
+        openTimeMin={org?.openTimeMin ?? 360}
+        closeTimeMin={org?.closeTimeMin ?? 1320}
+        mode={mode}
+      />
+    </>
   );
 }

--- a/app/(app)/orgs/[orgId]/timetable/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/page.tsx
@@ -103,6 +103,7 @@ export default async function TimetablePage({
         <div className="flex rounded-md overflow-hidden border text-sm font-medium">
           <Link
             href={timetableHref("calendar")}
+            aria-current={mode === "calendar" ? "page" : undefined}
             className={`px-3 py-1 transition-colors ${
               mode === "calendar"
                 ? "bg-primary text-primary-foreground"
@@ -113,6 +114,7 @@ export default async function TimetablePage({
           </Link>
           <Link
             href={timetableHref("simple")}
+            aria-current={mode === "simple" ? "page" : undefined}
             className={`px-3 py-1 border-l transition-colors ${
               mode === "simple"
                 ? "bg-primary text-primary-foreground"

--- a/app/(app)/orgs/[orgId]/timetable/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/page.tsx
@@ -1,6 +1,86 @@
-/** Timetable page — placeholder for the org schedule view. */
-const Page = () => {
-  return <div>{/* Timetable content */}</div>;
-};
+import { redirect } from "next/navigation";
+import { requireOrgMember } from "@/lib/authz";
+import { prisma } from "@/lib/prisma";
+import { getTaskInstancesForTimetable } from "@/lib/services/task-instances";
+import {
+  TimetableClient,
+  type ClientTimetableInstance,
+} from "./timetable-client";
 
-export default Page;
+/** Returns the YYYY-MM-DD string for the Monday of the week containing `date` (UTC). */
+function getMondayDateStr(date: Date): string {
+  const d = new Date(date);
+  d.setUTCHours(0, 0, 0, 0);
+  const day = d.getUTCDay(); // 0 = Sunday
+  d.setUTCDate(d.getUTCDate() - (day === 0 ? 6 : day - 1));
+  return d.toISOString().split("T")[0];
+}
+
+export default async function TimetablePage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ orgId: string }>;
+  searchParams: Promise<{ week?: string; mode?: string }>;
+}) {
+  const { orgId } = await params;
+  const { week: weekParam, mode: modeParam } = await searchParams;
+
+  const authz = await requireOrgMember(orgId);
+  if (!authz.ok) redirect("/");
+
+  const weekStart = weekParam
+    ? getMondayDateStr(new Date(weekParam + "T00:00:00Z"))
+    : getMondayDateStr(new Date());
+
+  const from = new Date(weekStart + "T00:00:00Z");
+  const to = new Date(from);
+  to.setUTCDate(to.getUTCDate() + 7);
+
+  const [org, rawInstances] = await Promise.all([
+    prisma.organization.findUnique({
+      where: { id: orgId },
+      select: { openTimeMin: true, closeTimeMin: true },
+    }),
+    getTaskInstancesForTimetable(orgId, from, to),
+  ]);
+
+  const mode = modeParam === "simple" ? "simple" : "calendar";
+
+  // Explicitly serialize all Date fields so the client component boundary
+  // receives plain strings instead of Prisma Date objects.
+  const instances: ClientTimetableInstance[] = rawInstances.map((inst) => ({
+    id: inst.id,
+    taskId: inst.taskId,
+    status: inst.status,
+    scheduledStartAt: inst.scheduledStartAt?.toISOString() ?? null,
+    scheduledEndAt: inst.scheduledEndAt?.toISOString() ?? null,
+    task: {
+      id: inst.task.id,
+      title: inst.task.title,
+      durationMin: inst.task.durationMin,
+      preferredStartTimeMin: inst.task.preferredStartTimeMin,
+    },
+    assignees: inst.assignees.map((a) => ({
+      id: a.id,
+      membership: {
+        id: a.membership.id,
+        user: {
+          id: a.membership.user.id,
+          name: a.membership.user.name,
+        },
+      },
+    })),
+  }));
+
+  return (
+    <TimetableClient
+      orgId={orgId}
+      instances={instances}
+      weekStart={weekStart}
+      openTimeMin={org?.openTimeMin ?? 360}
+      closeTimeMin={org?.closeTimeMin ?? 1320}
+      mode={mode}
+    />
+  );
+}

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
@@ -1,0 +1,520 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Toolbar } from "@/components/layout/toolbar";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ClientTimetableInstance = {
+  id: string;
+  taskId: string;
+  status: "TODO" | "IN_PROGRESS" | "DONE" | "SKIPPED";
+  scheduledStartAt: string | null;
+  scheduledEndAt: string | null;
+  task: {
+    id: string;
+    title: string;
+    durationMin: number;
+    preferredStartTimeMin: number | null;
+  };
+  assignees: Array<{
+    id: string;
+    membership: {
+      id: string;
+      user: { id: string; name: string | null };
+    };
+  }>;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const HOUR_HEIGHT = 64; // px per hour
+
+const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+const MONTH_NAMES = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+const STATUS_LABELS: Record<ClientTimetableInstance["status"], string> = {
+  TODO: "TODO",
+  IN_PROGRESS: "IN PROG",
+  DONE: "DONE",
+  SKIPPED: "SKIP",
+};
+
+// ---------------------------------------------------------------------------
+// Date utilities — UTC-based to match server-side week computation
+// ---------------------------------------------------------------------------
+
+function addDays(dateStr: string, n: number): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().split("T")[0];
+}
+
+function isToday(dateStr: string): boolean {
+  return new Date().toISOString().split("T")[0] === dateStr;
+}
+
+function formatDateRange(weekStart: string): string {
+  const s = new Date(weekStart + "T00:00:00Z");
+  const e = new Date(addDays(weekStart, 6) + "T00:00:00Z");
+  return `${MONTH_NAMES[s.getUTCMonth()]} ${s.getUTCDate()} \u2013 ${MONTH_NAMES[e.getUTCMonth()]} ${e.getUTCDate()}, ${e.getUTCFullYear()}`;
+}
+
+/** Groups instances by UTC date string (YYYY-MM-DD). */
+function groupByDate(
+  instances: ClientTimetableInstance[],
+): Map<string, ClientTimetableInstance[]> {
+  const map = new Map<string, ClientTimetableInstance[]>();
+  for (const inst of instances) {
+    if (!inst.scheduledStartAt) continue;
+    const key = inst.scheduledStartAt.split("T")[0];
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(inst);
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Status styling
+// ---------------------------------------------------------------------------
+
+function statusBlockClass(status: ClientTimetableInstance["status"]): string {
+  switch (status) {
+    case "TODO":        return "bg-slate-300/80 text-slate-800 border-slate-400";
+    case "IN_PROGRESS": return "bg-amber-300/80 text-amber-900 border-amber-400";
+    case "DONE":        return "bg-green-300/80 text-green-900 border-green-400";
+    case "SKIPPED":     return "bg-red-300/80 text-red-900 border-red-400";
+  }
+}
+
+function statusBadgeClass(status: string): string {
+  switch (status) {
+    case "TODO":        return "bg-slate-200 text-slate-600";
+    case "IN_PROGRESS": return "bg-amber-100 text-amber-700";
+    case "DONE":        return "bg-green-100 text-green-700";
+    case "SKIPPED":     return "bg-red-100 text-red-700";
+    default:            return "bg-slate-100 text-slate-600";
+  }
+}
+
+function statusDotClass(status: string): string {
+  switch (status) {
+    case "TODO":        return "bg-slate-400";
+    case "IN_PROGRESS": return "bg-amber-500";
+    case "DONE":        return "bg-green-500";
+    case "SKIPPED":     return "bg-red-500";
+    default:            return "bg-slate-400";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Column-overlap layout for the calendar view
+// ---------------------------------------------------------------------------
+
+type PositionedInstance = {
+  instance: ClientTimetableInstance;
+  col: number;
+  totalCols: number;
+};
+
+/**
+ * Assigns non-overlapping column slots to instances within a single day.
+ * Overlapping tasks share the column width proportionally so they're both
+ * visible side by side.
+ */
+function assignColumns(
+  dayInstances: ClientTimetableInstance[],
+  openTimeMin: number,
+): PositionedInstance[] {
+  const sorted = [...dayInstances].sort((a, b) => {
+    const ta = a.scheduledStartAt ? new Date(a.scheduledStartAt).getTime() : 0;
+    const tb = b.scheduledStartAt ? new Date(b.scheduledStartAt).getTime() : 0;
+    return ta - tb;
+  });
+
+  // colEnds[i] = the UTC minute at which column i last becomes free
+  const colEnds: number[] = [];
+
+  const positioned = sorted.map((inst) => {
+    const start = inst.scheduledStartAt ? new Date(inst.scheduledStartAt) : null;
+    const startMin = start
+      ? start.getUTCHours() * 60 + start.getUTCMinutes()
+      : openTimeMin;
+    const endMin = startMin + inst.task.durationMin;
+
+    let col = colEnds.findIndex((e) => e <= startMin);
+    if (col === -1) {
+      col = colEnds.length;
+      colEnds.push(endMin);
+    } else {
+      colEnds[col] = endMin;
+    }
+
+    return { instance: inst, col, totalCols: 0 };
+  });
+
+  const totalCols = Math.max(colEnds.length, 1);
+  return positioned.map((p) => ({ ...p, totalCols }));
+}
+
+// ---------------------------------------------------------------------------
+// CalendarView
+// ---------------------------------------------------------------------------
+
+interface CalendarViewProps {
+  instances: ClientTimetableInstance[];
+  weekStart: string;
+  openTimeMin: number;
+  closeTimeMin: number;
+}
+
+function CalendarView({
+  instances,
+  weekStart,
+  openTimeMin,
+  closeTimeMin,
+}: CalendarViewProps) {
+  const startHour = Math.floor(openTimeMin / 60);
+  const endHour = Math.ceil(closeTimeMin / 60);
+  const hours = Array.from({ length: endHour - startHour }, (_, i) => startHour + i);
+  const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+  const totalHeight = hours.length * HOUR_HEIGHT;
+  const byDate = groupByDate(instances);
+
+  return (
+    <div className="rounded-xl border-2 border-purple-400 overflow-hidden">
+      {/* Day-name header */}
+      <div className="flex border-b-2 border-purple-300 bg-purple-100">
+        <div className="w-14 shrink-0 border-r border-purple-300" />
+        {days.map((dayStr, i) => {
+          const d = new Date(dayStr + "T00:00:00Z");
+          const today = isToday(dayStr);
+          return (
+            <div
+              key={dayStr}
+              className={`flex-1 py-2 text-center text-sm border-r border-purple-300 last:border-r-0 ${
+                today ? "bg-blue-200 text-blue-800" : "text-slate-700"
+              }`}
+            >
+              <div className="font-medium">{DAY_NAMES[i]}</div>
+              <div
+                className={`text-lg font-bold leading-none mt-0.5 ${
+                  today ? "text-blue-700" : ""
+                }`}
+              >
+                {d.getUTCDate()}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Scrollable time grid */}
+      <div className="overflow-y-auto bg-purple-50/40" style={{ maxHeight: 520 }}>
+        <div className="flex" style={{ height: totalHeight }}>
+          {/* Hour-label gutter */}
+          <div className="w-14 shrink-0 border-r border-purple-200">
+            {hours.map((h) => (
+              <div
+                key={h}
+                style={{ height: HOUR_HEIGHT }}
+                className="flex items-start justify-end pr-2 pt-1 text-xs text-muted-foreground border-b border-purple-200/50 select-none"
+              >
+                {`${h}:00`}
+              </div>
+            ))}
+          </div>
+
+          {/* Day columns */}
+          {days.map((dayStr) => {
+            const dayInstances = byDate.get(dayStr) ?? [];
+            const positioned = assignColumns(dayInstances, openTimeMin);
+            const today = isToday(dayStr);
+
+            return (
+              <div
+                key={dayStr}
+                className={`flex-1 relative border-r border-purple-300 last:border-r-0 ${
+                  today ? "bg-blue-50/50" : ""
+                }`}
+                style={{ height: totalHeight }}
+              >
+                {/* Background hour lines */}
+                {hours.map((h) => (
+                  <div
+                    key={h}
+                    className="absolute inset-x-0 border-b border-purple-200/50"
+                    style={{ top: (h - startHour) * HOUR_HEIGHT, height: HOUR_HEIGHT }}
+                  />
+                ))}
+
+                {/* Task blocks */}
+                {positioned.map(({ instance: inst, col, totalCols }) => {
+                  const startDate = new Date(inst.scheduledStartAt!);
+                  const startMin =
+                    startDate.getUTCHours() * 60 + startDate.getUTCMinutes();
+                  const topPx = Math.max(
+                    ((startMin - startHour * 60) / 60) * HOUR_HEIGHT,
+                    0,
+                  );
+                  const heightPx = Math.max(
+                    (inst.task.durationMin / 60) * HOUR_HEIGHT,
+                    20,
+                  );
+                  const widthPct = 100 / totalCols;
+                  const leftPct = col * widthPct;
+                  const assigneeNames = inst.assignees
+                    .map((a) => a.membership.user.name?.split(" ")[0] ?? "?")
+                    .join(", ");
+
+                  return (
+                    <div
+                      key={inst.id}
+                      className={`absolute rounded border overflow-hidden p-1 text-[11px] leading-snug cursor-pointer hover:opacity-90 transition-opacity ${statusBlockClass(inst.status)}`}
+                      style={{
+                        top: topPx + 1,
+                        height: Math.max(heightPx - 2, 18),
+                        left: `${leftPct + 0.5}%`,
+                        width: `${widthPct - 1}%`,
+                      }}
+                      title={`${inst.task.title} — ${inst.task.durationMin} min`}
+                    >
+                      <div className="font-semibold truncate">{inst.task.title}</div>
+                      {heightPx >= 36 && assigneeNames && (
+                        <div className="truncate opacity-80">{assigneeNames}</div>
+                      )}
+                      {heightPx >= 52 && (
+                        <div className="opacity-60 text-[10px]">
+                          • {STATUS_LABELS[inst.status]}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SimpleView
+// ---------------------------------------------------------------------------
+
+interface SimpleViewProps {
+  instances: ClientTimetableInstance[];
+  weekStart: string;
+}
+
+function SimpleView({ instances, weekStart }: SimpleViewProps) {
+  const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+  const byDate = groupByDate(instances);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {days.map((dayStr, dayIdx) => {
+        const d = new Date(dayStr + "T00:00:00Z");
+        const today = isToday(dayStr);
+        const dayInstances = byDate.get(dayStr) ?? [];
+        const dayLabel = `${DAY_NAMES[dayIdx]}, ${MONTH_NAMES[d.getUTCMonth()]} ${d.getUTCDate()}`;
+
+        return (
+          <div key={dayStr} className="rounded-xl border overflow-hidden">
+            {/* Day header */}
+            <div
+              className={`px-4 py-2.5 flex items-center gap-2 font-semibold text-sm border-b ${
+                today
+                  ? "bg-blue-50 text-blue-800 border-blue-200"
+                  : "bg-muted/50"
+              }`}
+            >
+              {dayLabel}
+              {today && (
+                <span className="text-xs font-normal text-blue-500 ml-1">
+                  Today
+                </span>
+              )}
+            </div>
+
+            {dayInstances.length === 0 ? (
+              <div className="px-4 py-3 text-sm text-muted-foreground">
+                No tasks scheduled
+              </div>
+            ) : (
+              <table className="w-full text-sm">
+                <thead className="border-b bg-muted/20">
+                  <tr className="text-xs text-muted-foreground uppercase tracking-wide">
+                    <th className="px-3 py-1.5 text-left font-medium w-8">#</th>
+                    <th className="px-3 py-1.5 text-left font-medium">Status</th>
+                    <th className="px-3 py-1.5 text-left font-medium">Task</th>
+                    <th className="px-3 py-1.5 text-left font-medium">Duration</th>
+                    <th className="px-3 py-1.5 text-left font-medium">Assigned To</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {dayInstances.map((inst, idx) => {
+                    const assigneeNames =
+                      inst.assignees
+                        .map((a) => a.membership.user.name ?? "Unknown")
+                        .join(", ") || "\u2014";
+                    const isSkipped = inst.status === "SKIPPED";
+
+                    return (
+                      <tr
+                        key={inst.id}
+                        className="hover:bg-muted/20 transition-colors"
+                      >
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {idx + 1}
+                        </td>
+                        <td className="px-3 py-2">
+                          <span
+                            className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClass(inst.status)}`}
+                          >
+                            <span
+                              className={`w-1.5 h-1.5 rounded-full ${statusDotClass(inst.status)}`}
+                            />
+                            {STATUS_LABELS[inst.status]}
+                          </span>
+                        </td>
+                        <td
+                          className={`px-3 py-2 font-medium ${
+                            isSkipped
+                              ? "line-through text-muted-foreground"
+                              : ""
+                          }`}
+                        >
+                          {inst.task.title}
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground text-xs">
+                          {inst.task.durationMin} min
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground text-xs">
+                          {assigneeNames}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+interface TimetableClientProps {
+  orgId: string;
+  instances: ClientTimetableInstance[];
+  weekStart: string;
+  openTimeMin: number;
+  closeTimeMin: number;
+  mode: "calendar" | "simple";
+}
+
+export function TimetableClient({
+  orgId,
+  instances,
+  weekStart,
+  openTimeMin,
+  closeTimeMin,
+  mode,
+}: TimetableClientProps) {
+  const prevWeek = addDays(weekStart, -7);
+  const nextWeek = addDays(weekStart, 7);
+  const dateRangeLabel = formatDateRange(weekStart);
+
+  const makeHref = (w: string, m: string) =>
+    `/orgs/${orgId}/timetable?week=${w}&mode=${m}`;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Toolbar actions={[{ label: "Templates", href: `/orgs/${orgId}/timetable/templates` }]}>
+        {/* Week-view type (placeholder) */}
+        <Button variant="outline" size="sm" className="gap-1.5" disabled>
+          Week <ChevronDown className="h-3.5 w-3.5" />
+        </Button>
+
+        {/* Templates (placeholder — cycle/template logic TBD) */}
+        <Button variant="outline" size="sm" className="gap-1.5" disabled>
+          Templates <ChevronDown className="h-3.5 w-3.5" />
+        </Button>
+
+        {/* Filter (placeholder) */}
+        <Button variant="outline" size="sm" className="gap-1.5" disabled>
+          Filter <ChevronDown className="h-3.5 w-3.5" />
+        </Button>
+
+        {/* Calendar / Simple toggle */}
+        <div className="flex rounded-md overflow-hidden border text-sm font-medium">
+          <Link
+            href={makeHref(weekStart, "calendar")}
+            className={`px-3 py-1 transition-colors ${
+              mode === "calendar"
+                ? "bg-primary text-primary-foreground"
+                : "hover:bg-muted text-muted-foreground"
+            }`}
+          >
+            Calendar
+          </Link>
+          <Link
+            href={makeHref(weekStart, "simple")}
+            className={`px-3 py-1 border-l transition-colors ${
+              mode === "simple"
+                ? "bg-primary text-primary-foreground"
+                : "hover:bg-muted text-muted-foreground"
+            }`}
+          >
+            Simple
+          </Link>
+        </div>
+      </Toolbar>
+
+      {/* Week navigation */}
+      <div className="flex items-center justify-between rounded-lg border px-4 py-1.5">
+        <Link href={makeHref(prevWeek, mode)}>
+          <Button variant="ghost" size="sm" className="gap-1">
+            <ChevronLeft className="h-4 w-4" /> Prev
+          </Button>
+        </Link>
+        <span className="text-sm font-medium">{dateRangeLabel}</span>
+        <Link href={makeHref(nextWeek, mode)}>
+          <Button variant="ghost" size="sm" className="gap-1">
+            Next <ChevronRight className="h-4 w-4" />
+          </Button>
+        </Link>
+      </div>
+
+      {/* View */}
+      {mode === "calendar" ? (
+        <CalendarView
+          instances={instances}
+          weekStart={weekStart}
+          openTimeMin={openTimeMin}
+          closeTimeMin={closeTimeMin}
+        />
+      ) : (
+        <SimpleView instances={instances} weekStart={weekStart} />
+      )}
+    </div>
+  );
+}

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Toolbar } from "@/components/layout/toolbar";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -448,47 +447,6 @@ export function TimetableClient({
 
   return (
     <div className="flex flex-col gap-4">
-      <Toolbar actions={[{ label: "Templates", href: `/orgs/${orgId}/timetable/templates` }]}>
-        {/* Week-view type (placeholder) */}
-        <Button variant="outline" size="sm" className="gap-1.5" disabled>
-          Week <ChevronDown className="h-3.5 w-3.5" />
-        </Button>
-
-        {/* Templates (placeholder — cycle/template logic TBD) */}
-        <Button variant="outline" size="sm" className="gap-1.5" disabled>
-          Templates <ChevronDown className="h-3.5 w-3.5" />
-        </Button>
-
-        {/* Filter (placeholder) */}
-        <Button variant="outline" size="sm" className="gap-1.5" disabled>
-          Filter <ChevronDown className="h-3.5 w-3.5" />
-        </Button>
-
-        {/* Calendar / Simple toggle */}
-        <div className="flex rounded-md overflow-hidden border text-sm font-medium">
-          <Link
-            href={makeHref(weekStart, "calendar")}
-            className={`px-3 py-1 transition-colors ${
-              mode === "calendar"
-                ? "bg-primary text-primary-foreground"
-                : "hover:bg-muted text-muted-foreground"
-            }`}
-          >
-            Calendar
-          </Link>
-          <Link
-            href={makeHref(weekStart, "simple")}
-            className={`px-3 py-1 border-l transition-colors ${
-              mode === "simple"
-                ? "bg-primary text-primary-foreground"
-                : "hover:bg-muted text-muted-foreground"
-            }`}
-          >
-            Simple
-          </Link>
-        </div>
-      </Toolbar>
-
       {/* Week navigation */}
       <div className="flex items-center justify-between rounded-lg border px-4 py-1.5">
         <Link href={makeHref(prevWeek, mode)}>

--- a/lib/services/task-instances.ts
+++ b/lib/services/task-instances.ts
@@ -157,3 +157,48 @@ export async function updateTaskInstanceStatus(
     throw e;
   }
 }
+
+/** Full instance shape used by the timetable view. */
+export type TimetableInstance = Prisma.TaskInstanceGetPayload<{
+  include: {
+    task: true;
+    assignees: {
+      include: {
+        membership: {
+          include: { user: { select: { id: true; name: true } } };
+        };
+      };
+    };
+  };
+}>;
+
+/**
+ * Fetches task instances within a UTC date range for the timetable view.
+ * Only instances with a scheduledStartAt in [from, to) are returned.
+ * Includes task details and assignee/user data needed to render blocks.
+ */
+export async function getTaskInstancesForTimetable(
+  orgId: string,
+  from: Date,
+  to: Date,
+): Promise<TimetableInstance[]> {
+  return prisma.taskInstance.findMany({
+    where: {
+      orgId,
+      scheduledStartAt: { gte: from, lt: to },
+    },
+    include: {
+      task: true,
+      assignees: {
+        include: {
+          membership: {
+            include: {
+              user: { select: { id: true, name: true } },
+            },
+          },
+        },
+      },
+    },
+    orderBy: { scheduledStartAt: "asc" },
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timetable interface with calendar and simple (list) modes, week navigation, and mode toggle preserved in links.
  * Calendar: 7-day UTC grid with time-based blocks, side-by-side overlap layout, hour labels, and week range label.
  * Simple: per-day tables with status badges, durations, assignee names, and empty-state messaging.
  * Toolbar with Week/Filter buttons (disabled) and access restricted to organization members; unauthorized users redirected.
  * Week defaults to the UTC Monday for the current week when not specified; time window bounds applied.

* **Documentation**
  * README updated with timetable behavior, modes, navigation, and status mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->