### PR TITLE
feat(franchisee): inherit tasks, templates & settings on join; fix mo…

### DIFF
--- a/app/(app)/orgs/[orgId]/franchisee/franchisee-client.tsx
+++ b/app/(app)/orgs/[orgId]/franchisee/franchisee-client.tsx
@@ -395,7 +395,7 @@ export function FranchiseeClient({
                         {t.token}
                       </td>
                       <td className="px-4 py-2 text-muted-foreground">
-                        {new Date(f.createdAt).toLocaleDateString("en-AU", { timeZone: "UTC" })}
+                        {new Date(t.expiresAt).toLocaleDateString("en-AU", { timeZone: "UTC" })}
                       </td>
                       <td className="px-4 py-2">
                         {used ? (

--- a/app/(app)/orgs/[orgId]/franchisee/franchisee-client.tsx
+++ b/app/(app)/orgs/[orgId]/franchisee/franchisee-client.tsx
@@ -1,0 +1,413 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { createPortal } from "react-dom";
+import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  generateFranchiseToken,
+  deleteFranchiseToken,
+  extendFranchiseToken,
+  removeFranchisee,
+  changeFranchiseeOwner,
+} from "@/app/actions/franchisee";
+
+// ─── Types (mirroring server page shape) ─────────────────────────────────────
+
+type Franchisee = {
+  id: string;
+  name: string;
+  address: string | null;
+  createdAt: Date;
+  owner: { id: string; name: string | null; email: string | null };
+};
+
+type Token = {
+  id: string;
+  token: string;
+  invitedEmail: string;
+  expiresAt: Date;
+  usedAt: Date | null;
+  usedByOrgId: string | null;
+};
+
+// ─── Modal portal ───────────────────────────────────────────────────────────
+
+function Modal({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div onClick={(e) => e.stopPropagation()}>{children}</div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─── Popup components ─────────────────────────────────────────────────────────
+
+function ConfirmPopup({
+  message,
+  onConfirm,
+  onCancel,
+  loading,
+}: {
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  loading: boolean;
+}) {
+  return (
+    <div className="absolute right-0 top-8 z-50 w-72 rounded-md border bg-popover p-4 shadow-md">
+      <p className="text-sm mb-3">{message}</p>
+      <div className="flex gap-2 justify-end">
+        <Button size="sm" variant="outline" onClick={onCancel} disabled={loading}>
+          Cancel
+        </Button>
+        <Button size="sm" variant="destructive" onClick={onConfirm} disabled={loading}>
+          {loading ? "..." : "Confirm"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function FranchiseeActions({
+  orgId,
+  franchisee,
+}: {
+  orgId: string;
+  franchisee: Franchisee;
+}) {
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<"menu" | "delete" | "changeOwner">("menu");
+  const [newOwnerEmail, setNewOwnerEmail] = useState("");
+  const [error, setError] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const reset = () => { setOpen(false); setMode("menu"); setNewOwnerEmail(""); setError(""); };
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      const res = await removeFranchisee(orgId, franchisee.id);
+      if (res.ok) reset();
+      else setError(res.error);
+    });
+  };
+
+  const handleChangeOwner = () => {
+    startTransition(async () => {
+      const res = await changeFranchiseeOwner(orgId, franchisee.id, newOwnerEmail);
+      if (res.ok) reset();
+      else setError(res.error);
+    });
+  };
+
+  return (
+    <div className="relative">
+      <Button
+        size="icon"
+        variant="ghost"
+        className="h-7 w-7"
+        onClick={() => { setOpen((v) => !v); setMode("menu"); setError(""); }}
+      >
+        <MoreHorizontal className="h-4 w-4" />
+      </Button>
+
+      {open && (
+        <Modal onClose={reset}>
+          <div className="w-80 rounded-md border bg-popover shadow-lg">
+            {mode === "menu" && (
+              <>
+                <button
+                  className="w-full text-left px-4 py-3 text-sm hover:bg-accent"
+                  onClick={() => setMode("changeOwner")}
+                >
+                  Change Owner
+                </button>
+                <button
+                  className="w-full text-left px-4 py-3 text-sm hover:bg-accent"
+                  onClick={reset}
+                >
+                  View
+                </button>
+                <button
+                  className="w-full text-left px-4 py-3 text-sm text-destructive hover:bg-accent"
+                  onClick={() => setMode("delete")}
+                >
+                  Delete
+                </button>
+              </>
+            )}
+
+            {mode === "delete" && (
+              <div className="p-4">
+                <p className="text-sm mb-3">
+                  Are you sure you want to remove{" "}
+                  <span className="font-medium">{franchisee.name}</span> from org?
+                </p>
+                {error && <p className="text-xs text-destructive mb-2">{error}</p>}
+                <div className="flex gap-2 justify-end">
+                  <Button size="sm" variant="outline" onClick={reset} disabled={isPending}>
+                    Cancel
+                  </Button>
+                  <Button size="sm" variant="destructive" onClick={handleDelete} disabled={isPending}>
+                    {isPending ? "..." : "Confirm"}
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {mode === "changeOwner" && (
+              <div className="p-4">
+                <p className="text-sm font-medium mb-3">Change Owner</p>
+                <Input
+                  placeholder="New owner email"
+                  value={newOwnerEmail}
+                  onChange={(e) => setNewOwnerEmail(e.target.value)}
+                  className="mb-2 h-8 text-sm"
+                />
+                {error && <p className="text-xs text-destructive mb-2">{error}</p>}
+                <div className="flex gap-2 justify-end mt-3">
+                  <Button size="sm" variant="outline" onClick={reset} disabled={isPending}>
+                    Cancel
+                  </Button>
+                  <Button size="sm" onClick={handleChangeOwner} disabled={isPending || !newOwnerEmail.trim()}>
+                    {isPending ? "..." : "Confirm"}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+function TokenActions({
+  orgId,
+  token,
+}: {
+  orgId: string;
+  token: Token;
+}) {
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<"menu" | "delete">("menu");
+  const [error, setError] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const reset = () => { setOpen(false); setMode("menu"); setError(""); };
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      const res = await deleteFranchiseToken(orgId, token.id);
+      if (res.ok) reset();
+      else setError(res.error);
+    });
+  };
+
+  const handleExtend = () => {
+    startTransition(async () => {
+      const res = await extendFranchiseToken(orgId, token.id);
+      if (res.ok) reset();
+      else setError(res.error);
+    });
+  };
+
+  return (
+    <div className="relative">
+      <Button
+        size="icon"
+        variant="ghost"
+        className="h-7 w-7"
+        onClick={() => { setOpen((v) => !v); setMode("menu"); setError(""); }}
+      >
+        <MoreHorizontal className="h-4 w-4" />
+      </Button>
+
+      {open && (
+        <Modal onClose={reset}>
+          <div className="w-72 rounded-md border bg-popover shadow-lg">
+            {mode === "menu" && (
+              <>
+                <button
+                  className="w-full text-left px-4 py-3 text-sm text-destructive hover:bg-accent"
+                  onClick={() => setMode("delete")}
+                >
+                  Delete
+                </button>
+                <button
+                  className="w-full text-left px-4 py-3 text-sm hover:bg-accent"
+                  onClick={handleExtend}
+                  disabled={isPending}
+                >
+                  {isPending ? "..." : "Extend (+1 day)"}
+                </button>
+            </>
+          )}
+
+            {mode === "delete" && (
+              <div className="p-4">
+                <p className="text-sm mb-3">Delete this token?</p>
+                {error && <p className="text-xs text-destructive mb-2">{error}</p>}
+                <div className="flex gap-2 justify-end">
+                  <Button size="sm" variant="outline" onClick={reset} disabled={isPending}>
+                    Cancel
+                  </Button>
+                  <Button size="sm" variant="destructive" onClick={handleDelete} disabled={isPending}>
+                    {isPending ? "..." : "Confirm"}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+// ─── Main client component ─────────────────────────────────────────────────────
+
+export function FranchiseeClient({
+  orgId,
+  franchisees,
+  tokens,
+}: {
+  orgId: string;
+  franchisees: Franchisee[];
+  tokens: Token[];
+}) {
+  const [email, setEmail] = useState("");
+  const [tokenError, setTokenError] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const handleGenerateToken = () => {
+    setTokenError("");
+    startTransition(async () => {
+      const res = await generateFranchiseToken(orgId, email);
+      if (res.ok) setEmail("");
+      else setTokenError(res.error);
+    });
+  };
+
+  return (
+    <div className="space-y-8">
+      {/* ── Franchisee List ─────────────────────────────────────────────── */}
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Franchisee List</h2>
+        <div className="rounded-md border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-muted-foreground">
+              <tr>
+                <th className="text-left px-4 py-2 font-medium">Name</th>
+                <th className="text-left px-4 py-2 font-medium">Location</th>
+                <th className="text-left px-4 py-2 font-medium">Owner</th>
+                <th className="text-left px-4 py-2 font-medium">Created</th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {franchisees.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-6 text-center text-muted-foreground">
+                    No franchisees yet. Generate an invite token below to add one.
+                  </td>
+                </tr>
+              ) : (
+                franchisees.map((f) => (
+                  <tr key={f.id} className="border-t hover:bg-muted/30">
+                    <td className="px-4 py-2 font-medium">{f.name}</td>
+                    <td className="px-4 py-2 text-muted-foreground">{f.address ?? "—"}</td>
+                    <td className="px-4 py-2">{f.owner.name ?? f.owner.email ?? "—"}</td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {new Date(f.createdAt).toLocaleDateString("en-AU")}
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <FranchiseeActions orgId={orgId} franchisee={f} />
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* ── Invite Tokens ───────────────────────────────────────────────── */}
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Invite Tokens</h2>
+
+        {/* Generate form */}
+        <div className="flex gap-2 mb-4">
+          <Input
+            placeholder="Email to invite"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="max-w-xs"
+            onKeyDown={(e) => e.key === "Enter" && handleGenerateToken()}
+          />
+          <Button onClick={handleGenerateToken} disabled={isPending || !email.trim()}>
+            {isPending ? "Generating..." : "Generate Token"}
+          </Button>
+        </div>
+        {tokenError && <p className="text-sm text-destructive mb-3">{tokenError}</p>}
+
+        {/* Token list */}
+        <div className="rounded-md border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-muted-foreground">
+              <tr>
+                <th className="text-left px-4 py-2 font-medium">Email</th>
+                <th className="text-left px-4 py-2 font-medium">Token</th>
+                <th className="text-left px-4 py-2 font-medium">Expires</th>
+                <th className="text-left px-4 py-2 font-medium">Status</th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {tokens.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-6 text-center text-muted-foreground">
+                    No tokens generated yet.
+                  </td>
+                </tr>
+              ) : (
+                tokens.map((t) => {
+                  const expired = new Date(t.expiresAt) < new Date();
+                  const used = !!t.usedAt;
+                  return (
+                    <tr key={t.id} className="border-t hover:bg-muted/30">
+                      <td className="px-4 py-2">{t.invitedEmail}</td>
+                      <td className="px-4 py-2 font-mono text-xs text-muted-foreground truncate max-w-[180px]">
+                        {t.token}
+                      </td>
+                      <td className="px-4 py-2 text-muted-foreground">
+                        {new Date(t.expiresAt).toLocaleDateString("en-AU")}
+                      </td>
+                      <td className="px-4 py-2">
+                        {used ? (
+                          <span className="text-xs text-muted-foreground">Used</span>
+                        ) : expired ? (
+                          <span className="text-xs text-destructive">Expired</span>
+                        ) : (
+                          <span className="text-xs text-green-600">Active</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-2 text-right">
+                        {!used && <TokenActions orgId={orgId} token={t} />}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/(app)/orgs/[orgId]/franchisee/franchisee-client.tsx
+++ b/app/(app)/orgs/[orgId]/franchisee/franchisee-client.tsx
@@ -111,6 +111,7 @@ function FranchiseeActions({
         size="icon"
         variant="ghost"
         className="h-7 w-7"
+        aria-label={`Open actions for ${franchisee.name}`}
         onClick={() => { setOpen((v) => !v); setMode("menu"); setError(""); }}
       >
         <MoreHorizontal className="h-4 w-4" />
@@ -223,6 +224,7 @@ function TokenActions({
         size="icon"
         variant="ghost"
         className="h-7 w-7"
+        aria-label={`Open token actions for ${token.invitedEmail}`}
         onClick={() => { setOpen((v) => !v); setMode("menu"); setError(""); }}
       >
         <MoreHorizontal className="h-4 w-4" />
@@ -285,13 +287,15 @@ export function FranchiseeClient({
   const [tokenError, setTokenError] = useState("");
   const [isPending, startTransition] = useTransition();
 
-  const handleGenerateToken = () => {
-    setTokenError("");
-    startTransition(async () => {
-      const res = await generateFranchiseToken(orgId, email);
-      if (res.ok) setEmail("");
-      else setTokenError(res.error);
-    });
+   const handleGenerateToken = () => {
+   const trimmedEmail = email.trim();
+    if (isPending || !trimmedEmail) return;
+     setTokenError("");
+     startTransition(async () => {
+      const res = await generateFranchiseToken(orgId, trimmedEmail);
+       if (res.ok) setEmail("");
+       else setTokenError(res.error);
+     });
   };
 
   return (
@@ -324,7 +328,7 @@ export function FranchiseeClient({
                     <td className="px-4 py-2 text-muted-foreground">{f.address ?? "—"}</td>
                     <td className="px-4 py-2">{f.owner.name ?? f.owner.email ?? "—"}</td>
                     <td className="px-4 py-2 text-muted-foreground">
-                      {new Date(f.createdAt).toLocaleDateString("en-AU")}
+                      {new Date(f.createdAt).toLocaleDateString("en-AU", { timeZone: "UTC" })}
                     </td>
                     <td className="px-4 py-2 text-right">
                       <FranchiseeActions orgId={orgId} franchisee={f} />
@@ -348,7 +352,12 @@ export function FranchiseeClient({
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             className="max-w-xs"
-            onKeyDown={(e) => e.key === "Enter" && handleGenerateToken()}
+           onKeyDown={(e) => {
+             if (e.key === "Enter" && !e.repeat) {
+               e.preventDefault();
+               handleGenerateToken();
+             }
+           }}
           />
           <Button onClick={handleGenerateToken} disabled={isPending || !email.trim()}>
             {isPending ? "Generating..." : "Generate Token"}
@@ -386,7 +395,7 @@ export function FranchiseeClient({
                         {t.token}
                       </td>
                       <td className="px-4 py-2 text-muted-foreground">
-                        {new Date(t.expiresAt).toLocaleDateString("en-AU")}
+                        {new Date(f.createdAt).toLocaleDateString("en-AU", { timeZone: "UTC" })}
                       </td>
                       <td className="px-4 py-2">
                         {used ? (

--- a/app/(app)/orgs/[orgId]/franchisee/page.tsx
+++ b/app/(app)/orgs/[orgId]/franchisee/page.tsx
@@ -1,0 +1,40 @@
+import { requireParentOrgOwnerPage } from "@/lib/authz";
+import { prisma } from "@/lib/prisma";
+import { FranchiseeClient } from "./franchisee-client";
+
+export default async function FranchiseePage({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) {
+  const { orgId } = await params;
+  await requireParentOrgOwnerPage(orgId);
+
+  const [franchisees, tokens] = await Promise.all([
+    prisma.organization.findMany({
+      where: { parentId: orgId },
+      select: {
+        id: true,
+        name: true,
+        address: true,
+        createdAt: true,
+        owner: { select: { id: true, name: true, email: true } },
+      },
+      orderBy: { createdAt: "asc" },
+    }),
+    prisma.franchiseToken.findMany({
+      where: { orgId },
+      select: {
+        id: true,
+        token: true,
+        invitedEmail: true,
+        expiresAt: true,
+        usedAt: true,
+        usedByOrgId: true,
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+  ]);
+
+  return <FranchiseeClient orgId={orgId} franchisees={franchisees} tokens={tokens} />;
+}

--- a/app/actions/franchisee.ts
+++ b/app/actions/franchisee.ts
@@ -1,0 +1,170 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireParentOrgOwnerAction } from "@/lib/authz";
+import { prisma } from "@/lib/prisma";
+
+type Result = { ok: true } | { ok: false; error: string };
+
+/** Generates a new franchise invite token for the given email (expires in 7 days). */
+export async function generateFranchiseToken(
+  orgId: string,
+  email: string,
+): Promise<Result> {
+  const authz = await requireParentOrgOwnerAction(orgId);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const trimmed = email.trim().toLowerCase();
+  if (!trimmed) return { ok: false, error: "Email is required" };
+
+  const user = await prisma.user.findUnique({
+    where: { email: trimmed },
+    select: { id: true },
+  });
+  if (!user) return { ok: false, error: "No account found with that email" };
+
+  const expiresAt = new Date();
+  expiresAt.setDate(expiresAt.getDate() + 7);
+
+  await prisma.franchiseToken.create({
+    data: { orgId, invitedEmail: trimmed, expiresAt },
+  });
+
+  revalidatePath(`/orgs/${orgId}/franchisee`);
+  return { ok: true };
+}
+
+/** Deletes a franchise invite token. */
+export async function deleteFranchiseToken(
+  orgId: string,
+  tokenId: string,
+): Promise<Result> {
+  const authz = await requireParentOrgOwnerAction(orgId);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const token = await prisma.franchiseToken.findFirst({
+    where: { id: tokenId, orgId },
+    select: { id: true },
+  });
+  if (!token) return { ok: false, error: "Token not found" };
+
+  await prisma.franchiseToken.delete({ where: { id: tokenId } });
+  revalidatePath(`/orgs/${orgId}/franchisee`);
+  return { ok: true };
+}
+
+/** Extends a franchise token's expiry by 1 day. */
+export async function extendFranchiseToken(
+  orgId: string,
+  tokenId: string,
+): Promise<Result> {
+  const authz = await requireParentOrgOwnerAction(orgId);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const token = await prisma.franchiseToken.findFirst({
+    where: { id: tokenId, orgId },
+    select: { id: true, expiresAt: true },
+  });
+  if (!token) return { ok: false, error: "Token not found" };
+
+  const newExpiry = new Date(token.expiresAt);
+  newExpiry.setDate(newExpiry.getDate() + 1);
+
+  await prisma.franchiseToken.update({
+    where: { id: tokenId },
+    data: { expiresAt: newExpiry },
+  });
+
+  revalidatePath(`/orgs/${orgId}/franchisee`);
+  return { ok: true };
+}
+
+/** Removes a franchisee from this org (detaches it by clearing parentId). */
+export async function removeFranchisee(
+  orgId: string,
+  childOrgId: string,
+): Promise<Result> {
+  const authz = await requireParentOrgOwnerAction(orgId);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const child = await prisma.organization.findFirst({
+    where: { id: childOrgId, parentId: orgId },
+    select: { id: true },
+  });
+  if (!child) return { ok: false, error: "Franchisee not found" };
+
+  await prisma.organization.update({
+    where: { id: childOrgId },
+    data: { parentId: null },
+  });
+
+  revalidatePath(`/orgs/${orgId}/franchisee`);
+  return { ok: true };
+}
+
+/** Changes the owner of a franchisee org (by email). */
+export async function changeFranchiseeOwner(
+  orgId: string,
+  childOrgId: string,
+  newOwnerEmail: string,
+): Promise<Result> {
+  const authz = await requireParentOrgOwnerAction(orgId);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const child = await prisma.organization.findFirst({
+    where: { id: childOrgId, parentId: orgId },
+    select: { id: true, ownerId: true },
+  });
+  if (!child) return { ok: false, error: "Franchisee not found" };
+
+  const newOwner = await prisma.user.findUnique({
+    where: { email: newOwnerEmail.trim().toLowerCase() },
+    select: { id: true },
+  });
+  if (!newOwner) return { ok: false, error: "User not found" };
+
+  // Find the Owner role in the child org
+  const ownerRole = await prisma.role.findFirst({
+    where: { orgId: childOrgId, key: "owner" },
+    select: { id: true },
+  });
+  if (!ownerRole) return { ok: false, error: "Owner role not found" };
+
+  await prisma.$transaction(async (tx) => {
+    const oldMembership = await tx.membership.findFirst({
+      where: { orgId: childOrgId, userId: child.ownerId },
+      select: { id: true },
+    });
+    if (oldMembership) {
+      await tx.memberRole.deleteMany({
+        where: { membershipId: oldMembership.id, roleId: ownerRole.id },
+      });
+    }
+
+    // Upsert membership for new owner and assign Owner role
+    const newMembership = await tx.membership.upsert({
+      where: { userId_orgId: { userId: newOwner.id, orgId: childOrgId } },
+      create: { orgId: childOrgId, userId: newOwner.id, workingDays: [] },
+      update: {},
+    });
+
+    await tx.memberRole.upsert({
+      where: {
+        membershipId_roleId: {
+          membershipId: newMembership.id,
+          roleId: ownerRole.id,
+        },
+      },
+      create: { membershipId: newMembership.id, roleId: ownerRole.id },
+      update: {},
+    });
+
+    await tx.organization.update({
+      where: { id: childOrgId },
+      data: { ownerId: newOwner.id },
+    });
+  });
+
+  revalidatePath(`/orgs/${orgId}/franchisee`);
+  return { ok: true };
+}

--- a/app/actions/franchisee.ts
+++ b/app/actions/franchisee.ts
@@ -89,16 +89,11 @@ export async function removeFranchisee(
   const authz = await requireParentOrgOwnerAction(orgId);
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
-  const child = await prisma.organization.findFirst({
+  const { count } = await prisma.organization.updateMany({
     where: { id: childOrgId, parentId: orgId },
-    select: { id: true },
-  });
-  if (!child) return { ok: false, error: "Franchisee not found" };
-
-  await prisma.organization.update({
-    where: { id: childOrgId },
     data: { parentId: null },
   });
+  if (count === 0) return { ok: false, error: "Franchisee not found" };
 
   revalidatePath(`/orgs/${orgId}/franchisee`);
   return { ok: true };
@@ -113,59 +108,65 @@ export async function changeFranchiseeOwner(
   const authz = await requireParentOrgOwnerAction(orgId);
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
-  const child = await prisma.organization.findFirst({
-    where: { id: childOrgId, parentId: orgId },
-    select: { id: true, ownerId: true },
-  });
-  if (!child) return { ok: false, error: "Franchisee not found" };
-
   const newOwner = await prisma.user.findUnique({
     where: { email: newOwnerEmail.trim().toLowerCase() },
     select: { id: true },
   });
   if (!newOwner) return { ok: false, error: "User not found" };
 
-  // Find the Owner role in the child org
-  const ownerRole = await prisma.role.findFirst({
-    where: { orgId: childOrgId, key: "owner" },
-    select: { id: true },
-  });
-  if (!ownerRole) return { ok: false, error: "Owner role not found" };
-
-  await prisma.$transaction(async (tx) => {
-    const oldMembership = await tx.membership.findFirst({
-      where: { orgId: childOrgId, userId: child.ownerId },
-      select: { id: true },
-    });
-    if (oldMembership) {
-      await tx.memberRole.deleteMany({
-        where: { membershipId: oldMembership.id, roleId: ownerRole.id },
+  try {
+    await prisma.$transaction(async (tx) => {
+      // Read child inside the transaction so ownerId and parentId are current
+      const child = await tx.organization.findFirst({
+        where: { id: childOrgId, parentId: orgId },
+        select: { id: true, ownerId: true },
       });
-    }
+      if (!child) throw new Error("Franchisee not found");
 
-    // Upsert membership for new owner and assign Owner role
-    const newMembership = await tx.membership.upsert({
-      where: { userId_orgId: { userId: newOwner.id, orgId: childOrgId } },
-      create: { orgId: childOrgId, userId: newOwner.id, workingDays: [] },
-      update: {},
-    });
+      const ownerRole = await tx.role.findFirst({
+        where: { orgId: childOrgId, key: "owner" },
+        select: { id: true },
+      });
+      if (!ownerRole) throw new Error("Owner role not found");
 
-    await tx.memberRole.upsert({
-      where: {
-        membershipId_roleId: {
-          membershipId: newMembership.id,
-          roleId: ownerRole.id,
+      const oldMembership = await tx.membership.findFirst({
+        where: { orgId: childOrgId, userId: child.ownerId },
+        select: { id: true },
+      });
+      if (oldMembership) {
+        await tx.memberRole.deleteMany({
+          where: { membershipId: oldMembership.id, roleId: ownerRole.id },
+        });
+      }
+
+      const newMembership = await tx.membership.upsert({
+        where: { userId_orgId: { userId: newOwner.id, orgId: childOrgId } },
+        create: { orgId: childOrgId, userId: newOwner.id, workingDays: [] },
+        update: {},
+      });
+
+      await tx.memberRole.upsert({
+        where: {
+          membershipId_roleId: {
+            membershipId: newMembership.id,
+            roleId: ownerRole.id,
+          },
         },
-      },
-      create: { membershipId: newMembership.id, roleId: ownerRole.id },
-      update: {},
-    });
+        create: { membershipId: newMembership.id, roleId: ownerRole.id },
+        update: {},
+      });
 
-    await tx.organization.update({
-      where: { id: childOrgId },
-      data: { ownerId: newOwner.id },
+      // Include parentId in the where clause so we never update an org that
+      // has been reparented between the child read and this write
+      const { count } = await tx.organization.updateMany({
+        where: { id: childOrgId, parentId: orgId },
+        data: { ownerId: newOwner.id },
+      });
+      if (count === 0) throw new Error("Franchisee not found");
     });
-  });
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "Failed to change owner" };
+  }
 
   revalidatePath(`/orgs/${orgId}/franchisee`);
   return { ok: true };

--- a/app/actions/franchisee.ts
+++ b/app/actions/franchisee.ts
@@ -67,7 +67,9 @@ export async function extendFranchiseToken(
   });
   if (!token) return { ok: false, error: "Token not found" };
 
-  const newExpiry = new Date(token.expiresAt);
+  const now = new Date();
+  const base = token.expiresAt > now ? token.expiresAt : now;
+  const newExpiry = new Date(base);
   newExpiry.setDate(newExpiry.getDate() + 1);
 
   await prisma.franchiseToken.update({

--- a/app/api/orgs/[orgId]/is-parent-owner/route.ts
+++ b/app/api/orgs/[orgId]/is-parent-owner/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { requireUser } from "@/lib/authz";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const authz = await requireUser();
+  if (!authz.ok) return authz.response;
+
+  const { orgId } = await params;
+
+  const org = await prisma.organization.findFirst({
+    where: { id: orgId, ownerId: authz.userId, parentId: null },
+    select: { id: true },
+  });
+
+  return NextResponse.json({ isParentOwner: org !== null });
+}

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import {
@@ -22,6 +22,7 @@ import {
   ListCheckIcon,
   ShieldCheck,
   Bell,
+  Network,
 } from "lucide-react";
 import {
   Sidebar,
@@ -124,9 +125,12 @@ function getNavItems(orgId: string, pathname: string) {
  * Returns footer items (e.g. Settings) when inside an org but not in settings.
  * Empty array otherwise so the footer is hidden.
  */
-function getFooterItems(orgId: string, pathname: string) {
+function getFooterItems(orgId: string, pathname: string, isParentOwner: boolean) {
   if (pathname.startsWith(`/orgs/${orgId}/settings`)) return [];
   return [
+    ...(isParentOwner
+      ? [{ title: "Franchisee", url: `/orgs/${orgId}/franchisee`, icon: Network }]
+      : []),
     { title: "Settings", url: `/orgs/${orgId}/settings`, icon: Settings },
   ];
 }
@@ -144,9 +148,20 @@ export function AppSidebar() {
   // orgId is present on any /orgs/[orgId]/... route, undefined otherwise
   const { orgId } = useParams<{ orgId?: string }>();
   const pathname = usePathname();
+  const [isParentOwner, setIsParentOwner] = useState(false);
+
+  useEffect(() => {
+    if (!orgId) return;
+    const controller = new AbortController();
+    fetch(`/api/orgs/${orgId}/is-parent-owner`, { signal: controller.signal })
+      .then((r) => r.json())
+      .then((d) => setIsParentOwner(d.isParentOwner ?? false))
+      .catch(() => {});
+    return () => controller.abort();
+  }, [orgId]);
 
   const navItems = orgId ? getNavItems(orgId, pathname) : [];
-  const footerItems = orgId ? getFooterItems(orgId, pathname) : [];
+  const footerItems = orgId ? getFooterItems(orgId, pathname, isParentOwner) : [];
 
   /**
    * Returns true when a nav item should be highlighted.

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -148,10 +148,12 @@ export function AppSidebar() {
   // orgId is present on any /orgs/[orgId]/... route, undefined otherwise
   const { orgId } = useParams<{ orgId?: string }>();
   const pathname = usePathname();
-  const [isParentOwner, setIsParentOwner] = useState(false);
+  const [parentOwnerStatus, setParentOwnerStatus] = useState<{
+    orgId: string | null;
+    isParentOwner: boolean;
+  }>({ orgId: null, isParentOwner: false });
 
   useEffect(() => {
-    setIsParentOwner(false);
     if (!orgId) return;
     const controller = new AbortController();
     fetch(`/api/orgs/${orgId}/is-parent-owner`, { signal: controller.signal })
@@ -159,10 +161,13 @@ export function AppSidebar() {
         if (!r.ok) throw new Error("Failed to load parent-owner status");
         return r.json();
       })
-      .then((d) => setIsParentOwner(d.isParentOwner ?? false))
+      .then((d) => setParentOwnerStatus({ orgId, isParentOwner: d.isParentOwner ?? false }))
       .catch(() => {});
     return () => controller.abort();
   }, [orgId]);
+
+  // Only true when the stored status is for the current org (prevents stale flash on org switch)
+  const isParentOwner = parentOwnerStatus.orgId === orgId && parentOwnerStatus.isParentOwner;
 
   const navItems = orgId ? getNavItems(orgId, pathname) : [];
   const footerItems = orgId ? getFooterItems(orgId, pathname, isParentOwner) : [];

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -151,10 +151,14 @@ export function AppSidebar() {
   const [isParentOwner, setIsParentOwner] = useState(false);
 
   useEffect(() => {
+    setIsParentOwner(false);
     if (!orgId) return;
     const controller = new AbortController();
     fetch(`/api/orgs/${orgId}/is-parent-owner`, { signal: controller.signal })
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to load parent-owner status");
+        return r.json();
+      })
       .then((d) => setIsParentOwner(d.isParentOwner ?? false))
       .catch(() => {});
     return () => controller.abort();

--- a/lib/authz/_shared.ts
+++ b/lib/authz/_shared.ts
@@ -16,6 +16,15 @@ export async function getOrgMembership(orgId: string, userId: string) {
   });
 }
 
+/** Returns true if the user is the owner of an org that has no parent (i.e. a parent org). */
+export async function isParentOrgOwner(orgId: string, userId: string): Promise<boolean> {
+  const org = await prisma.organization.findFirst({
+    where: { id: orgId, ownerId: userId, parentId: null },
+    select: { id: true },
+  });
+  return org !== null;
+}
+
 /** Returns true if the membership's role(s) grant the given permission. */
 export async function memberHasPermission(
   membershipId: string,

--- a/lib/authz/action.ts
+++ b/lib/authz/action.ts
@@ -2,6 +2,7 @@ import { PermissionAction } from "@prisma/client";
 import {
   getAuthUserId,
   getOrgMembership,
+  isParentOrgOwner,
   memberHasPermission,
 } from "./_shared";
 
@@ -38,6 +39,14 @@ export async function requireOrgMemberAction(orgId: string) {
   if (!membership) return { ok: false as const };
 
   return { ok: true as const, userId, membership };
+}
+
+/** Requires the caller to be the owner of a parent org (no parentId). */
+export async function requireParentOrgOwnerAction(orgId: string) {
+  const userId = await getAuthUserId();
+  if (!userId) return { ok: false as const };
+  if (!(await isParentOrgOwner(orgId, userId))) return { ok: false as const };
+  return { ok: true as const, userId };
 }
 
 /** Requires the caller to be a member of the org with the given permission. */

--- a/lib/authz/index.ts
+++ b/lib/authz/index.ts
@@ -8,4 +8,6 @@ export {
   requireUserAction,
   requireOrgMemberAction,
   requireOrgPermissionAction,
+  requireParentOrgOwnerAction,
 } from "./action";
+export { requireParentOrgOwnerPage } from "./page";

--- a/lib/authz/page.ts
+++ b/lib/authz/page.ts
@@ -3,6 +3,7 @@ import { PermissionAction } from "@prisma/client";
 import {
   getAuthUserId,
   getOrgMembership,
+  isParentOrgOwner,
   memberHasPermission,
 } from "./_shared";
 
@@ -32,13 +33,13 @@ export async function requireUserPage({
  */
 export async function requireOrgMemberPage(
   orgId: string,
-  { redirectTo = "/" } = {},
+  { redirectTo }: { redirectTo?: string } = {},
 ): Promise<{ userId: string }> {
   const userId = await getAuthUserId();
   if (!userId) redirect("/signin");
 
   const membership = await getOrgMembership(orgId, userId);
-  if (!membership) redirect(redirectTo);
+  if (!membership) redirect(redirectTo ?? `/orgs/${orgId}`);
 
   return { userId };
 }
@@ -49,19 +50,33 @@ export async function requireOrgMemberPage(
  * - Permission denied  → redirects to redirectTo (default: /)
  * - Otherwise          → returns { userId }
  */
+/**
+ * Requires the caller to be the owner of a parent org (no parentId).
+ * Redirects to / if not signed in or not the parent org owner.
+ */
+export async function requireParentOrgOwnerPage(
+  orgId: string,
+  { redirectTo = "/" } = {},
+): Promise<{ userId: string }> {
+  const userId = await getAuthUserId();
+  if (!userId) redirect("/signin");
+  if (!(await isParentOrgOwner(orgId, userId))) redirect(redirectTo);
+  return { userId };
+}
+
 export async function requireOrgPermissionPage(
   orgId: string,
   permission: PermissionAction,
-  { redirectTo = "/" } = {},
+  { redirectTo }: { redirectTo?: string } = {},
 ): Promise<{ userId: string }> {
   const userId = await getAuthUserId();
   if (!userId) redirect("/signin");
 
   const membership = await getOrgMembership(orgId, userId);
-  if (!membership) redirect(redirectTo);
+  if (!membership) redirect(redirectTo ?? `/orgs/${orgId}`);
 
   if (!(await memberHasPermission(membership.id, orgId, permission)))
-    redirect(redirectTo);
+    redirect(redirectTo ?? `/orgs/${orgId}`);
 
   return { userId };
 }

--- a/lib/services/franchise.ts
+++ b/lib/services/franchise.ts
@@ -60,6 +60,11 @@ export async function cloneRolesFromParent(
     ),
   );
 
+  // Build a map of parent role ID → cloned role ID (Promise.all preserves order)
+  const roleIdMap = new Map<string, string>(
+    parentRoles.map((r, i) => [r.id, clonedRoles[i].id]),
+  );
+
   // Assign the joining user as Owner of the new child org
   const ownerRole = clonedRoles.find((r) => r.key === ROLE_KEYS.OWNER);
   if (!ownerRole) throw new Error("Parent org has no Owner role to clone");
@@ -72,36 +77,83 @@ export async function cloneRolesFromParent(
     data: { membershipId: membership.id, roleId: ownerRole.id },
   });
 
-  return { clonedRoles, membership };
+  return { clonedRoles, roleIdMap, membership };
 }
 
 /**
- * Clones all timetable templates and their entries from a parent org into a
- * child org.
+ * Clones all tasks and their role eligibility from a parent org into a child org.
+ *
+ * What is cloned:
+ *   - Every Task (name, description, color, durations, constraints)
+ *   - TaskEligibility records — role IDs are remapped via roleIdMap so
+ *     eligibility points at the cloned roles, not the parent's.
+ *
+ * Returns a taskIdMap (parent task ID → child task ID) for use by
+ * cloneTemplatesFromParent.
+ */
+export async function cloneTasksFromParent(
+  tx: Tx,
+  parentOrgId: string,
+  childOrgId: string,
+  roleIdMap: Map<string, string>,
+) {
+  const parentTasks = await tx.task.findMany({
+    where: { orgId: parentOrgId },
+    include: { eligibility: { select: { roleId: true } } },
+  });
+
+  const taskIdMap = new Map<string, string>();
+
+  await Promise.all(
+    parentTasks.map(async (task) => {
+      const cloned = await tx.task.create({
+        data: {
+          orgId: childOrgId,
+          name: task.name,
+          description: task.description,
+          color: task.color,
+          durationMin: task.durationMin,
+          minPeople: task.minPeople,
+          maxPeople: task.maxPeople,
+          priority: task.priority,
+          preferredStartTimeMin: task.preferredStartTimeMin,
+          minWaitDays: task.minWaitDays,
+          maxWaitDays: task.maxWaitDays,
+          eligibility: {
+            create: task.eligibility
+              .map(({ roleId }) => roleIdMap.get(roleId))
+              .filter((id): id is string => id !== undefined)
+              .map((roleId) => ({ roleId })),
+          },
+        },
+      });
+      taskIdMap.set(task.id, cloned.id);
+    }),
+  );
+
+  return { taskIdMap };
+}
+
+/**
  *
  * What is cloned:
  *   - Every Template (name, cycleLengthDays)
- *   - Every TemplateEntry per template (dayIndex, startTimeMin, endTimeMin,
- *     priority, durationMin) — the taskId is preserved so the entry still
- *     references the same task definition.
+ *   - Every TemplateEntry per template — taskIds are remapped via taskIdMap
+ *     so entries point at the cloned tasks, not the parent's.
  *
  * What is NOT cloned:
  *   - TemplateEntryAssignee records — no role/member assignments are carried
  *     over. The child org's staff will be assigned separately.
- *   - Tasks themselves — tasks belong to an org and are not cloned here.
- *     If you also want to clone tasks, call cloneTasksFromParent first and
- *     remap taskIds before calling this function.
  *
- * Note: if the parent has template entries that reference tasks not present in
- * the child org, those entries will fail to create (foreign key violation).
- * Clone tasks first if needed.
+ * Entries whose parent taskId has no mapping in taskIdMap are skipped to
+ * avoid foreign-key violations.
  */
 export async function cloneTemplatesFromParent(
   tx: Tx,
   parentOrgId: string,
   childOrgId: string,
+  taskIdMap: Map<string, string>,
 ) {
-  // Fetch all templates + their entries (no assignees)
   const parentTemplates = await tx.template.findMany({
     where: { orgId: parentOrgId },
     include: {
@@ -118,7 +170,6 @@ export async function cloneTemplatesFromParent(
     },
   });
 
-  // Clone each template with its entries (no assignees)
   const clonedTemplates = await Promise.all(
     parentTemplates.map((template) =>
       tx.template.create({
@@ -127,14 +178,16 @@ export async function cloneTemplatesFromParent(
           name: template.name,
           cycleLengthDays: template.cycleLengthDays,
           entries: {
-            create: template.entries.map((entry) => ({
-              taskId: entry.taskId,
-              dayIndex: entry.dayIndex,
-              startTimeMin: entry.startTimeMin,
-              endTimeMin: entry.endTimeMin,
-              priority: entry.priority,
-              durationMin: entry.durationMin,
-            })),
+            create: template.entries
+              .filter((entry) => taskIdMap.has(entry.taskId))
+              .map((entry) => ({
+                taskId: taskIdMap.get(entry.taskId)!,
+                dayIndex: entry.dayIndex,
+                startTimeMin: entry.startTimeMin,
+                endTimeMin: entry.endTimeMin,
+                priority: entry.priority,
+                durationMin: entry.durationMin,
+              })),
           },
         },
       }),
@@ -142,4 +195,27 @@ export async function cloneTemplatesFromParent(
   );
 
   return { clonedTemplates };
+}
+
+/**
+ * Clones timetable view settings from a parent org into a child org.
+ * If the parent has no settings record, this is a no-op.
+ */
+export async function cloneTimetableSettingsFromParent(
+  tx: Tx,
+  parentOrgId: string,
+  childOrgId: string,
+) {
+  const settings = await tx.timetableSettings.findUnique({
+    where: { orgId: parentOrgId },
+  });
+  if (!settings) return null;
+  return tx.timetableSettings.create({
+    data: {
+      orgId: childOrgId,
+      viewType: settings.viewType,
+      startDay: settings.startDay,
+      slotDuration: settings.slotDuration,
+    },
+  });
 }

--- a/lib/services/orgs.ts
+++ b/lib/services/orgs.ts
@@ -12,7 +12,7 @@ import type {
   JoinFranchiseInput,
   UpdateOrgSettingsInput,
 } from "@/lib/validators/org";
-import { cloneRolesFromParent, type Tx } from "@/lib/services/franchise";
+import { cloneRolesFromParent, cloneTasksFromParent, cloneTemplatesFromParent, cloneTimetableSettingsFromParent, type Tx } from "@/lib/services/franchise";
 
 /** Full set of permissions granted to the Owner role on a fresh org. */
 const ownerPermissions: PermissionAction[] = [
@@ -164,12 +164,21 @@ export async function joinFranchise(
     });
 
     // Clone all roles + permissions from the parent (no users carried over).
-    const { clonedRoles, membership } = await cloneRolesFromParent(
+    const { clonedRoles, roleIdMap, membership } = await cloneRolesFromParent(
       tx,
       token.orgId,
       org.id,
       userId,
     );
+
+    // Clone tasks with eligibility remapped to the cloned roles.
+    const { taskIdMap } = await cloneTasksFromParent(tx, token.orgId, org.id, roleIdMap);
+
+    // Clone timetable templates with taskIds remapped to the cloned tasks.
+    await cloneTemplatesFromParent(tx, token.orgId, org.id, taskIdMap);
+
+    // Clone timetable view settings.
+    await cloneTimetableSettingsFromParent(tx, token.orgId, org.id);
 
     // Mark the token as consumed so it cannot be reused.
     await tx.franchiseToken.update({


### PR DESCRIPTION
…dal clipping and hydration

- Clone tasks (with role eligibility remapped) from parent on joinFranchise
- Clone timetable templates (with taskIds remapped) from parent on joinFranchise
- Clone timetable settings from parent on joinFranchise
- Replace absolute-positioned [...] popups with centered portal modals
- Fix hydration mismatch by passing explicit locale to toLocaleDateString

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parent-org owners get a Franchisee management UI: lists for franchisees and invite tokens, modals, and inline pending/error states
  * Invite token lifecycle: generate, label (Active/Used/Expired), extend expiry, and delete
  * Franchisee actions: change owner and remove franchisee
  * Sidebar now surfaces a “Franchisee” link when the current org is a parent owner
  * Franchise join now clones roles, tasks, templates and timetable settings from parent
* **Security**
  * Access gated to parent-organization owners and enforced server-side
<!-- end of auto-generated comment: release notes by coderabbit.ai -->