### PR TITLE
feat: add timetable templates with drag-and-drop editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,18 +238,18 @@ Server Actions use `revalidatePath` to invalidate the Next.js cache so server-re
 
 ## Pages
 
-| Route                           | Guard                              | Description                    |
-| ------------------------------- | ---------------------------------- | ------------------------------ |
-| `/`                             | Signed in                          | Home — authenticated app shell |
-| `/signin`                       | —                                  | Google OAuth sign-in           |
-| `/orgs/new`                     | Signed in                          | Create a new organization      |
-| `/orgs/[orgId]`                 | `requireOrgMember`                 | Org overview (placeholder)     |
-| `/orgs/[orgId]/tasks`           | `requireOrgMember`                 | Task template list             |
-| `/orgs/[orgId]/tasks/new`       | `requireOrgPermission TASK_CREATE` | Create a new task template     |
-| `/orgs/[orgId]/memberships`     | `requireOrgMember`                 | Member list                    |
-| `/orgs/[orgId]/memberships/new` | `requireOrgPermission ORG_MANAGE`  | Invite a new member by email   |
-| `/orgs/[orgId]/timetable`       | `requireOrgMember`                 | Timetable — calendar or simple mode, week navigation |
-| `/orgs/[orgId]/timetable/templates` | `requireOrgMember`             | Timetable templates (coming soon) |
+| Route                               | Guard                              | Description                                          |
+| ----------------------------------- | ---------------------------------- | ---------------------------------------------------- |
+| `/`                                 | Signed in                          | Home — authenticated app shell                       |
+| `/signin`                           | —                                  | Google OAuth sign-in                                 |
+| `/orgs/new`                         | Signed in                          | Create a new organization                            |
+| `/orgs/[orgId]`                     | `requireOrgMember`                 | Org overview (placeholder)                           |
+| `/orgs/[orgId]/tasks`               | `requireOrgMember`                 | Task template list                                   |
+| `/orgs/[orgId]/tasks/new`           | `requireOrgPermission TASK_CREATE` | Create a new task template                           |
+| `/orgs/[orgId]/memberships`         | `requireOrgMember`                 | Member list                                          |
+| `/orgs/[orgId]/memberships/new`     | `requireOrgPermission ORG_MANAGE`  | Invite a new member by email                         |
+| `/orgs/[orgId]/timetable`           | `requireOrgMember`                 | Timetable — calendar or simple mode, week navigation |
+| `/orgs/[orgId]/timetable/templates` | `requireOrgMember`                 | Timetable templates (coming soon)                    |
 
 All `/orgs/[orgId]/*` pages are guarded by at least `requireOrgMember` — users not in the org are redirected to `/`.
 
@@ -257,7 +257,7 @@ All `/orgs/[orgId]/*` pages are guarded by at least `requireOrgMember` — users
 
 - **Sidebar active state** — uses prefix matching so nested pages (e.g. `/tasks/new`) correctly highlight the parent nav item. The Org Overview item uses exact matching to avoid lighting up on every org page.
 - **Form validation** — server-action errors are rendered inline next to each field with `aria-invalid` / `aria-describedby` for accessibility, plus a Sonner toast summary.
-- **Timetable** — the server page fetches the week's instances (scoped to `scheduledStartAt` in `[monday, monday+7)`) and renders the Calendar/Simple mode links; the client component handles the interactive timetable UI plus Prev/Next week navigation via `?week=` and `?mode=` search params. Calendar view uses absolute positioning to render task blocks by time; overlapping tasks are assigned side-by-side columns. Status colours: gray = TODO, amber = IN\_PROGRESS, green = DONE, red = SKIPPED.
+- **Timetable** — the server page fetches the week's instances (scoped to `scheduledStartAt` in `[monday, monday+7)`) and renders the Calendar/Simple mode links; the client component handles the interactive timetable UI plus Prev/Next week navigation via `?week=` and `?mode=` search params. Calendar view uses absolute positioning to render task blocks by time; overlapping tasks are assigned side-by-side columns. Status colours: gray = TODO, amber = IN_PROGRESS, green = DONE, red = SKIPPED.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Provider: PostgreSQL (Supabase), managed via Prisma ORM.
 | `RolePermission`       | Grants a specific `OrgPermission` enum value to a `Role`.                               |
 | `Task`                 | A reusable task template belonging to an org (title, duration, recurrence constraints). |
 | `TaskEligibility`      | Links a `Task` to a `Role`, defining which roles can be assigned to it.                 |
-| `TaskCycle`            | A planning horizon (e.g. weekly) that groups a set of `TaskInstance`s.                  |
+| `TimetableTemplate`    | A planning horizon/template (e.g. weekly) that groups a set of `TaskInstance`s.         |
 | `TaskInstance`         | A scheduled occurrence of a `Task`, with status, scheduled times, and assignees.        |
 | `TaskInstanceAssignee` | Links a `Membership` to a `TaskInstance` (many-to-many).                                |
 

--- a/app/(app)/orgs/[orgId]/timetable/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/page.tsx
@@ -126,6 +126,7 @@ function projectTemplateToWeek(
       result.push({
         id: `${inst.id}-d${weekdayIndex}`,
         taskId: inst.task.id,
+        isProjected: true,
         status: "TODO",
         scheduledStartAt: new Date(startMs).toISOString(),
         scheduledEndAt: new Date(endMs).toISOString(),

--- a/app/(app)/orgs/[orgId]/timetable/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/page.tsx
@@ -64,10 +64,28 @@ function localMidnightUTC(dateStr: string, tz: string): number {
   return utcMs;
 }
 
+/**
+ * Counts the number of calendar days from date string `a` to `b` (b − a).
+ * Uses UTC noon arithmetic so the result is independent of DST in any timezone.
+ */
+function calendarDaysBetween(a: string, b: string): number {
+  const [ay, am, ad] = a.split("-").map(Number);
+  const [by, bm, bd] = b.split("-").map(Number);
+  return Math.round(
+    (Date.UTC(by, bm - 1, bd) - Date.UTC(ay, am - 1, ad)) / MS_PER_DAY,
+  );
+}
+
+/** Returns the YYYY-MM-DD that is `n` calendar days after `dateStr`. */
+function addCalendarDays(dateStr: string, n: number): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d + n)).toISOString().split("T")[0];
+}
+
 /** Returns the YYYY-MM-DD of Monday of the week containing `dateStr`, computed in `tz`. */
 function getMondayDateStr(dateStr: string, tz: string): string {
   const [y, m, d] = dateStr.split("-").map(Number);
-  const probe = new Date(Date.UTC(y, m - 1, d, 12));
+  const probe = new Date(localMidnightUTC(dateStr, tz));
   const wd = new Intl.DateTimeFormat("en-US", {
     timeZone: tz,
     weekday: "short",
@@ -99,18 +117,15 @@ function projectTemplateToWeek(
   weekStart: string,
   orgTz: string,
 ): ClientTimetableInstance[] {
-  // Use org-local midnight so startTimeMin (local minutes) is added to the
-  // correct base, and the cycle offset isn't skewed by the UTC offset.
-  const weekStartMs = localMidnightUTC(weekStart, orgTz);
   const { templateDays, effectiveFrom, instances } = template;
 
-  // Anchor the cycle to local midnight of the effective date (or fixed Monday).
-  // Snapping effectiveFrom to local midnight avoids a skewed cycle offset when
-  // the stored timestamp isn't exactly midnight.
-  const anchorMs = effectiveFrom
-    ? localMidnightUTC(toLocalDateStr(effectiveFrom, orgTz), orgTz)
-    : localMidnightUTC("2000-01-03", orgTz);
-  const daysSince = Math.floor((weekStartMs - anchorMs) / MS_PER_DAY);
+  // Compute cycle offset from YYYY-MM-DD strings so DST hour shifts don't
+  // corrupt the day count (dividing a UTC-ms delta by 86_400_000 breaks on
+  // the DST transition week when anchor and weekStart are in different offsets).
+  const anchorDateStr = effectiveFrom
+    ? toLocalDateStr(effectiveFrom, orgTz)
+    : "2000-01-03";
+  const daysSince = calendarDaysBetween(anchorDateStr, weekStart);
   const cycleStartOffset =
     ((daysSince % templateDays) + templateDays) % templateDays;
 
@@ -128,8 +143,10 @@ function projectTemplateToWeek(
     // repeat if templateDays < 7 (short cycles fill whole week)
     let weekdayIndex = baseIndex;
     while (weekdayIndex < 7) {
-      // startTimeMin is minutes from local midnight → base on local midnight of that day
-      const dayMs = weekStartMs + weekdayIndex * MS_PER_DAY;
+      // Resolve each day's local midnight independently via localMidnightUTC so
+      // that startTimeMin (minutes from local midnight) lands at the right UTC
+      // instant even across a DST transition during the week.
+      const dayMs = localMidnightUTC(addCalendarDays(weekStart, weekdayIndex), orgTz);
       const startMs = dayMs + inst.startTimeMin * 60 * 1000;
       const endMs = startMs + inst.task.durationMin * 60 * 1000;
 
@@ -195,7 +212,9 @@ export default async function TimetablePage({
 
   const fromMs = localMidnightUTC(weekStart, orgTz);
   const from = new Date(fromMs);
-  const to = new Date(fromMs + 7 * MS_PER_DAY);
+  // Use localMidnightUTC for the end boundary so a DST change mid-week doesn't
+  // shrink or expand the [from, to) window by an hour.
+  const to = new Date(localMidnightUTC(addCalendarDays(weekStart, 7), orgTz));
 
   const mode = modeParam === "simple" ? "simple" : "calendar";
   const selectedTemplateId = templateParam ?? null;

--- a/app/(app)/orgs/[orgId]/timetable/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/page.tsx
@@ -32,23 +32,36 @@ function toLocalDateStr(d: Date, tz: string): string {
  */
 function localMidnightUTC(dateStr: string, tz: string): number {
   const [y, m, d] = dateStr.split("-").map(Number);
-  const noonUTC = Date.UTC(y, m - 1, d, 12, 0, 0);
-  const parts = Object.fromEntries(
-    new Intl.DateTimeFormat("en-US", {
-      timeZone: tz,
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: false,
-    })
-      .formatToParts(new Date(noonUTC))
-      .map((p) => [p.type, p.value]),
-  );
-  const lH = parseInt(parts.hour ?? "0") % 24;
-  const lM = parseInt(parts.minute ?? "0");
-  const lS = parseInt(parts.second ?? "0");
-  // offset = how far local time is ahead of UTC at noonUTC
-  return noonUTC - ((lH * 3600 + lM * 60 + lS) * 1000 - 12 * 3_600_000);
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  });
+
+  let utcMs = Date.UTC(y, m - 1, d, 0, 0, 0);
+  for (let i = 0; i < 3; i += 1) {
+    const parts = Object.fromEntries(
+      formatter.formatToParts(new Date(utcMs)).map((p) => [p.type, p.value]),
+    );
+    const localAsUtc = Date.UTC(
+      Number(parts.year),
+      Number(parts.month) - 1,
+      Number(parts.day),
+      Number(parts.hour),
+      Number(parts.minute),
+      Number(parts.second),
+    );
+    const desiredAsUtc = Date.UTC(y, m - 1, d, 0, 0, 0);
+    const delta = localAsUtc - desiredAsUtc;
+    if (delta === 0) break;
+    utcMs -= delta;
+  }
+  return utcMs;
 }
 
 /** Returns the YYYY-MM-DD of Monday of the week containing `dateStr`, computed in `tz`. */
@@ -95,10 +108,7 @@ function projectTemplateToWeek(
   // Snapping effectiveFrom to local midnight avoids a skewed cycle offset when
   // the stored timestamp isn't exactly midnight.
   const anchorMs = effectiveFrom
-    ? localMidnightUTC(
-        getMondayDateStr(toLocalDateStr(effectiveFrom, orgTz), orgTz),
-        orgTz,
-      )
+    ? localMidnightUTC(toLocalDateStr(effectiveFrom, orgTz), orgTz)
     : localMidnightUTC("2000-01-03", orgTz);
   const daysSince = Math.floor((weekStartMs - anchorMs) / MS_PER_DAY);
   const cycleStartOffset =

--- a/app/(app)/orgs/[orgId]/timetable/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/page.tsx
@@ -2,8 +2,14 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { requireOrgMember } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
-import { getTaskInstancesForTimetable } from "@/lib/services/task-instances";
-import { getTimetableTemplates, getTimetableTemplate } from "@/lib/services/templates";
+import {
+  getTaskInstancesForTimetable,
+  type TimetableInstance,
+} from "@/lib/services/task-instances";
+import {
+  getTimetableTemplates,
+  getTimetableTemplate,
+} from "@/lib/services/templates";
 import { Toolbar } from "@/components/layout/toolbar";
 import { Button } from "@/components/ui/button";
 import { ChevronDown } from "lucide-react";
@@ -15,13 +21,55 @@ import { TemplateSelector } from "./template-selector";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-/** Returns the YYYY-MM-DD string for the Monday of the week containing `date` (UTC). */
-function getMondayDateStr(date: Date): string {
-  const d = new Date(date);
-  d.setUTCHours(0, 0, 0, 0);
-  const day = d.getUTCDay();
-  d.setUTCDate(d.getUTCDate() - (day === 0 ? 6 : day - 1));
-  return d.toISOString().split("T")[0];
+/** Returns the YYYY-MM-DD local date string for `d` in the given IANA timezone. */
+function toLocalDateStr(d: Date, tz: string): string {
+  return d.toLocaleDateString("en-CA", { timeZone: tz });
+}
+
+/**
+ * Returns the UTC ms timestamp for local midnight of `dateStr` (YYYY-MM-DD) in `tz`.
+ * Probes at noon UTC to derive the offset robustly across DST transitions.
+ */
+function localMidnightUTC(dateStr: string, tz: string): number {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const noonUTC = Date.UTC(y, m - 1, d, 12, 0, 0);
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    })
+      .formatToParts(new Date(noonUTC))
+      .map((p) => [p.type, p.value]),
+  );
+  const lH = parseInt(parts.hour ?? "0") % 24;
+  const lM = parseInt(parts.minute ?? "0");
+  const lS = parseInt(parts.second ?? "0");
+  // offset = how far local time is ahead of UTC at noonUTC
+  return noonUTC - ((lH * 3600 + lM * 60 + lS) * 1000 - 12 * 3_600_000);
+}
+
+/** Returns the YYYY-MM-DD of Monday of the week containing `dateStr`, computed in `tz`. */
+function getMondayDateStr(dateStr: string, tz: string): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const probe = new Date(Date.UTC(y, m - 1, d, 12));
+  const wd = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    weekday: "short",
+  }).format(probe);
+  const DOW_OFFSET: Record<string, number> = {
+    Sun: -6,
+    Mon: 0,
+    Tue: -1,
+    Wed: -2,
+    Thu: -3,
+    Fri: -4,
+    Sat: -5,
+  };
+  const offset = DOW_OFFSET[wd] ?? 0;
+  return new Date(Date.UTC(y, m - 1, d + offset)).toISOString().split("T")[0];
 }
 
 /**
@@ -36,18 +84,25 @@ function getMondayDateStr(date: Date): string {
 function projectTemplateToWeek(
   template: NonNullable<Awaited<ReturnType<typeof getTimetableTemplate>>>,
   weekStart: string,
+  orgTz: string,
 ): ClientTimetableInstance[] {
-  const weekStartDate = new Date(weekStart + "T00:00:00Z");
+  // Use org-local midnight so startTimeMin (local minutes) is added to the
+  // correct base, and the cycle offset isn't skewed by the UTC offset.
+  const weekStartMs = localMidnightUTC(weekStart, orgTz);
   const { templateDays, effectiveFrom, instances } = template;
 
-  // Anchor the cycle: use effectiveFrom if set, otherwise fall back to a
-  // fixed Monday (2000-01-03) so cycles with any templateDays length stay
-  // continuous and correct across all weeks without an explicit start date.
-  const anchor = effectiveFrom ?? new Date("2000-01-03T00:00:00Z");
-  const daysSince = Math.floor(
-    (weekStartDate.getTime() - anchor.getTime()) / MS_PER_DAY,
-  );
-  const cycleStartOffset = ((daysSince % templateDays) + templateDays) % templateDays;
+  // Anchor the cycle to local midnight of the effective date (or fixed Monday).
+  // Snapping effectiveFrom to local midnight avoids a skewed cycle offset when
+  // the stored timestamp isn't exactly midnight.
+  const anchorMs = effectiveFrom
+    ? localMidnightUTC(
+        getMondayDateStr(toLocalDateStr(effectiveFrom, orgTz), orgTz),
+        orgTz,
+      )
+    : localMidnightUTC("2000-01-03", orgTz);
+  const daysSince = Math.floor((weekStartMs - anchorMs) / MS_PER_DAY);
+  const cycleStartOffset =
+    ((daysSince % templateDays) + templateDays) % templateDays;
 
   const result: ClientTimetableInstance[] = [];
 
@@ -56,14 +111,16 @@ function projectTemplateToWeek(
 
     // base weekday index for this dayOffset (0 = Monday of this week)
     const baseIndex =
-      ((inst.dayOffset - 1 - cycleStartOffset) % templateDays + templateDays) %
+      (((inst.dayOffset - 1 - cycleStartOffset) % templateDays) +
+        templateDays) %
       templateDays;
 
     // repeat if templateDays < 7 (short cycles fill whole week)
     let weekdayIndex = baseIndex;
     while (weekdayIndex < 7) {
-      const dayDate = new Date(weekStartDate.getTime() + weekdayIndex * MS_PER_DAY);
-      const startMs = dayDate.getTime() + inst.startTimeMin * 60 * 1000;
+      // startTimeMin is minutes from local midnight → base on local midnight of that day
+      const dayMs = weekStartMs + weekdayIndex * MS_PER_DAY;
+      const startMs = dayMs + inst.startTimeMin * 60 * 1000;
       const endMs = startMs + inst.task.durationMin * 60 * 1000;
 
       result.push({
@@ -102,48 +159,52 @@ export default async function TimetablePage({
   searchParams: Promise<{ week?: string; mode?: string; template?: string }>;
 }) {
   const { orgId } = await params;
-  const { week: weekParam, mode: modeParam, template: templateParam } = await searchParams;
+  const {
+    week: weekParam,
+    mode: modeParam,
+    template: templateParam,
+  } = await searchParams;
 
   const authz = await requireOrgMember(orgId);
   if (!authz.ok) redirect("/");
 
+  // Fetch org data first so the week window and projection use org-local time.
+  const orgMeta = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: { timezone: true, openTimeMin: true, closeTimeMin: true },
+  });
+  const orgTz = orgMeta?.timezone ?? "UTC";
+
   let weekStart: string;
   if (weekParam && /^\d{4}-\d{2}-\d{2}$/.test(weekParam)) {
-    const parsed = new Date(weekParam + "T00:00:00Z");
-    weekStart = Number.isNaN(parsed.getTime())
-      ? getMondayDateStr(new Date())
-      : getMondayDateStr(parsed);
+    weekStart = getMondayDateStr(weekParam, orgTz);
   } else {
-    weekStart = getMondayDateStr(new Date());
+    weekStart = getMondayDateStr(toLocalDateStr(new Date(), orgTz), orgTz);
   }
 
-  const from = new Date(weekStart + "T00:00:00Z");
-  const to = new Date(from);
-  to.setUTCDate(to.getUTCDate() + 7);
+  const fromMs = localMidnightUTC(weekStart, orgTz);
+  const from = new Date(fromMs);
+  const to = new Date(fromMs + 7 * MS_PER_DAY);
 
   const mode = modeParam === "simple" ? "simple" : "calendar";
   const selectedTemplateId = templateParam ?? null;
 
-  const [org, templates, selectedTemplate, rawInstances] = await Promise.all([
-    prisma.organization.findUnique({
-      where: { id: orgId },
-      select: { openTimeMin: true, closeTimeMin: true },
-    }),
+  const [templates, selectedTemplate, rawInstances] = await Promise.all([
     getTimetableTemplates(orgId),
     selectedTemplateId
       ? getTimetableTemplate(orgId, selectedTemplateId)
       : Promise.resolve(null),
     // Only fetch live scheduled instances when no template is selected
     selectedTemplateId
-      ? Promise.resolve([])
+      ? Promise.resolve([] as TimetableInstance[])
       : getTaskInstancesForTimetable(orgId, from, to),
   ]);
 
   let instances: ClientTimetableInstance[];
 
   if (selectedTemplate) {
-    // Project cycle template onto this week
-    instances = projectTemplateToWeek(selectedTemplate, weekStart);
+    // Project cycle template onto this week using org-local midnight as the base
+    instances = projectTemplateToWeek(selectedTemplate, weekStart, orgTz);
   } else if (selectedTemplateId) {
     // Template param set but not found — show empty
     instances = [];
@@ -176,7 +237,11 @@ export default async function TimetablePage({
 
   return (
     <>
-      <Toolbar actions={[{ label: "Templates", href: `/orgs/${orgId}/timetable/templates` }]}>
+      <Toolbar
+        actions={[
+          { label: "Templates", href: `/orgs/${orgId}/timetable/templates` },
+        ]}
+      >
         {/* Template dropdown */}
         <TemplateSelector
           templates={templates.map((t) => ({ id: t.id, title: t.title }))}
@@ -218,8 +283,8 @@ export default async function TimetablePage({
         orgId={orgId}
         instances={instances}
         weekStart={weekStart}
-        openTimeMin={org?.openTimeMin ?? 360}
-        closeTimeMin={org?.closeTimeMin ?? 1320}
+        openTimeMin={orgMeta?.openTimeMin ?? 360}
+        closeTimeMin={orgMeta?.closeTimeMin ?? 1320}
         mode={mode}
         selectedTemplateId={selectedTemplateId}
       />

--- a/app/(app)/orgs/[orgId]/timetable/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/page.tsx
@@ -146,7 +146,10 @@ function projectTemplateToWeek(
       // Resolve each day's local midnight independently via localMidnightUTC so
       // that startTimeMin (minutes from local midnight) lands at the right UTC
       // instant even across a DST transition during the week.
-      const dayMs = localMidnightUTC(addCalendarDays(weekStart, weekdayIndex), orgTz);
+      const dayMs = localMidnightUTC(
+        addCalendarDays(weekStart, weekdayIndex),
+        orgTz,
+      );
       const startMs = dayMs + inst.startTimeMin * 60 * 1000;
       const endMs = startMs + inst.task.durationMin * 60 * 1000;
 
@@ -184,14 +187,19 @@ export default async function TimetablePage({
   searchParams,
 }: {
   params: Promise<{ orgId: string }>;
-  searchParams: Promise<{ week?: string; mode?: string; template?: string }>;
+  searchParams: Promise<{
+    week?: string | string[];
+    mode?: string | string[];
+    template?: string | string[];
+  }>;
 }) {
   const { orgId } = await params;
-  const {
-    week: weekParam,
-    mode: modeParam,
-    template: templateParam,
-  } = await searchParams;
+  const first = (value: string | string[] | undefined) =>
+    Array.isArray(value) ? value[0] : value;
+  const rawSearchParams = await searchParams;
+  const weekParam = first(rawSearchParams.week);
+  const modeParam = first(rawSearchParams.mode);
+  const templateParam = first(rawSearchParams.template);
 
   const authz = await requireOrgMember(orgId);
   if (!authz.ok) redirect("/");

--- a/app/(app)/orgs/[orgId]/timetable/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { requireOrgMember } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { getTaskInstancesForTimetable } from "@/lib/services/task-instances";
+import { getTimetableTemplates, getTimetableTemplate } from "@/lib/services/templates";
 import { Toolbar } from "@/components/layout/toolbar";
 import { Button } from "@/components/ui/button";
 import { ChevronDown } from "lucide-react";
@@ -10,14 +11,87 @@ import {
   TimetableClient,
   type ClientTimetableInstance,
 } from "./timetable-client";
+import { TemplateSelector } from "./template-selector";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /** Returns the YYYY-MM-DD string for the Monday of the week containing `date` (UTC). */
 function getMondayDateStr(date: Date): string {
   const d = new Date(date);
   d.setUTCHours(0, 0, 0, 0);
-  const day = d.getUTCDay(); // 0 = Sunday
+  const day = d.getUTCDay();
   d.setUTCDate(d.getUTCDate() - (day === 0 ? 6 : day - 1));
   return d.toISOString().split("T")[0];
+}
+
+/**
+ * Projects template instances onto a calendar week.
+ *
+ * If the template has an `effectiveFrom` date, the cycle is aligned to it so
+ * Day 1 always lands on the correct weekday. Otherwise Day 1 = Monday.
+ *
+ * For cycles shorter than 7 days (e.g. a 3-day cycle) the projection repeats
+ * within the week so every day is covered.
+ */
+function projectTemplateToWeek(
+  template: NonNullable<Awaited<ReturnType<typeof getTimetableTemplate>>>,
+  weekStart: string,
+): ClientTimetableInstance[] {
+  const weekStartDate = new Date(weekStart + "T00:00:00Z");
+  const { templateDays, effectiveFrom, instances } = template;
+
+  // Anchor the cycle: use effectiveFrom if set, otherwise fall back to a
+  // fixed Monday (2000-01-03) so cycles with any templateDays length stay
+  // continuous and correct across all weeks without an explicit start date.
+  const anchor = effectiveFrom ?? new Date("2000-01-03T00:00:00Z");
+  const daysSince = Math.floor(
+    (weekStartDate.getTime() - anchor.getTime()) / MS_PER_DAY,
+  );
+  const cycleStartOffset = ((daysSince % templateDays) + templateDays) % templateDays;
+
+  const result: ClientTimetableInstance[] = [];
+
+  for (const inst of instances) {
+    if (inst.dayOffset == null || inst.startTimeMin == null) continue;
+
+    // base weekday index for this dayOffset (0 = Monday of this week)
+    const baseIndex =
+      ((inst.dayOffset - 1 - cycleStartOffset) % templateDays + templateDays) %
+      templateDays;
+
+    // repeat if templateDays < 7 (short cycles fill whole week)
+    let weekdayIndex = baseIndex;
+    while (weekdayIndex < 7) {
+      const dayDate = new Date(weekStartDate.getTime() + weekdayIndex * MS_PER_DAY);
+      const startMs = dayDate.getTime() + inst.startTimeMin * 60 * 1000;
+      const endMs = startMs + inst.task.durationMin * 60 * 1000;
+
+      result.push({
+        id: `${inst.id}-d${weekdayIndex}`,
+        taskId: inst.task.id,
+        status: "TODO",
+        scheduledStartAt: new Date(startMs).toISOString(),
+        scheduledEndAt: new Date(endMs).toISOString(),
+        task: {
+          id: inst.task.id,
+          title: inst.task.title,
+          durationMin: inst.task.durationMin,
+          preferredStartTimeMin: null,
+        },
+        assignees: inst.assignees.map((a) => ({
+          id: a.id,
+          membership: {
+            id: a.membership.id,
+            user: { id: a.membership.user.id, name: a.membership.user.name },
+          },
+        })),
+      });
+
+      weekdayIndex += templateDays;
+    }
+  }
+
+  return result;
 }
 
 export default async function TimetablePage({
@@ -25,10 +99,10 @@ export default async function TimetablePage({
   searchParams,
 }: {
   params: Promise<{ orgId: string }>;
-  searchParams: Promise<{ week?: string; mode?: string }>;
+  searchParams: Promise<{ week?: string; mode?: string; template?: string }>;
 }) {
   const { orgId } = await params;
-  const { week: weekParam, mode: modeParam } = await searchParams;
+  const { week: weekParam, mode: modeParam, template: templateParam } = await searchParams;
 
   const authz = await requireOrgMember(orgId);
   if (!authz.ok) redirect("/");
@@ -47,52 +121,67 @@ export default async function TimetablePage({
   const to = new Date(from);
   to.setUTCDate(to.getUTCDate() + 7);
 
-  const [org, rawInstances] = await Promise.all([
+  const mode = modeParam === "simple" ? "simple" : "calendar";
+  const selectedTemplateId = templateParam ?? null;
+
+  const [org, templates, selectedTemplate, rawInstances] = await Promise.all([
     prisma.organization.findUnique({
       where: { id: orgId },
       select: { openTimeMin: true, closeTimeMin: true },
     }),
-    getTaskInstancesForTimetable(orgId, from, to),
+    getTimetableTemplates(orgId),
+    selectedTemplateId
+      ? getTimetableTemplate(orgId, selectedTemplateId)
+      : Promise.resolve(null),
+    // Only fetch live scheduled instances when no template is selected
+    selectedTemplateId
+      ? Promise.resolve([])
+      : getTaskInstancesForTimetable(orgId, from, to),
   ]);
 
-  const mode = modeParam === "simple" ? "simple" : "calendar";
+  let instances: ClientTimetableInstance[];
 
-  // Explicitly serialize all Date fields so the client component boundary
-  // receives plain strings instead of Prisma Date objects.
-  const instances: ClientTimetableInstance[] = rawInstances.map((inst) => ({
-    id: inst.id,
-    taskId: inst.taskId,
-    status: inst.status,
-    scheduledStartAt: inst.scheduledStartAt?.toISOString() ?? null,
-    scheduledEndAt: inst.scheduledEndAt?.toISOString() ?? null,
-    task: {
-      id: inst.task.id,
-      title: inst.task.title,
-      durationMin: inst.task.durationMin,
-      preferredStartTimeMin: inst.task.preferredStartTimeMin,
-    },
-    assignees: inst.assignees.map((a) => ({
-      id: a.id,
-      membership: {
-        id: a.membership.id,
-        user: {
-          id: a.membership.user.id,
-          name: a.membership.user.name,
-        },
+  if (selectedTemplate) {
+    // Project cycle template onto this week
+    instances = projectTemplateToWeek(selectedTemplate, weekStart);
+  } else if (selectedTemplateId) {
+    // Template param set but not found — show empty
+    instances = [];
+  } else {
+    // No template selected — show live scheduled instances
+    instances = rawInstances.map((inst) => ({
+      id: inst.id,
+      taskId: inst.taskId,
+      status: inst.status,
+      scheduledStartAt: inst.scheduledStartAt?.toISOString() ?? null,
+      scheduledEndAt: inst.scheduledEndAt?.toISOString() ?? null,
+      task: {
+        id: inst.task.id,
+        title: inst.task.title,
+        durationMin: inst.task.durationMin,
+        preferredStartTimeMin: inst.task.preferredStartTimeMin,
       },
-    })),
-  }));
+      assignees: inst.assignees.map((a) => ({
+        id: a.id,
+        membership: {
+          id: a.membership.id,
+          user: { id: a.membership.user.id, name: a.membership.user.name },
+        },
+      })),
+    }));
+  }
 
   const timetableHref = (m: string) =>
-    `/orgs/${orgId}/timetable?week=${weekStart}&mode=${m}`;
+    `/orgs/${orgId}/timetable?week=${weekStart}&mode=${m}${selectedTemplateId ? `&template=${selectedTemplateId}` : ""}`;
 
   return (
     <>
       <Toolbar actions={[{ label: "Templates", href: `/orgs/${orgId}/timetable/templates` }]}>
-        {/* Week-view type (placeholder) */}
-        <Button variant="outline" size="sm" className="gap-1.5" disabled>
-          Week <ChevronDown className="h-3.5 w-3.5" />
-        </Button>
+        {/* Template dropdown */}
+        <TemplateSelector
+          templates={templates.map((t) => ({ id: t.id, title: t.title }))}
+          selectedId={selectedTemplateId}
+        />
 
         {/* Filter (placeholder) */}
         <Button variant="outline" size="sm" className="gap-1.5" disabled>
@@ -132,6 +221,7 @@ export default async function TimetablePage({
         openTimeMin={org?.openTimeMin ?? 360}
         closeTimeMin={org?.closeTimeMin ?? 1320}
         mode={mode}
+        selectedTemplateId={selectedTemplateId}
       />
     </>
   );

--- a/app/(app)/orgs/[orgId]/timetable/template-selector.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/template-selector.tsx
@@ -12,7 +12,10 @@ interface TemplateSelectorProps {
   selectedId: string | null;
 }
 
-export function TemplateSelector({ templates, selectedId }: TemplateSelectorProps) {
+export function TemplateSelector({
+  templates,
+  selectedId,
+}: TemplateSelectorProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -46,10 +49,7 @@ export function TemplateSelector({ templates, selectedId }: TemplateSelectorProp
       {open && (
         <>
           {/* backdrop */}
-          <div
-            className="fixed inset-0 z-40"
-            onClick={() => setOpen(false)}
-          />
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
           <div className="absolute top-full left-0 mt-1 z-50 bg-background border rounded-lg shadow-lg min-w-44 py-1">
             <button
               onClick={() => select(null)}
@@ -60,9 +60,7 @@ export function TemplateSelector({ templates, selectedId }: TemplateSelectorProp
                 Custom (no template)
               </span>
             </button>
-            {templates.length > 0 && (
-              <div className="border-t my-1" />
-            )}
+            {templates.length > 0 && <div className="border-t my-1" />}
             {templates.map((t) => (
               <button
                 key={t.id}
@@ -74,7 +72,11 @@ export function TemplateSelector({ templates, selectedId }: TemplateSelectorProp
                 ) : (
                   <span className="w-3.5" />
                 )}
-                <span className={t.id === selectedId ? "font-medium text-primary" : ""}>
+                <span
+                  className={
+                    t.id === selectedId ? "font-medium text-primary" : ""
+                  }
+                >
                   {t.title}
                 </span>
               </button>

--- a/app/(app)/orgs/[orgId]/timetable/template-selector.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/template-selector.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { ChevronDown, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export type TemplateSelectorItem = { id: string; title: string };
+
+interface TemplateSelectorProps {
+  templates: TemplateSelectorItem[];
+  selectedId: string | null;
+}
+
+export function TemplateSelector({ templates, selectedId }: TemplateSelectorProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [open, setOpen] = useState(false);
+
+  const selected = templates.find((t) => t.id === selectedId);
+  const label = selected ? selected.title : "Custom";
+
+  function select(id: string | null) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (id) {
+      params.set("template", id);
+    } else {
+      params.delete("template");
+    }
+    setOpen(false);
+    router.push(`${pathname}?${params.toString()}`);
+  }
+
+  return (
+    <div className="relative">
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-1.5"
+        onClick={() => setOpen((o) => !o)}
+      >
+        {label} <ChevronDown className="h-3.5 w-3.5" />
+      </Button>
+
+      {open && (
+        <>
+          {/* backdrop */}
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setOpen(false)}
+          />
+          <div className="absolute top-full left-0 mt-1 z-50 bg-background border rounded-lg shadow-lg min-w-44 py-1">
+            <button
+              onClick={() => select(null)}
+              className="w-full text-left px-3 py-1.5 text-sm hover:bg-muted/50 flex items-center gap-2"
+            >
+              {!selectedId && <Check className="h-3.5 w-3.5 text-primary" />}
+              <span className={!selectedId ? "font-medium" : "ml-5"}>
+                Custom (no template)
+              </span>
+            </button>
+            {templates.length > 0 && (
+              <div className="border-t my-1" />
+            )}
+            {templates.map((t) => (
+              <button
+                key={t.id}
+                onClick={() => select(t.id)}
+                className="w-full text-left px-3 py-1.5 text-sm hover:bg-muted/50 flex items-center gap-2"
+              >
+                {t.id === selectedId ? (
+                  <Check className="h-3.5 w-3.5 text-primary" />
+                ) : (
+                  <span className="w-3.5" />
+                )}
+                <span className={t.id === selectedId ? "font-medium text-primary" : ""}>
+                  {t.title}
+                </span>
+              </button>
+            ))}
+            {templates.length === 0 && (
+              <div className="px-3 py-1.5 text-xs text-muted-foreground italic">
+                No templates yet
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/page.tsx
@@ -68,7 +68,10 @@ export default async function TemplateEditorPage({
   const availableTasks: ClientTask[] = rawTasks;
   const memberships: ClientMembership[] = rawMemberships;
 
-  const statusLabel = template.effectiveFrom ? "Active" : "Draft";
+  const now = new Date();
+  const isActive = !!template.effectiveFrom && template.effectiveFrom <= now;
+  const isScheduled = !!template.effectiveFrom && template.effectiveFrom > now;
+  const statusLabel = isActive ? "Active" : isScheduled ? "Scheduled" : "Draft";
 
   return (
     <>
@@ -86,9 +89,11 @@ export default async function TemplateEditorPage({
           </span>
           <span
             className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${
-              template.effectiveFrom
+              isActive
                 ? "bg-green-100 text-green-700"
-                : "bg-slate-100 text-slate-500"
+                : isScheduled
+                  ? "bg-amber-100 text-amber-700"
+                  : "bg-slate-100 text-slate-500"
             }`}
           >
             {statusLabel}

--- a/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/page.tsx
@@ -1,0 +1,111 @@
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import { requireOrgMember } from "@/lib/authz";
+import { getTimetableTemplate } from "@/lib/services/templates";
+import { prisma } from "@/lib/prisma";
+import { Toolbar } from "@/components/layout/toolbar";
+import {
+  TemplateEditorClient,
+  type ClientTemplateInstance,
+  type ClientTask,
+  type ClientMembership,
+} from "./template-editor-client";
+
+export default async function TemplateEditorPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; templateId: string }>;
+}) {
+  const { orgId, templateId } = await params;
+
+  const authz = await requireOrgMember(orgId);
+  if (!authz.ok) redirect("/");
+
+  const [template, org, rawTasks, rawMemberships] = await Promise.all([
+    getTimetableTemplate(orgId, templateId),
+    prisma.organization.findUnique({
+      where: { id: orgId },
+      select: { openTimeMin: true, closeTimeMin: true },
+    }),
+    prisma.task.findMany({
+      where: { orgId },
+      select: { id: true, title: true, durationMin: true },
+      orderBy: { title: "asc" },
+    }),
+    prisma.membership.findMany({
+      where: { orgId },
+      select: { id: true, user: { select: { id: true, name: true } } },
+      orderBy: { user: { name: "asc" } },
+    }),
+  ]);
+
+  if (!template) notFound();
+
+  const instances: ClientTemplateInstance[] = template.instances.map(
+    (inst) => ({
+      id: inst.id,
+      dayOffset: inst.dayOffset!,
+      startTimeMin: inst.startTimeMin!,
+      task: {
+        id: inst.task.id,
+        title: inst.task.title,
+        durationMin: inst.task.durationMin,
+      },
+      assignees: inst.assignees.map((a) => ({
+        id: a.id,
+        membership: {
+          id: a.membership.id,
+          user: {
+            id: a.membership.user.id,
+            name: a.membership.user.name,
+          },
+        },
+      })),
+    }),
+  );
+
+  const availableTasks: ClientTask[] = rawTasks;
+  const memberships: ClientMembership[] = rawMemberships;
+
+  const statusLabel = template.effectiveFrom ? "Active" : "Draft";
+
+  return (
+    <>
+      <Toolbar>
+        <Link
+          href={`/orgs/${orgId}/timetable/templates`}
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" /> Templates
+        </Link>
+        <div className="flex items-center gap-2 ml-2">
+          <span className="font-semibold text-sm">{template.title}</span>
+          <span className="text-xs text-muted-foreground">
+            · {template.templateDays} day cycle
+          </span>
+          <span
+            className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${
+              template.effectiveFrom
+                ? "bg-green-100 text-green-700"
+                : "bg-slate-100 text-slate-500"
+            }`}
+          >
+            {statusLabel}
+          </span>
+        </div>
+      </Toolbar>
+
+      <TemplateEditorClient
+        orgId={orgId}
+        templateId={templateId}
+        templateDays={template.templateDays}
+        instances={instances}
+        availableTasks={availableTasks}
+        memberships={memberships}
+        openTimeMin={org?.openTimeMin ?? 360}
+        closeTimeMin={org?.closeTimeMin ?? 1320}
+      />
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/template-editor-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/template-editor-client.tsx
@@ -30,7 +30,10 @@ export type ClientTemplateInstance = {
 };
 
 export type ClientTask = { id: string; title: string; durationMin: number };
-export type ClientMembership = { id: string; user: { id: string; name: string | null } };
+export type ClientMembership = {
+  id: string;
+  user: { id: string; name: string | null };
+};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -64,7 +67,9 @@ function calcDropTimeMin(
   offsetMin = 0,
 ): number {
   const rect = colEl.getBoundingClientRect();
-  return snapMin(((clientY - rect.top) / HOUR_HEIGHT) * 60 + startHour * 60 - offsetMin);
+  return snapMin(
+    ((clientY - rect.top) / HOUR_HEIGHT) * 60 + startHour * 60 - offsetMin,
+  );
 }
 
 type PositionedInstance = {
@@ -108,7 +113,14 @@ interface EditPopupProps {
   onClose: () => void;
 }
 
-function EditPopup({ instance, memberships, orgId, onSave, onRemove, onClose }: EditPopupProps) {
+function EditPopup({
+  instance,
+  memberships,
+  orgId,
+  onSave,
+  onRemove,
+  onClose,
+}: EditPopupProps) {
   const router = useRouter();
   const [startTime, setStartTime] = useState(minToHHMM(instance.startTimeMin));
   const [localAssignees, setLocalAssignees] = useState(instance.assignees);
@@ -119,10 +131,13 @@ function EditPopup({ instance, memberships, orgId, onSave, onRemove, onClose }: 
   const available = memberships.filter((m) => !assignedIds.has(m.id));
 
   useEffect(() => {
-    if (available.length > 0 && !available.find((m) => m.id === addMembershipId)) {
+    if (
+      available.length > 0 &&
+      !available.find((m) => m.id === addMembershipId)
+    ) {
       setAddMembershipId(available[0].id);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [localAssignees]);
 
   const endMin = hhmmToMin(startTime) + instance.task.durationMin;
@@ -131,9 +146,16 @@ function EditPopup({ instance, memberships, orgId, onSave, onRemove, onClose }: 
     const membership = memberships.find((m) => m.id === addMembershipId);
     if (!membership) return;
     startT(async () => {
-      const r = await addInstanceAssigneeAction(orgId, instance.id, addMembershipId);
+      const r = await addInstanceAssigneeAction(
+        orgId,
+        instance.id,
+        addMembershipId,
+      );
       if (r.ok) {
-        setLocalAssignees((p) => [...p, { id: `opt-${addMembershipId}`, membership }]);
+        setLocalAssignees((p) => [
+          ...p,
+          { id: `opt-${addMembershipId}`, membership },
+        ]);
         router.refresh();
       }
     });
@@ -141,9 +163,15 @@ function EditPopup({ instance, memberships, orgId, onSave, onRemove, onClose }: 
 
   function handleRemoveAssignee(membershipId: string) {
     startT(async () => {
-      const r = await removeInstanceAssigneeAction(orgId, instance.id, membershipId);
+      const r = await removeInstanceAssigneeAction(
+        orgId,
+        instance.id,
+        membershipId,
+      );
       if (r.ok) {
-        setLocalAssignees((p) => p.filter((a) => a.membership.id !== membershipId));
+        setLocalAssignees((p) =>
+          p.filter((a) => a.membership.id !== membershipId),
+        );
         router.refresh();
       }
     });
@@ -160,14 +188,19 @@ function EditPopup({ instance, memberships, orgId, onSave, onRemove, onClose }: 
       >
         <div className="flex items-start justify-between">
           <span className="font-semibold">{instance.task.title}</span>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground"
+          >
             <X className="h-4 w-4" />
           </button>
         </div>
 
         {/* Time */}
         <div className="flex flex-col gap-1">
-          <label className="text-xs text-muted-foreground font-medium">Start time</label>
+          <label className="text-xs text-muted-foreground font-medium">
+            Start time
+          </label>
           <Input
             type="time"
             value={startTime}
@@ -181,13 +214,20 @@ function EditPopup({ instance, memberships, orgId, onSave, onRemove, onClose }: 
 
         {/* Assignees */}
         <div className="flex flex-col gap-1.5">
-          <label className="text-xs text-muted-foreground font-medium">Assign</label>
+          <label className="text-xs text-muted-foreground font-medium">
+            Assign
+          </label>
           {localAssignees.length === 0 && (
-            <span className="text-xs text-muted-foreground italic">No one assigned</span>
+            <span className="text-xs text-muted-foreground italic">
+              No one assigned
+            </span>
           )}
           <div className="flex flex-col gap-1">
             {localAssignees.map((a) => (
-              <div key={a.membership.id} className="flex items-center justify-between rounded bg-muted/50 px-2 py-1 text-xs">
+              <div
+                key={a.membership.id}
+                className="flex items-center justify-between rounded bg-muted/50 px-2 py-1 text-xs"
+              >
                 <span>{a.membership.user.name ?? "Unknown"}</span>
                 <button
                   onClick={() => handleRemoveAssignee(a.membership.id)}
@@ -206,10 +246,17 @@ function EditPopup({ instance, memberships, orgId, onSave, onRemove, onClose }: 
                 className="flex-1 border rounded px-2 py-1 text-xs bg-background"
               >
                 {available.map((m) => (
-                  <option key={m.id} value={m.id}>{m.user.name ?? "Unknown"}</option>
+                  <option key={m.id} value={m.id}>
+                    {m.user.name ?? "Unknown"}
+                  </option>
                 ))}
               </select>
-              <Button size="sm" variant="outline" onClick={handleAddAssignee} className="h-7 w-7 p-0">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleAddAssignee}
+                className="h-7 w-7 p-0"
+              >
                 <Plus className="h-3.5 w-3.5" />
               </Button>
             </div>
@@ -218,9 +265,24 @@ function EditPopup({ instance, memberships, orgId, onSave, onRemove, onClose }: 
 
         {/* Footer */}
         <div className="flex gap-2 pt-1 border-t">
-          <Button size="sm" onClick={() => onSave(hhmmToMin(startTime))} className="flex-1 h-7">Save</Button>
-          <Button size="sm" variant="destructive" onClick={onRemove} className="h-7">Remove</Button>
-          <Button size="sm" variant="ghost" onClick={onClose} className="h-7">Cancel</Button>
+          <Button
+            size="sm"
+            onClick={() => onSave(hhmmToMin(startTime))}
+            className="flex-1 h-7"
+          >
+            Save
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={onRemove}
+            className="h-7"
+          >
+            Remove
+          </Button>
+          <Button size="sm" variant="ghost" onClick={onClose} className="h-7">
+            Cancel
+          </Button>
         </div>
       </div>
     </div>
@@ -260,12 +322,18 @@ export function TemplateEditorClient({
   const [page, setPage] = useState(0);
   const pageStart = page * DAYS_PER_PAGE;
   const pageEnd = Math.min(pageStart + DAYS_PER_PAGE, templateDays);
-  const visibleDays = Array.from({ length: pageEnd - pageStart }, (_, i) => pageStart + i + 1);
+  const visibleDays = Array.from(
+    { length: pageEnd - pageStart },
+    (_, i) => pageStart + i + 1,
+  );
 
   // Grid dimensions
   const startHour = Math.floor(openTimeMin / 60);
   const endHour = Math.ceil(closeTimeMin / 60);
-  const hours = Array.from({ length: endHour - startHour }, (_, i) => startHour + i);
+  const hours = Array.from(
+    { length: endHour - startHour },
+    (_, i) => startHour + i,
+  );
   const totalHeight = hours.length * HOUR_HEIGHT;
 
   // Task search
@@ -279,10 +347,14 @@ export function TemplateEditorClient({
     | { type: "task"; taskId: string }
     | { type: "move"; instanceId: string; offsetMin: number };
   const dragDataRef = useRef<DragData | null>(null);
-  const [dragOver, setDragOver] = useState<{ day: number; timeMin: number } | null>(null);
+  const [dragOver, setDragOver] = useState<{
+    day: number;
+    timeMin: number;
+  } | null>(null);
 
   // Edit popup
-  const [editingInstance, setEditingInstance] = useState<ClientTemplateInstance | null>(null);
+  const [editingInstance, setEditingInstance] =
+    useState<ClientTemplateInstance | null>(null);
 
   // Group by day
   const byDay = new Map<number, ClientTemplateInstance[]>();
@@ -308,11 +380,24 @@ export function TemplateEditorClient({
     });
   }
 
-  function handleColumnDragOver(e: React.DragEvent<HTMLDivElement>, day: number) {
+  function handleColumnDragOver(
+    e: React.DragEvent<HTMLDivElement>,
+    day: number,
+  ) {
     e.preventDefault();
-    e.dataTransfer.dropEffect = dragDataRef.current?.type === "move" ? "move" : "copy";
-    const offsetMin = dragDataRef.current?.type === "move" ? dragDataRef.current.offsetMin : 0;
-    setDragOver({ day, timeMin: calcDropTimeMin(e.clientY, e.currentTarget, startHour, offsetMin) });
+    e.dataTransfer.dropEffect =
+      dragDataRef.current?.type === "move" ? "move" : "copy";
+    const offsetMin =
+      dragDataRef.current?.type === "move" ? dragDataRef.current.offsetMin : 0;
+    setDragOver({
+      day,
+      timeMin: calcDropTimeMin(
+        e.clientY,
+        e.currentTarget,
+        startHour,
+        offsetMin,
+      ),
+    });
   }
 
   function handleColumnDrop(e: React.DragEvent<HTMLDivElement>, day: number) {
@@ -322,12 +407,26 @@ export function TemplateEditorClient({
     setDragOver(null);
     if (!data) return;
     const offsetMin = data.type === "move" ? data.offsetMin : 0;
-    const timeMin = calcDropTimeMin(e.clientY, e.currentTarget, startHour, offsetMin);
+    const timeMin = calcDropTimeMin(
+      e.clientY,
+      e.currentTarget,
+      startHour,
+      offsetMin,
+    );
     startT(async () => {
       if (data.type === "task") {
-        await addTemplateInstanceAction(orgId, templateId, data.taskId, day, timeMin);
+        await addTemplateInstanceAction(
+          orgId,
+          templateId,
+          data.taskId,
+          day,
+          timeMin,
+        );
       } else {
-        await updateTemplateInstanceAction(orgId, data.instanceId, { dayOffset: day, startTimeMin: timeMin });
+        await updateTemplateInstanceAction(orgId, data.instanceId, {
+          dayOffset: day,
+          startTimeMin: timeMin,
+        });
       }
       router.refresh();
     });
@@ -336,7 +435,9 @@ export function TemplateEditorClient({
   function handleEditSave(startTimeMin: number) {
     if (!editingInstance) return;
     startT(async () => {
-      await updateTemplateInstanceAction(orgId, editingInstance.id, { startTimeMin });
+      await updateTemplateInstanceAction(orgId, editingInstance.id, {
+        startTimeMin,
+      });
       setEditingInstance(null);
       router.refresh();
     });
@@ -358,13 +459,24 @@ export function TemplateEditorClient({
         <div className="flex-1 min-w-0 flex flex-col gap-3">
           {/* Cycle navigation */}
           <div className="flex items-center justify-between rounded-lg border px-4 py-1.5">
-            <Button variant="ghost" size="sm" onClick={() => setPage((p) => p - 1)} disabled={page === 0}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setPage((p) => p - 1)}
+              disabled={page === 0}
+            >
               ◀ Prev
             </Button>
             <span className="text-sm font-medium">
-              Cycle: {templateDays} Day{templateDays !== 1 ? "s" : ""}, Day {pageStart + 1}–{pageEnd}
+              Cycle: {templateDays} Day{templateDays !== 1 ? "s" : ""}, Day{" "}
+              {pageStart + 1}–{pageEnd}
             </span>
-            <Button variant="ghost" size="sm" onClick={() => setPage((p) => p + 1)} disabled={page >= totalPages - 1}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={page >= totalPages - 1}
+            >
               Next ▶
             </Button>
           </div>
@@ -375,20 +487,34 @@ export function TemplateEditorClient({
             <div className="flex border-b-2 border-purple-300 bg-purple-100">
               <div className="w-14 shrink-0 border-r border-purple-300" />
               {visibleDays.map((day) => (
-                <div key={day} className="flex-1 py-2 text-center border-r border-purple-300 last:border-r-0 text-slate-700">
-                  <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Day</div>
-                  <div className="text-base font-bold leading-none mt-0.5">{day}</div>
+                <div
+                  key={day}
+                  className="flex-1 py-2 text-center border-r border-purple-300 last:border-r-0 text-slate-700"
+                >
+                  <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">
+                    Day
+                  </div>
+                  <div className="text-base font-bold leading-none mt-0.5">
+                    {day}
+                  </div>
                 </div>
               ))}
             </div>
 
             {/* Time grid */}
-            <div className="overflow-y-auto bg-purple-50/40" style={{ maxHeight: 520 }}>
+            <div
+              className="overflow-y-auto bg-purple-50/40"
+              style={{ maxHeight: 520 }}
+            >
               <div className="flex" style={{ height: totalHeight }}>
                 {/* Hour gutter */}
                 <div className="w-14 shrink-0 border-r border-purple-200">
                   {hours.map((h) => (
-                    <div key={h} style={{ height: HOUR_HEIGHT }} className="flex items-start justify-end pr-2 pt-1 text-xs text-muted-foreground border-b border-purple-200/50 select-none">
+                    <div
+                      key={h}
+                      style={{ height: HOUR_HEIGHT }}
+                      className="flex items-start justify-end pr-2 pt-1 text-xs text-muted-foreground border-b border-purple-200/50 select-none"
+                    >
                       {`${h}:00`}
                     </div>
                   ))}
@@ -407,27 +533,46 @@ export function TemplateEditorClient({
                       style={{ height: totalHeight }}
                       onDragOver={(e) => handleColumnDragOver(e, day)}
                       onDragLeave={(e) => {
-                        if (!e.currentTarget.contains(e.relatedTarget as Node)) setDragOver(null);
+                        if (!e.currentTarget.contains(e.relatedTarget as Node))
+                          setDragOver(null);
                       }}
                       onDrop={(e) => handleColumnDrop(e, day)}
                     >
                       {/* Hour lines */}
                       {hours.map((h) => (
-                        <div key={h} className="absolute inset-x-0 border-b border-purple-200/50 pointer-events-none" style={{ top: (h - startHour) * HOUR_HEIGHT, height: HOUR_HEIGHT }} />
+                        <div
+                          key={h}
+                          className="absolute inset-x-0 border-b border-purple-200/50 pointer-events-none"
+                          style={{
+                            top: (h - startHour) * HOUR_HEIGHT,
+                            height: HOUR_HEIGHT,
+                          }}
+                        />
                       ))}
 
                       {/* Drop indicator */}
                       {isDragTarget && dragOver && (
                         <div
                           className="absolute inset-x-1 h-0.5 bg-purple-500 z-10 pointer-events-none rounded"
-                          style={{ top: ((dragOver.timeMin - startHour * 60) / 60) * HOUR_HEIGHT }}
+                          style={{
+                            top:
+                              ((dragOver.timeMin - startHour * 60) / 60) *
+                              HOUR_HEIGHT,
+                          }}
                         />
                       )}
 
                       {/* Task blocks */}
                       {positioned.map(({ instance: inst, col, totalCols }) => {
-                        const topPx = Math.max(((inst.startTimeMin - startHour * 60) / 60) * HOUR_HEIGHT, 0);
-                        const heightPx = Math.max((inst.task.durationMin / 60) * HOUR_HEIGHT, 20);
+                        const topPx = Math.max(
+                          ((inst.startTimeMin - startHour * 60) / 60) *
+                            HOUR_HEIGHT,
+                          0,
+                        );
+                        const heightPx = Math.max(
+                          (inst.task.durationMin / 60) * HOUR_HEIGHT,
+                          20,
+                        );
                         const widthPct = 100 / totalCols;
                         const leftPct = col * widthPct;
                         return (
@@ -435,16 +580,24 @@ export function TemplateEditorClient({
                             key={inst.id}
                             draggable
                             onDragStart={(e) => {
-                              const rect = e.currentTarget.getBoundingClientRect();
+                              const rect =
+                                e.currentTarget.getBoundingClientRect();
                               dragDataRef.current = {
                                 type: "move",
                                 instanceId: inst.id,
-                                offsetMin: ((e.clientY - rect.top) / HOUR_HEIGHT) * 60,
+                                offsetMin:
+                                  ((e.clientY - rect.top) / HOUR_HEIGHT) * 60,
                               };
                               e.dataTransfer.effectAllowed = "move";
                             }}
-                            onDragEnd={() => { dragDataRef.current = null; setDragOver(null); }}
-                            onDoubleClick={(e) => { e.stopPropagation(); setEditingInstance(inst); }}
+                            onDragEnd={() => {
+                              dragDataRef.current = null;
+                              setDragOver(null);
+                            }}
+                            onDoubleClick={(e) => {
+                              e.stopPropagation();
+                              setEditingInstance(inst);
+                            }}
                             className="absolute rounded border p-1 text-[11px] leading-snug cursor-grab active:cursor-grabbing bg-purple-300/80 text-purple-900 border-purple-400 hover:opacity-90 select-none overflow-hidden"
                             style={{
                               top: topPx + 1,
@@ -454,13 +607,22 @@ export function TemplateEditorClient({
                             }}
                             title="Drag to move · Double-click to edit"
                           >
-                            <div className="font-semibold truncate">{inst.task.title}</div>
+                            <div className="font-semibold truncate">
+                              {inst.task.title}
+                            </div>
                             {heightPx >= 32 && (
-                              <div className="opacity-70 text-[10px]">{minToHHMM(inst.startTimeMin)}</div>
+                              <div className="opacity-70 text-[10px]">
+                                {minToHHMM(inst.startTimeMin)}
+                              </div>
                             )}
                             {heightPx >= 48 && inst.assignees.length > 0 && (
                               <div className="opacity-70 text-[10px] truncate">
-                                {inst.assignees.map((a) => a.membership.user.name?.split(" ")[0]).join(", ")}
+                                {inst.assignees
+                                  .map(
+                                    (a) =>
+                                      a.membership.user.name?.split(" ")[0],
+                                  )
+                                  .join(", ")}
                               </div>
                             )}
                           </div>
@@ -478,18 +640,33 @@ export function TemplateEditorClient({
         <div className="w-56 shrink-0 flex flex-col gap-3">
           {/* Cycle controls */}
           <div className="rounded-xl border p-3 flex flex-col gap-2">
-            <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Cycle</div>
-            <Button variant="outline" size="sm" className="justify-start gap-2" onClick={handleAddDay}>
+            <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Cycle
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="justify-start gap-2"
+              onClick={handleAddDay}
+            >
               <Plus className="h-3.5 w-3.5" /> Add Day
             </Button>
-            <Button variant="outline" size="sm" className="justify-start gap-2" onClick={handleRemoveDay} disabled={templateDays <= 1}>
+            <Button
+              variant="outline"
+              size="sm"
+              className="justify-start gap-2"
+              onClick={handleRemoveDay}
+              disabled={templateDays <= 1}
+            >
               <Minus className="h-3.5 w-3.5" /> Remove Day
             </Button>
           </div>
 
           {/* Task list */}
           <div className="rounded-xl border flex flex-col overflow-hidden flex-1">
-            <div className="px-3 py-2.5 font-medium text-sm border-b">Search</div>
+            <div className="px-3 py-2.5 font-medium text-sm border-b">
+              Search
+            </div>
             <div className="px-2 py-2 border-b">
               <div className="relative">
                 <SearchIcon className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
@@ -503,7 +680,9 @@ export function TemplateEditorClient({
             </div>
             <div className="overflow-y-auto flex-1">
               {filteredTasks.length === 0 ? (
-                <div className="px-3 py-3 text-xs text-muted-foreground italic">No tasks found</div>
+                <div className="px-3 py-3 text-xs text-muted-foreground italic">
+                  No tasks found
+                </div>
               ) : (
                 filteredTasks.map((task) => (
                   <div
@@ -513,11 +692,16 @@ export function TemplateEditorClient({
                       dragDataRef.current = { type: "task", taskId: task.id };
                       e.dataTransfer.effectAllowed = "copy";
                     }}
-                    onDragEnd={() => { dragDataRef.current = null; setDragOver(null); }}
+                    onDragEnd={() => {
+                      dragDataRef.current = null;
+                      setDragOver(null);
+                    }}
                     className="px-3 py-2.5 border-b last:border-b-0 cursor-grab active:cursor-grabbing hover:bg-muted/30 transition-colors select-none"
                   >
                     <div className="text-sm font-medium">{task.title}</div>
-                    <div className="text-xs text-muted-foreground">{task.durationMin} min</div>
+                    <div className="text-xs text-muted-foreground">
+                      {task.durationMin} min
+                    </div>
                   </div>
                 ))
               )}

--- a/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/template-editor-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/template-editor-client.tsx
@@ -135,10 +135,9 @@ function EditPopup({
       available.length > 0 &&
       !available.find((m) => m.id === addMembershipId)
     ) {
-      setAddMembershipId(available[0].id);
+     (async () => setAddMembershipId(available[0].id))();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [localAssignees]);
+  }, [localAssignees, available, addMembershipId]);
 
   const endMin = hhmmToMin(startTime) + instance.task.durationMin;
 

--- a/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/template-editor-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/template-editor-client.tsx
@@ -51,9 +51,10 @@ function minToHHMM(min: number): string {
   return `${String(Math.floor(min / 60)).padStart(2, "0")}:${String(min % 60).padStart(2, "0")}`;
 }
 
-function hhmmToMin(hhmm: string): number {
-  const [h, m] = hhmm.split(":").map(Number);
-  return h * 60 + m;
+function hhmmToMin(hhmm: string): number | null {
+  const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(hhmm);
+  if (!match) return null;
+  return Number(match[1]) * 60 + Number(match[2]);
 }
 
 function snapMin(raw: number): number {
@@ -139,7 +140,9 @@ function EditPopup({
     }
   }, [localAssignees, available, addMembershipId]);
 
-  const endMin = hhmmToMin(startTime) + instance.task.durationMin;
+  const parsedStartTime = hhmmToMin(startTime);
+  const endMin =
+    parsedStartTime == null ? null : parsedStartTime + instance.task.durationMin;
 
   function handleAddAssignee() {
     const membership = memberships.find((m) => m.id === addMembershipId);
@@ -207,7 +210,7 @@ function EditPopup({
             className="h-8 w-32 text-sm"
           />
           <p className="text-xs text-muted-foreground">
-            {startTime} → {minToHHMM(endMin)} · {instance.task.durationMin} min
+            {startTime} → {endMin == null ? "--:--" : minToHHMM(endMin)} · {instance.task.durationMin} min
           </p>
         </div>
 
@@ -266,7 +269,8 @@ function EditPopup({
         <div className="flex gap-2 pt-1 border-t">
           <Button
             size="sm"
-            onClick={() => onSave(hhmmToMin(startTime))}
+            onClick={() => parsedStartTime != null && onSave(parsedStartTime)}
+            disabled={parsedStartTime == null}
             className="flex-1 h-7"
           >
             Save
@@ -413,20 +417,20 @@ export function TemplateEditorClient({
       offsetMin,
     );
     startT(async () => {
-      if (data.type === "task") {
-        await addTemplateInstanceAction(
-          orgId,
-          templateId,
-          data.taskId,
-          day,
-          timeMin,
-        );
-      } else {
-        await updateTemplateInstanceAction(orgId, data.instanceId, {
-          dayOffset: day,
-          startTimeMin: timeMin,
-        });
-      }
+      const result =
+        data.type === "task"
+          ? await addTemplateInstanceAction(
+              orgId,
+              templateId,
+              data.taskId,
+              day,
+              timeMin,
+            )
+          : await updateTemplateInstanceAction(orgId, data.instanceId, {
+              dayOffset: day,
+              startTimeMin: timeMin,
+            });
+      if (!result.ok) return;
       router.refresh();
     });
   }
@@ -434,9 +438,10 @@ export function TemplateEditorClient({
   function handleEditSave(startTimeMin: number) {
     if (!editingInstance) return;
     startT(async () => {
-      await updateTemplateInstanceAction(orgId, editingInstance.id, {
+      const result = await updateTemplateInstanceAction(orgId, editingInstance.id, {
         startTimeMin,
       });
+      if (!result.ok) return;
       setEditingInstance(null);
       router.refresh();
     });
@@ -445,7 +450,8 @@ export function TemplateEditorClient({
   function handleEditRemove() {
     if (!editingInstance) return;
     startT(async () => {
-      await removeTemplateInstanceAction(orgId, editingInstance.id);
+      const result = await removeTemplateInstanceAction(orgId, editingInstance.id);
+      if (!result.ok) return;
       setEditingInstance(null);
       router.refresh();
     });

--- a/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/template-editor-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/template-editor-client.tsx
@@ -136,13 +136,15 @@ function EditPopup({
       available.length > 0 &&
       !available.find((m) => m.id === addMembershipId)
     ) {
-     (async () => setAddMembershipId(available[0].id))();
+      (async () => setAddMembershipId(available[0].id))();
     }
   }, [localAssignees, available, addMembershipId]);
 
   const parsedStartTime = hhmmToMin(startTime);
   const endMin =
-    parsedStartTime == null ? null : parsedStartTime + instance.task.durationMin;
+    parsedStartTime == null
+      ? null
+      : parsedStartTime + instance.task.durationMin;
 
   function handleAddAssignee() {
     const membership = memberships.find((m) => m.id === addMembershipId);
@@ -210,7 +212,8 @@ function EditPopup({
             className="h-8 w-32 text-sm"
           />
           <p className="text-xs text-muted-foreground">
-            {startTime} → {endMin == null ? "--:--" : minToHHMM(endMin)} · {instance.task.durationMin} min
+            {startTime} → {endMin == null ? "--:--" : minToHHMM(endMin)} ·{" "}
+            {instance.task.durationMin} min
           </p>
         </div>
 
@@ -438,9 +441,13 @@ export function TemplateEditorClient({
   function handleEditSave(startTimeMin: number) {
     if (!editingInstance) return;
     startT(async () => {
-      const result = await updateTemplateInstanceAction(orgId, editingInstance.id, {
-        startTimeMin,
-      });
+      const result = await updateTemplateInstanceAction(
+        orgId,
+        editingInstance.id,
+        {
+          startTimeMin,
+        },
+      );
       if (!result.ok) return;
       setEditingInstance(null);
       router.refresh();
@@ -450,7 +457,10 @@ export function TemplateEditorClient({
   function handleEditRemove() {
     if (!editingInstance) return;
     startT(async () => {
-      const result = await removeTemplateInstanceAction(orgId, editingInstance.id);
+      const result = await removeTemplateInstanceAction(
+        orgId,
+        editingInstance.id,
+      );
       if (!result.ok) return;
       setEditingInstance(null);
       router.refresh();

--- a/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/template-editor-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/template-editor-client.tsx
@@ -1,0 +1,542 @@
+"use client";
+
+import { useState, useTransition, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Plus, Minus, X, Search as SearchIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  addTemplateInstanceAction,
+  removeTemplateInstanceAction,
+  updateTemplateInstanceAction,
+  updateTemplateDaysAction,
+  addInstanceAssigneeAction,
+  removeInstanceAssigneeAction,
+} from "@/app/actions/templates";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ClientTemplateInstance = {
+  id: string;
+  dayOffset: number;
+  startTimeMin: number;
+  task: { id: string; title: string; durationMin: number };
+  assignees: Array<{
+    id: string;
+    membership: { id: string; user: { id: string; name: string | null } };
+  }>;
+};
+
+export type ClientTask = { id: string; title: string; durationMin: number };
+export type ClientMembership = { id: string; user: { id: string; name: string | null } };
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const HOUR_HEIGHT = 64;
+const SNAP_MIN = 15;
+const DAYS_PER_PAGE = 7;
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function minToHHMM(min: number): string {
+  return `${String(Math.floor(min / 60)).padStart(2, "0")}:${String(min % 60).padStart(2, "0")}`;
+}
+
+function hhmmToMin(hhmm: string): number {
+  const [h, m] = hhmm.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function snapMin(raw: number): number {
+  return Math.max(0, Math.min(1439, Math.round(raw / SNAP_MIN) * SNAP_MIN));
+}
+
+function calcDropTimeMin(
+  clientY: number,
+  colEl: Element,
+  startHour: number,
+  offsetMin = 0,
+): number {
+  const rect = colEl.getBoundingClientRect();
+  return snapMin(((clientY - rect.top) / HOUR_HEIGHT) * 60 + startHour * 60 - offsetMin);
+}
+
+type PositionedInstance = {
+  instance: ClientTemplateInstance;
+  col: number;
+  totalCols: number;
+};
+
+function assignColumns(
+  instances: ClientTemplateInstance[],
+): PositionedInstance[] {
+  const sorted = [...instances].sort((a, b) => a.startTimeMin - b.startTimeMin);
+  const colEnds: number[] = [];
+
+  const positioned = sorted.map((inst) => {
+    const endMin = inst.startTimeMin + inst.task.durationMin;
+    let col = colEnds.findIndex((e) => e <= inst.startTimeMin);
+    if (col === -1) {
+      col = colEnds.length;
+      colEnds.push(endMin);
+    } else {
+      colEnds[col] = endMin;
+    }
+    return { instance: inst, col, totalCols: 0 };
+  });
+
+  const totalCols = Math.max(colEnds.length, 1);
+  return positioned.map((p) => ({ ...p, totalCols }));
+}
+
+// ---------------------------------------------------------------------------
+// EditPopup
+// ---------------------------------------------------------------------------
+
+interface EditPopupProps {
+  instance: ClientTemplateInstance;
+  memberships: ClientMembership[];
+  orgId: string;
+  onSave: (startTimeMin: number) => void;
+  onRemove: () => void;
+  onClose: () => void;
+}
+
+function EditPopup({ instance, memberships, orgId, onSave, onRemove, onClose }: EditPopupProps) {
+  const router = useRouter();
+  const [startTime, setStartTime] = useState(minToHHMM(instance.startTimeMin));
+  const [localAssignees, setLocalAssignees] = useState(instance.assignees);
+  const [addMembershipId, setAddMembershipId] = useState("");
+  const [, startT] = useTransition();
+
+  const assignedIds = new Set(localAssignees.map((a) => a.membership.id));
+  const available = memberships.filter((m) => !assignedIds.has(m.id));
+
+  useEffect(() => {
+    if (available.length > 0 && !available.find((m) => m.id === addMembershipId)) {
+      setAddMembershipId(available[0].id);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [localAssignees]);
+
+  const endMin = hhmmToMin(startTime) + instance.task.durationMin;
+
+  function handleAddAssignee() {
+    const membership = memberships.find((m) => m.id === addMembershipId);
+    if (!membership) return;
+    startT(async () => {
+      const r = await addInstanceAssigneeAction(orgId, instance.id, addMembershipId);
+      if (r.ok) {
+        setLocalAssignees((p) => [...p, { id: `opt-${addMembershipId}`, membership }]);
+        router.refresh();
+      }
+    });
+  }
+
+  function handleRemoveAssignee(membershipId: string) {
+    startT(async () => {
+      const r = await removeInstanceAssigneeAction(orgId, instance.id, membershipId);
+      if (r.ok) {
+        setLocalAssignees((p) => p.filter((a) => a.membership.id !== membershipId));
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onMouseDown={onClose}
+    >
+      <div
+        className="bg-background rounded-xl border shadow-2xl w-72 p-4 flex flex-col gap-3"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between">
+          <span className="font-semibold">{instance.task.title}</span>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Time */}
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-muted-foreground font-medium">Start time</label>
+          <Input
+            type="time"
+            value={startTime}
+            onChange={(e) => setStartTime(e.target.value)}
+            className="h-8 w-32 text-sm"
+          />
+          <p className="text-xs text-muted-foreground">
+            {startTime} → {minToHHMM(endMin)} · {instance.task.durationMin} min
+          </p>
+        </div>
+
+        {/* Assignees */}
+        <div className="flex flex-col gap-1.5">
+          <label className="text-xs text-muted-foreground font-medium">Assign</label>
+          {localAssignees.length === 0 && (
+            <span className="text-xs text-muted-foreground italic">No one assigned</span>
+          )}
+          <div className="flex flex-col gap-1">
+            {localAssignees.map((a) => (
+              <div key={a.membership.id} className="flex items-center justify-between rounded bg-muted/50 px-2 py-1 text-xs">
+                <span>{a.membership.user.name ?? "Unknown"}</span>
+                <button
+                  onClick={() => handleRemoveAssignee(a.membership.id)}
+                  className="text-muted-foreground hover:text-destructive ml-2"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </div>
+            ))}
+          </div>
+          {available.length > 0 && (
+            <div className="flex gap-1 items-center mt-0.5">
+              <select
+                value={addMembershipId}
+                onChange={(e) => setAddMembershipId(e.target.value)}
+                className="flex-1 border rounded px-2 py-1 text-xs bg-background"
+              >
+                {available.map((m) => (
+                  <option key={m.id} value={m.id}>{m.user.name ?? "Unknown"}</option>
+                ))}
+              </select>
+              <Button size="sm" variant="outline" onClick={handleAddAssignee} className="h-7 w-7 p-0">
+                <Plus className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex gap-2 pt-1 border-t">
+          <Button size="sm" onClick={() => onSave(hhmmToMin(startTime))} className="flex-1 h-7">Save</Button>
+          <Button size="sm" variant="destructive" onClick={onRemove} className="h-7">Remove</Button>
+          <Button size="sm" variant="ghost" onClick={onClose} className="h-7">Cancel</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+interface TemplateEditorClientProps {
+  orgId: string;
+  templateId: string;
+  templateDays: number;
+  instances: ClientTemplateInstance[];
+  availableTasks: ClientTask[];
+  memberships: ClientMembership[];
+  openTimeMin: number;
+  closeTimeMin: number;
+}
+
+export function TemplateEditorClient({
+  orgId,
+  templateId,
+  templateDays,
+  instances,
+  availableTasks,
+  memberships,
+  openTimeMin,
+  closeTimeMin,
+}: TemplateEditorClientProps) {
+  const router = useRouter();
+  const [, startT] = useTransition();
+
+  // Cycle page nav
+  const totalPages = Math.ceil(templateDays / DAYS_PER_PAGE);
+  const [page, setPage] = useState(0);
+  const pageStart = page * DAYS_PER_PAGE;
+  const pageEnd = Math.min(pageStart + DAYS_PER_PAGE, templateDays);
+  const visibleDays = Array.from({ length: pageEnd - pageStart }, (_, i) => pageStart + i + 1);
+
+  // Grid dimensions
+  const startHour = Math.floor(openTimeMin / 60);
+  const endHour = Math.ceil(closeTimeMin / 60);
+  const hours = Array.from({ length: endHour - startHour }, (_, i) => startHour + i);
+  const totalHeight = hours.length * HOUR_HEIGHT;
+
+  // Task search
+  const [search, setSearch] = useState("");
+  const filteredTasks = availableTasks.filter((t) =>
+    t.title.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  // Drag
+  type DragData =
+    | { type: "task"; taskId: string }
+    | { type: "move"; instanceId: string; offsetMin: number };
+  const dragDataRef = useRef<DragData | null>(null);
+  const [dragOver, setDragOver] = useState<{ day: number; timeMin: number } | null>(null);
+
+  // Edit popup
+  const [editingInstance, setEditingInstance] = useState<ClientTemplateInstance | null>(null);
+
+  // Group by day
+  const byDay = new Map<number, ClientTemplateInstance[]>();
+  for (const inst of instances) {
+    if (!byDay.has(inst.dayOffset)) byDay.set(inst.dayOffset, []);
+    byDay.get(inst.dayOffset)!.push(inst);
+  }
+
+  function handleAddDay() {
+    startT(async () => {
+      await updateTemplateDaysAction(orgId, templateId, templateDays + 1);
+      router.refresh();
+    });
+  }
+
+  function handleRemoveDay() {
+    if (templateDays <= 1) return;
+    startT(async () => {
+      await updateTemplateDaysAction(orgId, templateId, templateDays - 1);
+      const newPages = Math.ceil((templateDays - 1) / DAYS_PER_PAGE);
+      if (page >= newPages) setPage(Math.max(0, newPages - 1));
+      router.refresh();
+    });
+  }
+
+  function handleColumnDragOver(e: React.DragEvent<HTMLDivElement>, day: number) {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = dragDataRef.current?.type === "move" ? "move" : "copy";
+    const offsetMin = dragDataRef.current?.type === "move" ? dragDataRef.current.offsetMin : 0;
+    setDragOver({ day, timeMin: calcDropTimeMin(e.clientY, e.currentTarget, startHour, offsetMin) });
+  }
+
+  function handleColumnDrop(e: React.DragEvent<HTMLDivElement>, day: number) {
+    e.preventDefault();
+    const data = dragDataRef.current;
+    dragDataRef.current = null;
+    setDragOver(null);
+    if (!data) return;
+    const offsetMin = data.type === "move" ? data.offsetMin : 0;
+    const timeMin = calcDropTimeMin(e.clientY, e.currentTarget, startHour, offsetMin);
+    startT(async () => {
+      if (data.type === "task") {
+        await addTemplateInstanceAction(orgId, templateId, data.taskId, day, timeMin);
+      } else {
+        await updateTemplateInstanceAction(orgId, data.instanceId, { dayOffset: day, startTimeMin: timeMin });
+      }
+      router.refresh();
+    });
+  }
+
+  function handleEditSave(startTimeMin: number) {
+    if (!editingInstance) return;
+    startT(async () => {
+      await updateTemplateInstanceAction(orgId, editingInstance.id, { startTimeMin });
+      setEditingInstance(null);
+      router.refresh();
+    });
+  }
+
+  function handleEditRemove() {
+    if (!editingInstance) return;
+    startT(async () => {
+      await removeTemplateInstanceAction(orgId, editingInstance.id);
+      setEditingInstance(null);
+      router.refresh();
+    });
+  }
+
+  return (
+    <>
+      <div className="flex gap-4">
+        {/* ── Left: grid ── */}
+        <div className="flex-1 min-w-0 flex flex-col gap-3">
+          {/* Cycle navigation */}
+          <div className="flex items-center justify-between rounded-lg border px-4 py-1.5">
+            <Button variant="ghost" size="sm" onClick={() => setPage((p) => p - 1)} disabled={page === 0}>
+              ◀ Prev
+            </Button>
+            <span className="text-sm font-medium">
+              Cycle: {templateDays} Day{templateDays !== 1 ? "s" : ""}, Day {pageStart + 1}–{pageEnd}
+            </span>
+            <Button variant="ghost" size="sm" onClick={() => setPage((p) => p + 1)} disabled={page >= totalPages - 1}>
+              Next ▶
+            </Button>
+          </div>
+
+          {/* Grid */}
+          <div className="rounded-xl border-2 border-purple-400 overflow-hidden">
+            {/* Day headers */}
+            <div className="flex border-b-2 border-purple-300 bg-purple-100">
+              <div className="w-14 shrink-0 border-r border-purple-300" />
+              {visibleDays.map((day) => (
+                <div key={day} className="flex-1 py-2 text-center border-r border-purple-300 last:border-r-0 text-slate-700">
+                  <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Day</div>
+                  <div className="text-base font-bold leading-none mt-0.5">{day}</div>
+                </div>
+              ))}
+            </div>
+
+            {/* Time grid */}
+            <div className="overflow-y-auto bg-purple-50/40" style={{ maxHeight: 520 }}>
+              <div className="flex" style={{ height: totalHeight }}>
+                {/* Hour gutter */}
+                <div className="w-14 shrink-0 border-r border-purple-200">
+                  {hours.map((h) => (
+                    <div key={h} style={{ height: HOUR_HEIGHT }} className="flex items-start justify-end pr-2 pt-1 text-xs text-muted-foreground border-b border-purple-200/50 select-none">
+                      {`${h}:00`}
+                    </div>
+                  ))}
+                </div>
+
+                {/* Day columns */}
+                {visibleDays.map((day) => {
+                  const dayInsts = byDay.get(day) ?? [];
+                  const positioned = assignColumns(dayInsts);
+                  const isDragTarget = dragOver?.day === day;
+
+                  return (
+                    <div
+                      key={day}
+                      className={`flex-1 relative border-r border-purple-300 last:border-r-0 transition-colors ${isDragTarget ? "bg-purple-100/70" : ""}`}
+                      style={{ height: totalHeight }}
+                      onDragOver={(e) => handleColumnDragOver(e, day)}
+                      onDragLeave={(e) => {
+                        if (!e.currentTarget.contains(e.relatedTarget as Node)) setDragOver(null);
+                      }}
+                      onDrop={(e) => handleColumnDrop(e, day)}
+                    >
+                      {/* Hour lines */}
+                      {hours.map((h) => (
+                        <div key={h} className="absolute inset-x-0 border-b border-purple-200/50 pointer-events-none" style={{ top: (h - startHour) * HOUR_HEIGHT, height: HOUR_HEIGHT }} />
+                      ))}
+
+                      {/* Drop indicator */}
+                      {isDragTarget && dragOver && (
+                        <div
+                          className="absolute inset-x-1 h-0.5 bg-purple-500 z-10 pointer-events-none rounded"
+                          style={{ top: ((dragOver.timeMin - startHour * 60) / 60) * HOUR_HEIGHT }}
+                        />
+                      )}
+
+                      {/* Task blocks */}
+                      {positioned.map(({ instance: inst, col, totalCols }) => {
+                        const topPx = Math.max(((inst.startTimeMin - startHour * 60) / 60) * HOUR_HEIGHT, 0);
+                        const heightPx = Math.max((inst.task.durationMin / 60) * HOUR_HEIGHT, 20);
+                        const widthPct = 100 / totalCols;
+                        const leftPct = col * widthPct;
+                        return (
+                          <div
+                            key={inst.id}
+                            draggable
+                            onDragStart={(e) => {
+                              const rect = e.currentTarget.getBoundingClientRect();
+                              dragDataRef.current = {
+                                type: "move",
+                                instanceId: inst.id,
+                                offsetMin: ((e.clientY - rect.top) / HOUR_HEIGHT) * 60,
+                              };
+                              e.dataTransfer.effectAllowed = "move";
+                            }}
+                            onDragEnd={() => { dragDataRef.current = null; setDragOver(null); }}
+                            onDoubleClick={(e) => { e.stopPropagation(); setEditingInstance(inst); }}
+                            className="absolute rounded border p-1 text-[11px] leading-snug cursor-grab active:cursor-grabbing bg-purple-300/80 text-purple-900 border-purple-400 hover:opacity-90 select-none overflow-hidden"
+                            style={{
+                              top: topPx + 1,
+                              height: Math.max(heightPx - 2, 18),
+                              left: `${leftPct + 0.5}%`,
+                              width: `${widthPct - 1}%`,
+                            }}
+                            title="Drag to move · Double-click to edit"
+                          >
+                            <div className="font-semibold truncate">{inst.task.title}</div>
+                            {heightPx >= 32 && (
+                              <div className="opacity-70 text-[10px]">{minToHHMM(inst.startTimeMin)}</div>
+                            )}
+                            {heightPx >= 48 && inst.assignees.length > 0 && (
+                              <div className="opacity-70 text-[10px] truncate">
+                                {inst.assignees.map((a) => a.membership.user.name?.split(" ")[0]).join(", ")}
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Right panel ── */}
+        <div className="w-56 shrink-0 flex flex-col gap-3">
+          {/* Cycle controls */}
+          <div className="rounded-xl border p-3 flex flex-col gap-2">
+            <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Cycle</div>
+            <Button variant="outline" size="sm" className="justify-start gap-2" onClick={handleAddDay}>
+              <Plus className="h-3.5 w-3.5" /> Add Day
+            </Button>
+            <Button variant="outline" size="sm" className="justify-start gap-2" onClick={handleRemoveDay} disabled={templateDays <= 1}>
+              <Minus className="h-3.5 w-3.5" /> Remove Day
+            </Button>
+          </div>
+
+          {/* Task list */}
+          <div className="rounded-xl border flex flex-col overflow-hidden flex-1">
+            <div className="px-3 py-2.5 font-medium text-sm border-b">Search</div>
+            <div className="px-2 py-2 border-b">
+              <div className="relative">
+                <SearchIcon className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+                <Input
+                  placeholder="Search tasks…"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="pl-7 h-8 text-sm"
+                />
+              </div>
+            </div>
+            <div className="overflow-y-auto flex-1">
+              {filteredTasks.length === 0 ? (
+                <div className="px-3 py-3 text-xs text-muted-foreground italic">No tasks found</div>
+              ) : (
+                filteredTasks.map((task) => (
+                  <div
+                    key={task.id}
+                    draggable
+                    onDragStart={(e) => {
+                      dragDataRef.current = { type: "task", taskId: task.id };
+                      e.dataTransfer.effectAllowed = "copy";
+                    }}
+                    onDragEnd={() => { dragDataRef.current = null; setDragOver(null); }}
+                    className="px-3 py-2.5 border-b last:border-b-0 cursor-grab active:cursor-grabbing hover:bg-muted/30 transition-colors select-none"
+                  >
+                    <div className="text-sm font-medium">{task.title}</div>
+                    <div className="text-xs text-muted-foreground">{task.durationMin} min</div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Edit popup */}
+      {editingInstance && (
+        <EditPopup
+          instance={editingInstance}
+          memberships={memberships}
+          orgId={orgId}
+          onSave={handleEditSave}
+          onRemove={handleEditRemove}
+          onClose={() => setEditingInstance(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/timetable/templates/new/create-template-form.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/new/create-template-form.tsx
@@ -72,11 +72,15 @@ export function CreateTemplateForm({ orgId }: { orgId: string }) {
           id="templateDays"
           name="templateDays"
           type="number"
+          required
+          step={1}
           min={1}
           max={365}
           defaultValue={7}
           aria-invalid={!!err("templateDays")}
-          aria-describedby={err("templateDays") ? "templateDays-error" : undefined}
+          aria-describedby={
+            err("templateDays") ? "templateDays-error" : undefined
+          }
         />
         <p className="text-xs text-muted-foreground">
           How many days the cycle repeats over (e.g. 7 for a weekly roster).

--- a/app/(app)/orgs/[orgId]/timetable/templates/new/create-template-form.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/new/create-template-form.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useActionState, useEffect, useTransition } from "react";
+import { toast } from "sonner";
+import { createTemplateAction } from "@/app/actions/templates";
+import type { CreateTemplateFormState } from "@/app/actions/templates";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function CreateTemplateForm({ orgId }: { orgId: string }) {
+  const boundAction = createTemplateAction.bind(null, orgId);
+  const [state, dispatch, pending] = useActionState<
+    CreateTemplateFormState,
+    FormData
+  >(boundAction, null);
+  const [, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (state && !state.ok) {
+      const messages = Object.entries(state.errors)
+        .flatMap(([field, errs]) =>
+          field === "_" ? errs : errs.map((e) => `${field}: ${e}`),
+        )
+        .join("\n");
+      toast.error(messages || "Something went wrong");
+    }
+  }, [state]);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    startTransition(() => dispatch(formData));
+  };
+
+  const err = (field: string): string | null =>
+    state && !state.ok ? (state.errors[field]?.[0] ?? null) : null;
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+      {err("_") && (
+        <p role="alert" className="text-sm text-destructive">
+          {err("_")}
+        </p>
+      )}
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="title" className="text-sm font-medium">
+          Name <span className="text-destructive">*</span>
+        </label>
+        <Input
+          id="title"
+          name="title"
+          type="text"
+          required
+          placeholder="e.g. Week 1, Summer Roster"
+          autoFocus
+          aria-invalid={!!err("title")}
+          aria-describedby={err("title") ? "title-error" : undefined}
+        />
+        {err("title") && (
+          <p id="title-error" className="text-xs text-destructive">
+            {err("title")}
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="templateDays" className="text-sm font-medium">
+          Cycle length (days) <span className="text-destructive">*</span>
+        </label>
+        <Input
+          id="templateDays"
+          name="templateDays"
+          type="number"
+          min={1}
+          max={365}
+          defaultValue={7}
+          aria-invalid={!!err("templateDays")}
+          aria-describedby={err("templateDays") ? "templateDays-error" : undefined}
+        />
+        <p className="text-xs text-muted-foreground">
+          How many days the cycle repeats over (e.g. 7 for a weekly roster).
+        </p>
+        {err("templateDays") && (
+          <p id="templateDays-error" className="text-xs text-destructive">
+            {err("templateDays")}
+          </p>
+        )}
+      </div>
+
+      <Button type="submit" disabled={pending} className="self-start">
+        {pending ? "Creating…" : "Create & Edit Template"}
+      </Button>
+    </form>
+  );
+}

--- a/app/(app)/orgs/[orgId]/timetable/templates/new/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/new/page.tsx
@@ -1,0 +1,29 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import { requireOrgPermission } from "@/lib/authz";
+import { OrgPermission } from "@prisma/client";
+import { CreateTemplateForm } from "./create-template-form";
+
+export default async function NewTemplatePage({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) {
+  const { orgId } = await params;
+  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_CREATE);
+  if (!authz.ok) redirect("/");
+
+  return (
+    <div className="max-w-lg mx-auto">
+      <Link
+        href={`/orgs/${orgId}/timetable/templates`}
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ChevronLeft className="h-3.5 w-3.5" /> Templates
+      </Link>
+      <h1 className="text-xl font-semibold mb-6">New Template</h1>
+      <CreateTemplateForm orgId={orgId} />
+    </div>
+  );
+}

--- a/app/(app)/orgs/[orgId]/timetable/templates/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/page.tsx
@@ -53,15 +53,30 @@ export default async function TemplatesPage({
                   <span>·</span>
                   <span>{t._count.instances} slots</span>
                   <span>·</span>
-                  <span
-                    className={
-                      t.effectiveFrom
-                        ? "text-green-600 font-medium"
-                        : "text-slate-400"
-                    }
-                  >
-                    {t.effectiveFrom ? "Active" : "Draft"}
-                  </span>
+                  {(() => {
+                    const now = new Date();
+                    const isActive =
+                      !!t.effectiveFrom && t.effectiveFrom <= now;
+                    const isScheduled =
+                      !!t.effectiveFrom && t.effectiveFrom > now;
+                    return (
+                      <span
+                        className={
+                          isActive
+                            ? "text-green-600 font-medium"
+                            : isScheduled
+                              ? "text-amber-600 font-medium"
+                              : "text-slate-400"
+                        }
+                      >
+                        {isActive
+                          ? "Active"
+                          : isScheduled
+                            ? "Scheduled"
+                            : "Draft"}
+                      </span>
+                    );
+                  })()}
                 </div>
               </div>
             </Link>

--- a/app/(app)/orgs/[orgId]/timetable/templates/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/page.tsx
@@ -1,0 +1,73 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { CalendarDays, Plus } from "lucide-react";
+import { requireOrgMember } from "@/lib/authz";
+import { getTimetableTemplates } from "@/lib/services/templates";
+import { Toolbar } from "@/components/layout/toolbar";
+import { Button } from "@/components/ui/button";
+
+export default async function TemplatesPage({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) {
+  const { orgId } = await params;
+  const authz = await requireOrgMember(orgId);
+  if (!authz.ok) redirect("/");
+
+  const templates = await getTimetableTemplates(orgId);
+
+  return (
+    <>
+      <Toolbar>
+        <Link href={`/orgs/${orgId}/timetable/templates/new`}>
+          <Button size="sm" className="gap-1.5">
+            <Plus className="h-3.5 w-3.5" /> New Template
+          </Button>
+        </Link>
+      </Toolbar>
+
+      {templates.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 py-16 text-center text-muted-foreground">
+          <CalendarDays className="h-10 w-10 opacity-30" />
+          <p className="text-sm">
+            No templates yet. Create one to get started.
+          </p>
+          <Link href={`/orgs/${orgId}/timetable/templates/new`}>
+            <Button variant="outline" size="sm">
+              Create Template
+            </Button>
+          </Link>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {templates.map((t) => (
+            <Link
+              key={t.id}
+              href={`/orgs/${orgId}/timetable/templates/${t.id}`}
+            >
+              <div className="rounded-xl border p-4 hover:bg-muted/40 transition-colors cursor-pointer">
+                <div className="font-semibold text-sm">{t.title}</div>
+                <div className="text-xs text-muted-foreground mt-1 flex items-center gap-2">
+                  <span>{t.templateDays} days</span>
+                  <span>·</span>
+                  <span>{t._count.instances} slots</span>
+                  <span>·</span>
+                  <span
+                    className={
+                      t.effectiveFrom
+                        ? "text-green-600 font-medium"
+                        : "text-slate-400"
+                    }
+                  >
+                    {t.effectiveFrom ? "Active" : "Draft"}
+                  </span>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
@@ -38,8 +38,18 @@ const HOUR_HEIGHT = 64; // px per hour
 const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
 const MONTH_NAMES = [
-  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
 ];
 
 const STATUS_LABELS: Record<ClientTimetableInstance["status"], string> = {
@@ -89,30 +99,44 @@ function groupByDate(
 
 function statusBlockClass(status: ClientTimetableInstance["status"]): string {
   switch (status) {
-    case "TODO":        return "bg-slate-300/80 text-slate-800 border-slate-400";
-    case "IN_PROGRESS": return "bg-amber-300/80 text-amber-900 border-amber-400";
-    case "DONE":        return "bg-green-300/80 text-green-900 border-green-400";
-    case "SKIPPED":     return "bg-red-300/80 text-red-900 border-red-400";
+    case "TODO":
+      return "bg-slate-300/80 text-slate-800 border-slate-400";
+    case "IN_PROGRESS":
+      return "bg-amber-300/80 text-amber-900 border-amber-400";
+    case "DONE":
+      return "bg-green-300/80 text-green-900 border-green-400";
+    case "SKIPPED":
+      return "bg-red-300/80 text-red-900 border-red-400";
   }
 }
 
 function statusBadgeClass(status: string): string {
   switch (status) {
-    case "TODO":        return "bg-slate-200 text-slate-600";
-    case "IN_PROGRESS": return "bg-amber-100 text-amber-700";
-    case "DONE":        return "bg-green-100 text-green-700";
-    case "SKIPPED":     return "bg-red-100 text-red-700";
-    default:            return "bg-slate-100 text-slate-600";
+    case "TODO":
+      return "bg-slate-200 text-slate-600";
+    case "IN_PROGRESS":
+      return "bg-amber-100 text-amber-700";
+    case "DONE":
+      return "bg-green-100 text-green-700";
+    case "SKIPPED":
+      return "bg-red-100 text-red-700";
+    default:
+      return "bg-slate-100 text-slate-600";
   }
 }
 
 function statusDotClass(status: string): string {
   switch (status) {
-    case "TODO":        return "bg-slate-400";
-    case "IN_PROGRESS": return "bg-amber-500";
-    case "DONE":        return "bg-green-500";
-    case "SKIPPED":     return "bg-red-500";
-    default:            return "bg-slate-400";
+    case "TODO":
+      return "bg-slate-400";
+    case "IN_PROGRESS":
+      return "bg-amber-500";
+    case "DONE":
+      return "bg-green-500";
+    case "SKIPPED":
+      return "bg-red-500";
+    default:
+      return "bg-slate-400";
   }
 }
 
@@ -145,7 +169,9 @@ function assignColumns(
   const colEnds: number[] = [];
 
   const positioned = sorted.map((inst) => {
-    const start = inst.scheduledStartAt ? new Date(inst.scheduledStartAt) : null;
+    const start = inst.scheduledStartAt
+      ? new Date(inst.scheduledStartAt)
+      : null;
     const startMin = start
       ? start.getUTCHours() * 60 + start.getUTCMinutes()
       : openTimeMin;
@@ -185,7 +211,10 @@ function CalendarView({
 }: CalendarViewProps) {
   const startHour = Math.floor(openTimeMin / 60);
   const endHour = Math.ceil(closeTimeMin / 60);
-  const hours = Array.from({ length: endHour - startHour }, (_, i) => startHour + i);
+  const hours = Array.from(
+    { length: endHour - startHour },
+    (_, i) => startHour + i,
+  );
   const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
   const totalHeight = hours.length * HOUR_HEIGHT;
   const byDate = groupByDate(instances);
@@ -219,7 +248,10 @@ function CalendarView({
       </div>
 
       {/* Scrollable time grid */}
-      <div className="overflow-y-auto bg-purple-50/40" style={{ maxHeight: 520 }}>
+      <div
+        className="overflow-y-auto bg-purple-50/40"
+        style={{ maxHeight: 520 }}
+      >
         <div className="flex" style={{ height: totalHeight }}>
           {/* Hour-label gutter */}
           <div className="w-14 shrink-0 border-r border-purple-200">
@@ -253,7 +285,10 @@ function CalendarView({
                   <div
                     key={h}
                     className="absolute inset-x-0 border-b border-purple-200/50"
-                    style={{ top: (h - startHour) * HOUR_HEIGHT, height: HOUR_HEIGHT }}
+                    style={{
+                      top: (h - startHour) * HOUR_HEIGHT,
+                      height: HOUR_HEIGHT,
+                    }}
                   />
                 ))}
 
@@ -288,9 +323,13 @@ function CalendarView({
                       }}
                       title={`${inst.task.title} — ${inst.task.durationMin} min`}
                     >
-                      <div className="font-semibold truncate">{inst.task.title}</div>
+                      <div className="font-semibold truncate">
+                        {inst.task.title}
+                      </div>
                       {heightPx >= 36 && assigneeNames && (
-                        <div className="truncate opacity-80">{assigneeNames}</div>
+                        <div className="truncate opacity-80">
+                          {assigneeNames}
+                        </div>
                       )}
                       {heightPx >= 52 && (
                         <div className="opacity-60 text-[10px]">
@@ -357,10 +396,16 @@ function SimpleView({ instances, weekStart }: SimpleViewProps) {
                 <thead className="border-b bg-muted/20">
                   <tr className="text-xs text-muted-foreground uppercase tracking-wide">
                     <th className="px-3 py-1.5 text-left font-medium w-8">#</th>
-                    <th className="px-3 py-1.5 text-left font-medium">Status</th>
+                    <th className="px-3 py-1.5 text-left font-medium">
+                      Status
+                    </th>
                     <th className="px-3 py-1.5 text-left font-medium">Task</th>
-                    <th className="px-3 py-1.5 text-left font-medium">Duration</th>
-                    <th className="px-3 py-1.5 text-left font-medium">Assigned To</th>
+                    <th className="px-3 py-1.5 text-left font-medium">
+                      Duration
+                    </th>
+                    <th className="px-3 py-1.5 text-left font-medium">
+                      Assigned To
+                    </th>
                   </tr>
                 </thead>
                 <tbody className="divide-y">

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
@@ -11,6 +11,8 @@ import { Button } from "@/components/ui/button";
 export type ClientTimetableInstance = {
   id: string;
   taskId: string;
+  /** True for template-projected instances — id is synthetic, not a DB record. Do not use for mutations. */
+  isProjected?: boolean;
   status: "TODO" | "IN_PROGRESS" | "DONE" | "SKIPPED";
   scheduledStartAt: string | null;
   scheduledEndAt: string | null;

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
@@ -428,6 +428,7 @@ interface TimetableClientProps {
   openTimeMin: number;
   closeTimeMin: number;
   mode: "calendar" | "simple";
+  selectedTemplateId: string | null;
 }
 
 export function TimetableClient({
@@ -437,13 +438,16 @@ export function TimetableClient({
   openTimeMin,
   closeTimeMin,
   mode,
+  selectedTemplateId,
 }: TimetableClientProps) {
   const prevWeek = addDays(weekStart, -7);
   const nextWeek = addDays(weekStart, 7);
   const dateRangeLabel = formatDateRange(weekStart);
 
-  const makeHref = (w: string, m: string) =>
-    `/orgs/${orgId}/timetable?week=${w}&mode=${m}`;
+  const makeHref = (w: string, m: string) => {
+    const t = selectedTemplateId ? `&template=${selectedTemplateId}` : "";
+    return `/orgs/${orgId}/timetable?week=${w}&mode=${m}${t}`;
+  };
 
   return (
     <div className="flex flex-col gap-4">

--- a/app/actions/templates.ts
+++ b/app/actions/templates.ts
@@ -53,7 +53,10 @@ export async function addTemplateInstanceAction(
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
   const [task, template] = await Promise.all([
-    prisma.task.findFirst({ where: { id: taskId, orgId }, select: { id: true } }),
+    prisma.task.findFirst({
+      where: { id: taskId, orgId },
+      select: { id: true },
+    }),
     prisma.timetableTemplate.findFirst({
       where: { id: templateId, orgId },
       select: { id: true, templateDays: true },
@@ -88,7 +91,7 @@ export async function removeTemplateInstanceAction(
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
   const instance = await prisma.taskInstance.findFirst({
-    where: { id: instanceId, orgId },
+    where: { id: instanceId, orgId, templateId: { not: null } },
     select: { id: true },
   });
   if (!instance) return { ok: false, error: "Not found" };
@@ -103,20 +106,47 @@ export async function updateTemplateInstanceAction(
   instanceId: string,
   update: { dayOffset?: number; startTimeMin?: number },
 ): Promise<{ ok: boolean; error?: string }> {
-  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_CREATE);
+  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_UPDATE);
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
   const instance = await prisma.taskInstance.findFirst({
-    where: { id: instanceId, orgId },
-    select: { id: true },
+    where: { id: instanceId, orgId, templateId: { not: null } },
+    select: { id: true, templateId: true },
   });
   if (!instance) return { ok: false, error: "Not found" };
+
+  if (update.dayOffset !== undefined) {
+    const template = await prisma.timetableTemplate.findFirst({
+      where: { id: instance.templateId!, orgId },
+      select: { templateDays: true },
+    });
+    if (!template) return { ok: false, error: "Template not found" };
+    if (
+      !Number.isInteger(update.dayOffset) ||
+      update.dayOffset < 1 ||
+      update.dayOffset > template.templateDays
+    ) {
+      return {
+        ok: false,
+        error: `Day must be between 1 and ${template.templateDays}`,
+      };
+    }
+  }
+
+  if (
+    update.startTimeMin !== undefined &&
+    (update.startTimeMin < 0 || update.startTimeMin > 1439)
+  ) {
+    return { ok: false, error: "Invalid time" };
+  }
 
   await prisma.taskInstance.update({
     where: { id: instanceId },
     data: {
       ...(update.dayOffset !== undefined && { dayOffset: update.dayOffset }),
-      ...(update.startTimeMin !== undefined && { startTimeMin: update.startTimeMin }),
+      ...(update.startTimeMin !== undefined && {
+        startTimeMin: update.startTimeMin,
+      }),
     },
   });
 
@@ -129,11 +159,30 @@ export async function updateTemplateDaysAction(
   templateId: string,
   templateDays: number,
 ): Promise<{ ok: boolean; error?: string }> {
-  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_CREATE);
+  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_UPDATE);
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
-  if (!Number.isInteger(templateDays) || templateDays < 1 || templateDays > 365) {
+  if (
+    !Number.isInteger(templateDays) ||
+    templateDays < 1 ||
+    templateDays > 365
+  ) {
     return { ok: false, error: "Invalid cycle length" };
+  }
+
+  // Block shrink if any instances have a dayOffset that would be out of range
+  const stranded = await prisma.taskInstance.count({
+    where: {
+      templateId,
+      orgId,
+      dayOffset: { gt: templateDays },
+    },
+  });
+  if (stranded > 0) {
+    return {
+      ok: false,
+      error: `Cannot shrink cycle: ${stranded} task${stranded === 1 ? "" : "s"} are on days beyond ${templateDays}. Move or remove them first.`,
+    };
   }
 
   await prisma.timetableTemplate.updateMany({
@@ -154,14 +203,22 @@ export async function addInstanceAssigneeAction(
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
   const [instance, membership] = await Promise.all([
-    prisma.taskInstance.findFirst({ where: { id: instanceId, orgId }, select: { id: true } }),
-    prisma.membership.findFirst({ where: { id: membershipId, orgId }, select: { id: true } }),
+    prisma.taskInstance.findFirst({
+      where: { id: instanceId, orgId },
+      select: { id: true },
+    }),
+    prisma.membership.findFirst({
+      where: { id: membershipId, orgId },
+      select: { id: true },
+    }),
   ]);
   if (!instance) return { ok: false, error: "Instance not found" };
   if (!membership) return { ok: false, error: "Membership not found" };
 
   await prisma.taskInstanceAssignee.upsert({
-    where: { taskInstanceId_membershipId: { taskInstanceId: instanceId, membershipId } },
+    where: {
+      taskInstanceId_membershipId: { taskInstanceId: instanceId, membershipId },
+    },
     create: { taskInstanceId: instanceId, membershipId },
     update: {},
   });
@@ -179,7 +236,11 @@ export async function removeInstanceAssigneeAction(
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
   const assignee = await prisma.taskInstanceAssignee.findFirst({
-    where: { taskInstanceId: instanceId, membershipId, taskInstance: { orgId } },
+    where: {
+      taskInstanceId: instanceId,
+      membershipId,
+      taskInstance: { orgId },
+    },
     select: { id: true },
   });
   if (!assignee) return { ok: false, error: "Not found" };

--- a/app/actions/templates.ts
+++ b/app/actions/templates.ts
@@ -1,0 +1,190 @@
+"use server";
+
+import { OrgPermission } from "@prisma/client";
+import { requireOrgPermission } from "@/lib/authz";
+import { prisma } from "@/lib/prisma";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+export type CreateTemplateFormState =
+  | { ok: false; errors: Record<string, string[]> }
+  | { ok: true }
+  | null;
+
+export async function createTemplateAction(
+  orgId: string,
+  _prev: CreateTemplateFormState,
+  formData: FormData,
+): Promise<CreateTemplateFormState> {
+  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_CREATE);
+  if (!authz.ok) return { ok: false, errors: { _: ["Unauthorized"] } };
+
+  const title = String(formData.get("title") ?? "").trim();
+  const templateDaysRaw = Number(formData.get("templateDays") ?? 7);
+
+  if (!title) return { ok: false, errors: { title: ["Title is required"] } };
+  if (
+    !Number.isInteger(templateDaysRaw) ||
+    templateDaysRaw < 1 ||
+    templateDaysRaw > 365
+  ) {
+    return {
+      ok: false,
+      errors: { templateDays: ["Must be between 1 and 365"] },
+    };
+  }
+
+  const template = await prisma.timetableTemplate.create({
+    data: { orgId, title, templateDays: templateDaysRaw },
+  });
+
+  revalidatePath(`/orgs/${orgId}/timetable/templates`);
+  redirect(`/orgs/${orgId}/timetable/templates/${template.id}`);
+}
+
+export async function addTemplateInstanceAction(
+  orgId: string,
+  templateId: string,
+  taskId: string,
+  dayOffset: number,
+  startTimeMin: number,
+): Promise<{ ok: boolean; error?: string }> {
+  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_CREATE);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const [task, template] = await Promise.all([
+    prisma.task.findFirst({ where: { id: taskId, orgId }, select: { id: true } }),
+    prisma.timetableTemplate.findFirst({
+      where: { id: templateId, orgId },
+      select: { id: true, templateDays: true },
+    }),
+  ]);
+
+  if (!task) return { ok: false, error: "Task not found" };
+  if (!template) return { ok: false, error: "Template not found" };
+  if (dayOffset < 1 || dayOffset > template.templateDays) {
+    return {
+      ok: false,
+      error: `Day must be between 1 and ${template.templateDays}`,
+    };
+  }
+  if (startTimeMin < 0 || startTimeMin > 1439) {
+    return { ok: false, error: "Invalid time" };
+  }
+
+  await prisma.taskInstance.create({
+    data: { orgId, taskId, templateId, dayOffset, startTimeMin },
+  });
+
+  revalidatePath(`/orgs/${orgId}/timetable/templates/${templateId}`);
+  return { ok: true };
+}
+
+export async function removeTemplateInstanceAction(
+  orgId: string,
+  instanceId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_DELETE);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const instance = await prisma.taskInstance.findFirst({
+    where: { id: instanceId, orgId },
+    select: { id: true },
+  });
+  if (!instance) return { ok: false, error: "Not found" };
+
+  await prisma.taskInstance.delete({ where: { id: instanceId } });
+  revalidatePath(`/orgs/${orgId}/timetable/templates`);
+  return { ok: true };
+}
+
+export async function updateTemplateInstanceAction(
+  orgId: string,
+  instanceId: string,
+  update: { dayOffset?: number; startTimeMin?: number },
+): Promise<{ ok: boolean; error?: string }> {
+  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_CREATE);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const instance = await prisma.taskInstance.findFirst({
+    where: { id: instanceId, orgId },
+    select: { id: true },
+  });
+  if (!instance) return { ok: false, error: "Not found" };
+
+  await prisma.taskInstance.update({
+    where: { id: instanceId },
+    data: {
+      ...(update.dayOffset !== undefined && { dayOffset: update.dayOffset }),
+      ...(update.startTimeMin !== undefined && { startTimeMin: update.startTimeMin }),
+    },
+  });
+
+  revalidatePath(`/orgs/${orgId}/timetable/templates`);
+  return { ok: true };
+}
+
+export async function updateTemplateDaysAction(
+  orgId: string,
+  templateId: string,
+  templateDays: number,
+): Promise<{ ok: boolean; error?: string }> {
+  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_CREATE);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  if (!Number.isInteger(templateDays) || templateDays < 1 || templateDays > 365) {
+    return { ok: false, error: "Invalid cycle length" };
+  }
+
+  await prisma.timetableTemplate.updateMany({
+    where: { id: templateId, orgId },
+    data: { templateDays },
+  });
+
+  revalidatePath(`/orgs/${orgId}/timetable/templates/${templateId}`);
+  return { ok: true };
+}
+
+export async function addInstanceAssigneeAction(
+  orgId: string,
+  instanceId: string,
+  membershipId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_ASSIGN);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const [instance, membership] = await Promise.all([
+    prisma.taskInstance.findFirst({ where: { id: instanceId, orgId }, select: { id: true } }),
+    prisma.membership.findFirst({ where: { id: membershipId, orgId }, select: { id: true } }),
+  ]);
+  if (!instance) return { ok: false, error: "Instance not found" };
+  if (!membership) return { ok: false, error: "Membership not found" };
+
+  await prisma.taskInstanceAssignee.upsert({
+    where: { taskInstanceId_membershipId: { taskInstanceId: instanceId, membershipId } },
+    create: { taskInstanceId: instanceId, membershipId },
+    update: {},
+  });
+
+  revalidatePath(`/orgs/${orgId}/timetable/templates`);
+  return { ok: true };
+}
+
+export async function removeInstanceAssigneeAction(
+  orgId: string,
+  instanceId: string,
+  membershipId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const authz = await requireOrgPermission(orgId, OrgPermission.TASK_ASSIGN);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const assignee = await prisma.taskInstanceAssignee.findFirst({
+    where: { taskInstanceId: instanceId, membershipId, taskInstance: { orgId } },
+    select: { id: true },
+  });
+  if (!assignee) return { ok: false, error: "Not found" };
+
+  await prisma.taskInstanceAssignee.delete({ where: { id: assignee.id } });
+  revalidatePath(`/orgs/${orgId}/timetable/templates`);
+  return { ok: true };
+}

--- a/app/api/orgs/[orgId]/memberships/route.ts
+++ b/app/api/orgs/[orgId]/memberships/route.ts
@@ -12,6 +12,10 @@ import {
   deleteMembership,
   getMemberships,
 } from "@/lib/services/memberships";
+import { requireOrgPermission } from "@/lib/authz";
+import { OrgPermission } from "@prisma/client";
+import { deleteMembershipSchema } from "@/lib/validators/membership";
+import { createMembershipSchema } from "@/lib/validators/membership";
 
 export async function POST(
   req: Request,

--- a/app/api/orgs/[orgId]/memberships/route.ts
+++ b/app/api/orgs/[orgId]/memberships/route.ts
@@ -14,8 +14,7 @@ import {
 } from "@/lib/services/memberships";
 import { requireOrgPermission } from "@/lib/authz";
 import { OrgPermission } from "@prisma/client";
-import { deleteMembershipSchema } from "@/lib/validators/membership";
-import { createMembershipSchema } from "@/lib/validators/membership";
+import { deleteMembershipSchema, createMembershipSchema } from "@/lib/validators/membership";
 
 export async function POST(
   req: Request,

--- a/app/api/orgs/[orgId]/memberships/route.ts
+++ b/app/api/orgs/[orgId]/memberships/route.ts
@@ -14,7 +14,10 @@ import {
 } from "@/lib/services/memberships";
 import { requireOrgPermission } from "@/lib/authz";
 import { OrgPermission } from "@prisma/client";
-import { deleteMembershipSchema, createMembershipSchema } from "@/lib/validators/membership";
+import {
+  deleteMembershipSchema,
+  createMembershipSchema,
+} from "@/lib/validators/membership";
 
 export async function POST(
   req: Request,

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -10,7 +10,8 @@ import Google from "next-auth/providers/google";
  * For the full config with Prisma adapter and session callbacks, see auth.ts.
  */
 export const authConfig: NextAuthConfig = {
-  providers: [Google],
+  // Remove after testing - allows linking any Google account, even if the email matches an existing user in the DB
+  providers: [Google({ allowDangerousEmailAccountLinking: true })],
   pages: {
     signIn: "/signin",
   },

--- a/lib/services/templates.ts
+++ b/lib/services/templates.ts
@@ -19,6 +19,9 @@ export async function getTimetableTemplate(orgId: string, templateId: string) {
         include: {
           task: { select: { id: true, title: true, durationMin: true } },
           assignees: {
+            where: {
+              membership: { orgId },
+            },
             include: {
               membership: {
                 include: { user: { select: { id: true, name: true } } },

--- a/lib/services/templates.ts
+++ b/lib/services/templates.ts
@@ -1,0 +1,33 @@
+import { prisma } from "@/lib/prisma";
+
+export async function getTimetableTemplates(orgId: string) {
+  return prisma.timetableTemplate.findMany({
+    where: { orgId },
+    include: {
+      _count: { select: { instances: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+export async function getTimetableTemplate(orgId: string, templateId: string) {
+  return prisma.timetableTemplate.findFirst({
+    where: { id: templateId, orgId },
+    include: {
+      instances: {
+        where: { dayOffset: { not: null }, startTimeMin: { not: null } },
+        include: {
+          task: { select: { id: true, title: true, durationMin: true } },
+          assignees: {
+            include: {
+              membership: {
+                include: { user: { select: { id: true, name: true } } },
+              },
+            },
+          },
+        },
+        orderBy: [{ dayOffset: "asc" }, { startTimeMin: "asc" }],
+      },
+    },
+  });
+}

--- a/prisma/migrations/20260319000001_rename_taskcycle_to_timetable_template/migration.sql
+++ b/prisma/migrations/20260319000001_rename_taskcycle_to_timetable_template/migration.sql
@@ -19,6 +19,12 @@ ALTER TABLE "TaskInstance" RENAME COLUMN "cycleId" TO "templateId";
 -- Add template-relative position columns to TaskInstance
 ALTER TABLE "TaskInstance" ADD COLUMN "dayOffset" INTEGER;
 ALTER TABLE "TaskInstance" ADD COLUMN "startTimeMin" INTEGER;
+ALTER TABLE "TaskInstance"
+  ADD CONSTRAINT "TaskInstance_dayOffset_check"
+  CHECK ("dayOffset" IS NULL OR "dayOffset" >= 1);
+ALTER TABLE "TaskInstance"
+  ADD CONSTRAINT "TaskInstance_startTimeMin_check"
+  CHECK ("startTimeMin" IS NULL OR ("startTimeMin" >= 0 AND "startTimeMin" <= 1439));
 
 -- Add timezone to Organization
 ALTER TABLE "Organization" ADD COLUMN "timezone" TEXT NOT NULL DEFAULT 'Australia/Sydney';

--- a/prisma/migrations/20260319000001_rename_taskcycle_to_timetable_template/migration.sql
+++ b/prisma/migrations/20260319000001_rename_taskcycle_to_timetable_template/migration.sql
@@ -1,0 +1,35 @@
+-- Rename table: TaskCycle → TimetableTemplate
+ALTER TABLE "TaskCycle" RENAME TO "TimetableTemplate";
+
+-- Rename column on TimetableTemplate
+ALTER TABLE "TimetableTemplate" RENAME COLUMN "cycleDays" TO "templateDays";
+
+-- Add title column (default existing rows to 'Untitled')
+ALTER TABLE "TimetableTemplate" ADD COLUMN "title" TEXT NOT NULL DEFAULT 'Untitled';
+
+-- Add effectiveFrom column (nullable — null means draft)
+ALTER TABLE "TimetableTemplate" ADD COLUMN "effectiveFrom" TIMESTAMP(3);
+
+-- Set default for templateDays
+ALTER TABLE "TimetableTemplate" ALTER COLUMN "templateDays" SET DEFAULT 7;
+
+-- Rename column on TaskInstance
+ALTER TABLE "TaskInstance" RENAME COLUMN "cycleId" TO "templateId";
+
+-- Add template-relative position columns to TaskInstance
+ALTER TABLE "TaskInstance" ADD COLUMN "dayOffset" INTEGER;
+ALTER TABLE "TaskInstance" ADD COLUMN "startTimeMin" INTEGER;
+
+-- Add timezone to Organization
+ALTER TABLE "Organization" ADD COLUMN "timezone" TEXT NOT NULL DEFAULT 'Australia/Sydney';
+
+-- Rename primary key constraint
+ALTER TABLE "TimetableTemplate" RENAME CONSTRAINT "TaskCycle_pkey" TO "TimetableTemplate_pkey";
+
+-- Rename foreign key constraints
+ALTER TABLE "TimetableTemplate" RENAME CONSTRAINT "TaskCycle_orgId_fkey" TO "TimetableTemplate_orgId_fkey";
+ALTER TABLE "TaskInstance" RENAME CONSTRAINT "TaskInstance_cycleId_fkey" TO "TaskInstance_templateId_fkey";
+
+-- Rename indexes
+ALTER INDEX "TaskCycle_orgId_idx" RENAME TO "TimetableTemplate_orgId_idx";
+ALTER INDEX "TaskInstance_cycleId_idx" RENAME TO "TaskInstance_templateId_idx";

--- a/prisma/migrations/20260323020149_add_org_timezone/migration.sql
+++ b/prisma/migrations/20260323020149_add_org_timezone/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Made the column `templateDays` on table `TimetableTemplate` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "TimetableTemplate" ALTER COLUMN "templateDays" SET NOT NULL,
+ALTER COLUMN "title" DROP DEFAULT;

--- a/prisma/migrations/20260323020149_add_org_timezone/migration.sql
+++ b/prisma/migrations/20260323020149_add_org_timezone/migration.sql
@@ -5,5 +5,8 @@
 
 */
 -- AlterTable
+UPDATE "TimetableTemplate"
+SET "templateDays" = 7
+WHERE "templateDays" IS NULL;
 ALTER TABLE "TimetableTemplate" ALTER COLUMN "templateDays" SET NOT NULL,
 ALTER COLUMN "title" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,11 +37,12 @@ model Organization {
   ownerUserId  String  
   openTimeMin  Int?     // minutes from midnight (0-1439)
   closeTimeMin Int?
+  timezone     String   @default("Australia/Sydney")
 
   memberships  Membership[]
   roles        Role[]
   tasks        Task[]
-  cycles       TaskCycle[]
+  timetableTemplates TimetableTemplate[]
   taskInstances TaskInstance[]
   user       User   @relation(fields: [ownerUserId], references: [id])
 
@@ -218,11 +219,14 @@ model TaskEligibility {
   @@index([roleId])
 }
 
-model TaskCycle {
+model TimetableTemplate {
   id      String  @id @default(cuid())
   orgId   String
-  // planning horizon in days (weekly/monthly/custom). allow null if "system chooses"
-  cycleDays Int?
+  title   String
+  // planning horizon in days (weekly/monthly/custom)
+  templateDays Int  @default(7)
+  // when this template becomes active (null = draft)
+  effectiveFrom DateTime?
 
   // later: versioning fields like effectiveFrom/effectiveTo
   org     Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
@@ -239,11 +243,15 @@ model TaskInstance {
   id        String   @id @default(cuid())
   orgId     String
   taskId    String
-  cycleId   String?
+  templateId String?
 
   status    TaskInstanceStatus @default(TODO)
 
-  // scheduling for this instance
+  // Template-relative position (set when templateId is set)
+  dayOffset    Int?   // which day in the cycle (1..templateDays)
+  startTimeMin Int?   // local minutes from midnight (0..1439)
+
+  // Real scheduled times (set when applied to a live week)
   scheduledStartAt DateTime?
   scheduledEndAt   DateTime?
 
@@ -252,7 +260,7 @@ model TaskInstance {
 
   org       Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
   task      Task         @relation(fields: [taskId], references: [id], onDelete: Cascade)
-  cycle     TaskCycle?   @relation(fields: [cycleId], references: [id], onDelete: SetNull)
+  template  TimetableTemplate? @relation(fields: [templateId], references: [id], onDelete: SetNull)
 
   assignees TaskInstanceAssignee[]
 
@@ -261,7 +269,7 @@ model TaskInstance {
 
   @@index([orgId])
   @@index([taskId])
-  @@index([cycleId])
+  @@index([templateId])
   @@index([status])
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -36,10 +36,18 @@ async function main() {
   });
 
   const [worker1, worker2, worker3, worker4] = await Promise.all([
-    prisma.user.create({ data: { name: "Jordan", email: "alt28918@gmail.com" } }),
-    prisma.user.create({ data: { name: "Casey",  email: "alt28919@gmail.com" } }),
-    prisma.user.create({ data: { name: "Riley",  email: "alt28920@gmail.com" } }),
-    prisma.user.create({ data: { name: "Morgan", email: "alt28921@gmail.com" } }),
+    prisma.user.create({
+      data: { name: "Jordan", email: "alt28918@gmail.com" },
+    }),
+    prisma.user.create({
+      data: { name: "Casey", email: "alt28919@gmail.com" },
+    }),
+    prisma.user.create({
+      data: { name: "Riley", email: "alt28920@gmail.com" },
+    }),
+    prisma.user.create({
+      data: { name: "Morgan", email: "alt28921@gmail.com" },
+    }),
   ]);
 
   // Org
@@ -101,10 +109,18 @@ async function main() {
   });
 
   const [mem1, mem2, mem3, mem4] = await Promise.all([
-    prisma.membership.create({ data: { orgId: org.id, userId: worker1.id, roleId: workerRole.id } }),
-    prisma.membership.create({ data: { orgId: org.id, userId: worker2.id, roleId: workerRole.id } }),
-    prisma.membership.create({ data: { orgId: org.id, userId: worker3.id, roleId: workerRole.id } }),
-    prisma.membership.create({ data: { orgId: org.id, userId: worker4.id, roleId: workerRole.id } }),
+    prisma.membership.create({
+      data: { orgId: org.id, userId: worker1.id, roleId: workerRole.id },
+    }),
+    prisma.membership.create({
+      data: { orgId: org.id, userId: worker2.id, roleId: workerRole.id },
+    }),
+    prisma.membership.create({
+      data: { orgId: org.id, userId: worker3.id, roleId: workerRole.id },
+    }),
+    prisma.membership.create({
+      data: { orgId: org.id, userId: worker4.id, roleId: workerRole.id },
+    }),
   ]);
 
   // Tasks
@@ -209,21 +225,58 @@ async function main() {
   });
 
   // Live scheduled instances (this week, no template — shown on timetable calendar)
-  const monday = (() => {
-    const d = new Date();
-    const day = d.getDay(); // 0=Sun, 1=Mon
-    const diff = (day === 0 ? -6 : 1 - day);
-    d.setDate(d.getDate() + diff);
-    d.setHours(0, 0, 0, 0);
-    return d;
-  })();
+  // Build dates in the org timezone (Australia/Sydney) so seeded timestamps are
+  // consistent regardless of the machine running the seed.
+  const ORG_TZ = "Australia/Sydney";
 
-  const atTime = (dayIndex: number, hhmm: string) => {
-    const [h, m] = hhmm.split(":").map(Number);
-    const d = new Date(monday);
-    d.setDate(d.getDate() + dayIndex);
-    d.setHours(h, m, 0, 0);
-    return d;
+  const todayLocal = new Date().toLocaleDateString("en-CA", {
+    timeZone: ORG_TZ,
+  });
+  const [ty, tm, td] = todayLocal.split("-").map(Number);
+  const probeNoon = Date.UTC(ty, tm - 1, td, 12);
+  const localWd = new Intl.DateTimeFormat("en-US", {
+    timeZone: ORG_TZ,
+    weekday: "short",
+  }).format(new Date(probeNoon));
+  const DOW: Record<string, number> = {
+    Sun: -6,
+    Mon: 0,
+    Tue: -1,
+    Wed: -2,
+    Thu: -3,
+    Fri: -4,
+    Sat: -5,
+  };
+  const mondayLocal = new Date(Date.UTC(ty, tm - 1, td + (DOW[localWd] ?? 0)))
+    .toISOString()
+    .split("T")[0];
+
+  /** Returns a UTC Date representing `hhmm` local time on Monday + dayIndex in the org timezone. */
+  const atTime = (dayIndex: number, hhmm: string): Date => {
+    const [my, mm, md] = mondayLocal.split("-").map(Number);
+    const [h, min] = hhmm.split(":").map(Number);
+    const dateStr = new Date(Date.UTC(my, mm - 1, md + dayIndex))
+      .toISOString()
+      .split("T")[0];
+    // Find UTC offset for that date at noon to handle DST
+    const noon = Date.UTC(
+      ...(dateStr.split("-").map(Number) as [number, number, number]),
+      12,
+    );
+    const parts = Object.fromEntries(
+      new Intl.DateTimeFormat("en-US", {
+        timeZone: ORG_TZ,
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      })
+        .formatToParts(new Date(noon))
+        .map((p) => [p.type, p.value]),
+    );
+    const lH = parseInt(parts.hour ?? "0") % 24;
+    const lM = parseInt(parts.minute ?? "0");
+    const midnightUTC = noon - ((lH * 60 + lM) * 60 * 1000 - 12 * 3_600_000);
+    return new Date(midnightUTC + (h * 60 + min) * 60 * 1000);
   };
 
   const live1 = await prisma.taskInstance.create({
@@ -232,7 +285,7 @@ async function main() {
       taskId: tasks[0].id,
       status: TaskInstanceStatus.TODO,
       scheduledStartAt: atTime(0, "06:00"),
-      scheduledEndAt:   atTime(0, "06:30"),
+      scheduledEndAt: atTime(0, "06:30"),
       assignees: { create: [{ membershipId: mem1.id }] },
     },
   });
@@ -243,7 +296,7 @@ async function main() {
       taskId: tasks[1].id,
       status: TaskInstanceStatus.IN_PROGRESS,
       scheduledStartAt: atTime(2, "14:00"),
-      scheduledEndAt:   atTime(2, "14:45"),
+      scheduledEndAt: atTime(2, "14:45"),
       assignees: { create: [{ membershipId: mem3.id }] },
     },
   });
@@ -254,7 +307,7 @@ async function main() {
       taskId: tasks[2].id,
       status: TaskInstanceStatus.TODO,
       scheduledStartAt: atTime(4, "17:00"),
-      scheduledEndAt:   atTime(4, "17:40"),
+      scheduledEndAt: atTime(4, "17:40"),
       assignees: { create: [{ membershipId: mem4.id }] },
     },
   });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -21,7 +21,7 @@ async function main() {
   await prisma.taskEligibility.deleteMany();
   await prisma.rolePermission.deleteMany();
   await prisma.membership.deleteMany();
-  await prisma.taskCycle.deleteMany();
+  await prisma.timetableTemplate.deleteMany();
   await prisma.task.deleteMany();
   await prisma.role.deleteMany();
   await prisma.organization.deleteMany(); // must precede user (ownerUserId FK)
@@ -30,17 +30,17 @@ async function main() {
   // Users
   const ownerUser = await prisma.user.create({
     data: {
-      name: "Ivan Owner",
-      email: "owner@example.com",
+      name: "Ivan",
+      email: "mystoganx2001@gmail.com",
     },
   });
 
-  const workerUser = await prisma.user.create({
-    data: {
-      name: "Wendy Worker",
-      email: "worker@example.com",
-    },
-  });
+  const [worker1, worker2, worker3, worker4] = await Promise.all([
+    prisma.user.create({ data: { name: "Jordan", email: "alt28918@gmail.com" } }),
+    prisma.user.create({ data: { name: "Casey",  email: "alt28919@gmail.com" } }),
+    prisma.user.create({ data: { name: "Riley",  email: "alt28920@gmail.com" } }),
+    prisma.user.create({ data: { name: "Morgan", email: "alt28921@gmail.com" } }),
+  ]);
 
   // Org
   const org = await prisma.organization.create({
@@ -49,6 +49,7 @@ async function main() {
       ownerUserId: ownerUser.id,
       openTimeMin: timeToMin("06:00"),
       closeTimeMin: timeToMin("18:00"),
+      timezone: "Australia/Sydney",
     },
   });
 
@@ -96,20 +97,15 @@ async function main() {
 
   // Memberships
   const ownerMembership = await prisma.membership.create({
-    data: {
-      orgId: org.id,
-      userId: ownerUser.id,
-      roleId: ownerRole.id,
-    },
+    data: { orgId: org.id, userId: ownerUser.id, roleId: ownerRole.id },
   });
 
-  const workerMembership = await prisma.membership.create({
-    data: {
-      orgId: org.id,
-      userId: workerUser.id,
-      roleId: workerRole.id,
-    },
-  });
+  const [mem1, mem2, mem3, mem4] = await Promise.all([
+    prisma.membership.create({ data: { orgId: org.id, userId: worker1.id, roleId: workerRole.id } }),
+    prisma.membership.create({ data: { orgId: org.id, userId: worker2.id, roleId: workerRole.id } }),
+    prisma.membership.create({ data: { orgId: org.id, userId: worker3.id, roleId: workerRole.id } }),
+    prisma.membership.create({ data: { orgId: org.id, userId: worker4.id, roleId: workerRole.id } }),
+  ]);
 
   // Tasks
   const tasks = await Promise.all([
@@ -160,29 +156,26 @@ async function main() {
     skipDuplicates: true,
   });
 
-  // Cycle
-  const cycle = await prisma.taskCycle.create({
+  // Timetable template
+  const template = await prisma.timetableTemplate.create({
     data: {
       orgId: org.id,
-      cycleDays: 7,
+      title: "Week 1",
+      templateDays: 7,
     },
   });
 
-  // Instances (example)
-  const now = new Date();
-  const inOneHour = new Date(now.getTime() + 60 * 60 * 1000);
-  const inTwoHours = new Date(now.getTime() + 2 * 60 * 60 * 1000);
-
+  // Template instances — positions are cycle-relative (dayOffset + startTimeMin)
   const instance1 = await prisma.taskInstance.create({
     data: {
       orgId: org.id,
       taskId: tasks[0].id,
-      cycleId: cycle.id,
+      templateId: template.id,
       status: TaskInstanceStatus.TODO,
-      scheduledStartAt: inOneHour,
-      scheduledEndAt: inTwoHours,
+      dayOffset: 1,
+      startTimeMin: timeToMin("06:00"),
       assignees: {
-        create: [{ membershipId: workerMembership.id }],
+        create: [{ membershipId: mem1.id }, { membershipId: mem2.id }],
       },
     },
   });
@@ -191,10 +184,12 @@ async function main() {
     data: {
       orgId: org.id,
       taskId: tasks[1].id,
-      cycleId: cycle.id,
+      templateId: template.id,
       status: TaskInstanceStatus.TODO,
+      dayOffset: 3,
+      startTimeMin: timeToMin("14:00"),
       assignees: {
-        create: [{ membershipId: workerMembership.id }],
+        create: [{ membershipId: mem3.id }],
       },
     },
   });
@@ -203,15 +198,64 @@ async function main() {
     data: {
       orgId: org.id,
       taskId: tasks[2].id,
-      cycleId: cycle.id,
+      templateId: template.id,
       status: TaskInstanceStatus.TODO,
-      scheduledStartAt: new Date(now.getTime() + 11 * 60 * 60 * 1000), // ~5pm
-      scheduledEndAt: new Date(
-        now.getTime() + 11 * 60 * 60 * 1000 + 40 * 60 * 1000,
-      ),
+      dayOffset: 7,
+      startTimeMin: timeToMin("17:00"),
       assignees: {
-        create: [{ membershipId: workerMembership.id }],
+        create: [{ membershipId: mem4.id }],
       },
+    },
+  });
+
+  // Live scheduled instances (this week, no template — shown on timetable calendar)
+  const monday = (() => {
+    const d = new Date();
+    const day = d.getDay(); // 0=Sun, 1=Mon
+    const diff = (day === 0 ? -6 : 1 - day);
+    d.setDate(d.getDate() + diff);
+    d.setHours(0, 0, 0, 0);
+    return d;
+  })();
+
+  const atTime = (dayIndex: number, hhmm: string) => {
+    const [h, m] = hhmm.split(":").map(Number);
+    const d = new Date(monday);
+    d.setDate(d.getDate() + dayIndex);
+    d.setHours(h, m, 0, 0);
+    return d;
+  };
+
+  const live1 = await prisma.taskInstance.create({
+    data: {
+      orgId: org.id,
+      taskId: tasks[0].id,
+      status: TaskInstanceStatus.TODO,
+      scheduledStartAt: atTime(0, "06:00"),
+      scheduledEndAt:   atTime(0, "06:30"),
+      assignees: { create: [{ membershipId: mem1.id }] },
+    },
+  });
+
+  const live2 = await prisma.taskInstance.create({
+    data: {
+      orgId: org.id,
+      taskId: tasks[1].id,
+      status: TaskInstanceStatus.IN_PROGRESS,
+      scheduledStartAt: atTime(2, "14:00"),
+      scheduledEndAt:   atTime(2, "14:45"),
+      assignees: { create: [{ membershipId: mem3.id }] },
+    },
+  });
+
+  const live3 = await prisma.taskInstance.create({
+    data: {
+      orgId: org.id,
+      taskId: tasks[2].id,
+      status: TaskInstanceStatus.TODO,
+      scheduledStartAt: atTime(4, "17:00"),
+      scheduledEndAt:   atTime(4, "17:40"),
+      assignees: { create: [{ membershipId: mem4.id }] },
     },
   });
 
@@ -219,13 +263,14 @@ async function main() {
   console.log({
     orgId: org.id,
     ownerUserId: ownerUser.id,
-    workerUserId: workerUser.id,
+    workerUserIds: [worker1.id, worker2.id, worker3.id, worker4.id],
     ownerMembershipId: ownerMembership.id,
-    workerMembershipId: workerMembership.id,
+    workerMembershipIds: [mem1.id, mem2.id, mem3.id, mem4.id],
     roleIds: { ownerRoleId: ownerRole.id, workerRoleId: workerRole.id },
     taskIds: tasks.map((t) => t.id),
-    cycleId: cycle.id,
-    instanceIds: [instance1.id, instance2.id, instance3.id],
+    templateId: template.id,
+    templateInstanceIds: [instance1.id, instance2.id, instance3.id],
+    liveInstanceIds: [live1.id, live2.id, live3.id],
   });
 }
 


### PR DESCRIPTION
- Add TimetableTemplate model (renamed from TaskCycle) with templateDays, effectiveFrom, timezone; add dayOffset/startTimeMin to TaskInstance
- Add template CRUD: list, create form, drag-and-drop editor (reposition blocks, edit popup, assignee management, add/remove cycle days)
- Project template cycles onto the timetable week with correct alignment for any cycle length (< 7 repeats, > 7 spans multiple weeks)
- Add template selector dropdown; preserve ?template param across week nav
- Update seed with template instances and live scheduled instances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timetable templates: create, list, edit in a visual 7‑day cycle grid; select templates to project into weekly schedules and include template selection in timetable links.
  * Template editor: drag‑and‑drop scheduling with 15‑minute snapping, assignee management, pagination and day controls.
  * Template selector dropdown, template detail and new‑template pages, and template creation form with inline validation.

* **Bug Fixes**
  * Fixed timetable status label formatting to display IN_PROGRESS.

* **Documentation**
  * Updated model documentation entry and Pages table formatting.

* **Chores**
  * Seed data and organization timezone support updated; auth configuration adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->