### PR TITLE
feat(tasks): add task view page with detail card, eligible roles, and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,30 +307,30 @@ Server Actions call `revalidatePath` to invalidate the Next.js cache so server-r
 
 ## Pages
 
-| Route                                            | Guard                                      | Description                                                         |
-| ------------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------- |
-| `/`                                              | Signed in                                  | Home                                                                |
-| `/signin`                                        | —                                          | Google OAuth sign-in                                                |
-| `/orgs/new`                                      | Signed in                                  | Create a new organization                                           |
-| `/orgs/[orgId]`                                  | `requireOrgMemberPage`                     | Org overview                                                        |
-| `/orgs/[orgId]/franchisee`                       | `requireParentOrgOwnerPage`                | Franchise management — invite tokens + franchisee list              |
+| Route                                            | Guard                                      | Description                                                                                                     |
+| ------------------------------------------------ | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `/`                                              | Signed in                                  | Home                                                                                                            |
+| `/signin`                                        | —                                          | Google OAuth sign-in                                                                                            |
+| `/orgs/new`                                      | Signed in                                  | Create a new organization                                                                                       |
+| `/orgs/[orgId]`                                  | `requireOrgMemberPage`                     | Org overview                                                                                                    |
+| `/orgs/[orgId]/franchisee`                       | `requireParentOrgOwnerPage`                | Franchise management — invite tokens + franchisee list                                                          |
 | `/orgs/[orgId]/tasks`                            | `requireOrgMemberPage`                     | Task definition list — searchable/sortable table with role filter and per-row actions (edit, duplicate, delete) |
-| `/orgs/[orgId]/tasks/new`                        | `requireOrgPermissionPage MANAGE_TASKS`    | Create a new task definition with role eligibility selector          |
-| `/orgs/[orgId]/tasks/[taskId]`                   | `requireOrgMemberPage`                     | Task detail view — fields, eligible roles, Actions menu (edit/delete) for `MANAGE_TASKS` holders |
-| `/orgs/[orgId]/tasks/[taskId]/edit`              | `requireOrgPermissionPage MANAGE_TASKS`    | Edit a task definition's fields and role eligibility                 |
-| `/orgs/[orgId]/memberships`                      | `requireOrgMemberPage`                     | Member list                                                         |
-| `/orgs/[orgId]/memberships/new`                  | `requireOrgPermissionPage MANAGE_MEMBERS`  | Invite a new member by email                                        |
-| `/orgs/[orgId]/timetable`                        | `requireOrgMemberPage`                     | Timetable — calendar or simple mode, week navigation                |
-| `/orgs/[orgId]/timetable/templates`              | `requireOrgMemberPage`                     | Timetable template list                                             |
-| `/orgs/[orgId]/timetable/templates/new`          | `requireOrgMemberPage`                     | Create a new timetable template                                     |
-| `/orgs/[orgId]/timetable/templates/[templateId]` | `requireOrgMemberPage`                     | Template editor — drag-and-drop schedule builder                    |
-| `/orgs/[orgId]/settings`                         | —                                          | Redirects to `/settings/organization`                               |
-| `/orgs/[orgId]/settings/organization`            | `requireOrgPermissionPage MANAGE_SETTINGS` | Org info, timezone, hours, transfer, delete                         |
-| `/orgs/[orgId]/settings/roles`                   | `requireOrgPermissionPage MANAGE_ROLES`    | Role list + delete custom roles                                     |
-| `/orgs/[orgId]/settings/roles/new`               | `requireOrgPermissionPage MANAGE_ROLES`    | Create a new custom role                                            |
-| `/orgs/[orgId]/settings/roles/[roleId]/edit`     | `requireOrgPermissionPage MANAGE_ROLES`    | Edit a custom role's name, color, permissions, and task eligibility |
-| `/orgs/[orgId]/settings/timetable`               | —                                          | Timetable display settings (stub)                                   |
-| `/orgs/[orgId]/settings/notification`            | —                                          | Notification preferences (stub)                                     |
+| `/orgs/[orgId]/tasks/new`                        | `requireOrgPermissionPage MANAGE_TASKS`    | Create a new task definition with role eligibility selector                                                     |
+| `/orgs/[orgId]/tasks/[taskId]`                   | `requireOrgMemberPage`                     | Task detail view — fields, eligible roles, Actions menu (edit/delete) for `MANAGE_TASKS` holders                |
+| `/orgs/[orgId]/tasks/[taskId]/edit`              | `requireOrgPermissionPage MANAGE_TASKS`    | Edit a task definition's fields and role eligibility                                                            |
+| `/orgs/[orgId]/memberships`                      | `requireOrgMemberPage`                     | Member list                                                                                                     |
+| `/orgs/[orgId]/memberships/new`                  | `requireOrgPermissionPage MANAGE_MEMBERS`  | Invite a new member by email                                                                                    |
+| `/orgs/[orgId]/timetable`                        | `requireOrgMemberPage`                     | Timetable — calendar or simple mode, week navigation                                                            |
+| `/orgs/[orgId]/timetable/templates`              | `requireOrgMemberPage`                     | Timetable template list                                                                                         |
+| `/orgs/[orgId]/timetable/templates/new`          | `requireOrgMemberPage`                     | Create a new timetable template                                                                                 |
+| `/orgs/[orgId]/timetable/templates/[templateId]` | `requireOrgMemberPage`                     | Template editor — drag-and-drop schedule builder                                                                |
+| `/orgs/[orgId]/settings`                         | —                                          | Redirects to `/settings/organization`                                                                           |
+| `/orgs/[orgId]/settings/organization`            | `requireOrgPermissionPage MANAGE_SETTINGS` | Org info, timezone, hours, transfer, delete                                                                     |
+| `/orgs/[orgId]/settings/roles`                   | `requireOrgPermissionPage MANAGE_ROLES`    | Role list + delete custom roles                                                                                 |
+| `/orgs/[orgId]/settings/roles/new`               | `requireOrgPermissionPage MANAGE_ROLES`    | Create a new custom role                                                                                        |
+| `/orgs/[orgId]/settings/roles/[roleId]/edit`     | `requireOrgPermissionPage MANAGE_ROLES`    | Edit a custom role's name, color, permissions, and task eligibility                                             |
+| `/orgs/[orgId]/settings/timetable`               | —                                          | Timetable display settings (stub)                                                                               |
+| `/orgs/[orgId]/settings/notification`            | —                                          | Notification preferences (stub)                                                                                 |
 
 All `/orgs/[orgId]/*` pages are guarded by at least `requireOrgMemberPage` — users not in the org are redirected.
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,9 @@ app/
         page.tsx          # Org overview
         franchisee/       # Franchise management (parent org owners only)
         memberships/      # Members list + invite new member
-        tasks/            # Task definition list (searchable, sortable, filterable table) + create form
+        tasks/            # Task definition list + create form
+          [taskId]/       # Task detail view
+            edit/         # Edit task form
         timetable/        # Weekly timetable, template selector, template editor
         settings/
           page.tsx        # Redirects to /settings/organization
@@ -215,7 +217,7 @@ app/
   actions/                # Server Actions (web UI mutations)
     orgs.ts               # createOrg, updateOrgSettings, transferOrgOwnership, deleteOrg, joinFranchise
     memberships.ts        # createMembership, deleteMembership
-    tasks.ts              # createTaskAction, deleteTaskAction
+    tasks.ts              # createTaskAction, deleteTaskAction, updateTaskAction, addEligibilityAction, removeEligibilityAction
     templates.ts          # createTemplate, updateTemplateEntry, deleteTemplateEntry, etc.
     franchisee.ts         # generateFranchiseToken, deleteFranchiseToken, removeFranchisee, etc.
     roles.ts              # deleteRoleAction, createRoleAction, updateRoleAction
@@ -271,7 +273,7 @@ lib/
     types.ts            # ServiceResult<T> discriminated union
     orgs.ts             # createOrg, updateOrgSettings, transferOrgOwnership, deleteOrg
     memberships.ts      # getMemberships, createMembership, deleteMembership
-    tasks.ts            # getTasks (includes role eligibility), createTask, deleteTask
+    tasks.ts            # getTasks, getTaskById, createTask, deleteTask, updateTask, addTaskEligibility, removeTaskEligibility, setTaskEligibilities
     task-instances.ts   # getTaskInstances, createTaskInstance, updateTaskInstanceStatus
     assignees.ts        # getAssignees, createAssignee, deleteAssignee
     templates.ts        # getTimetableTemplates, getTimetableTemplate, template mutations
@@ -313,7 +315,9 @@ Server Actions call `revalidatePath` to invalidate the Next.js cache so server-r
 | `/orgs/[orgId]`                                  | `requireOrgMemberPage`                     | Org overview                                                        |
 | `/orgs/[orgId]/franchisee`                       | `requireParentOrgOwnerPage`                | Franchise management — invite tokens + franchisee list              |
 | `/orgs/[orgId]/tasks`                            | `requireOrgMemberPage`                     | Task definition list — searchable/sortable table with role filter and per-row actions (edit, duplicate, delete) |
-| `/orgs/[orgId]/tasks/new`                        | `requireOrgPermissionPage MANAGE_TASKS`    | Create a new task definition                                        |
+| `/orgs/[orgId]/tasks/new`                        | `requireOrgPermissionPage MANAGE_TASKS`    | Create a new task definition with role eligibility selector          |
+| `/orgs/[orgId]/tasks/[taskId]`                   | `requireOrgMemberPage`                     | Task detail view — fields, eligible roles, Actions menu (edit/delete) for `MANAGE_TASKS` holders |
+| `/orgs/[orgId]/tasks/[taskId]/edit`              | `requireOrgPermissionPage MANAGE_TASKS`    | Edit a task definition's fields and role eligibility                 |
 | `/orgs/[orgId]/memberships`                      | `requireOrgMemberPage`                     | Member list                                                         |
 | `/orgs/[orgId]/memberships/new`                  | `requireOrgPermissionPage MANAGE_MEMBERS`  | Invite a new member by email                                        |
 | `/orgs/[orgId]/timetable`                        | `requireOrgMemberPage`                     | Timetable — calendar or simple mode, week navigation                |

--- a/app/(app)/orgs/[orgId]/tasks/[taskId]/edit/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/[taskId]/edit/page.tsx
@@ -1,3 +1,11 @@
+/**
+ * Edit Task page — `/orgs/[orgId]/tasks/[taskId]/edit`
+ *
+ * Server component. Guards with `MANAGE_TASKS`. Fetches the task and all org
+ * roles in parallel, then renders the shared `TaskForm` in edit mode.
+ * Hydrates default field values and the current role eligibility list.
+ * Returns 404 if the task does not belong to the org.
+ */
 import { notFound } from "next/navigation";
 import { requireOrgPermissionPage } from "@/lib/authz";
 import { PermissionAction } from "@prisma/client";

--- a/app/(app)/orgs/[orgId]/tasks/[taskId]/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/[taskId]/page.tsx
@@ -12,13 +12,13 @@ import Link from "next/link";
 import { PermissionAction } from "@prisma/client";
 import { requireOrgMemberPage } from "@/lib/authz";
 import {
-  getAuthUserId,
   getOrgMembership,
   memberHasPermission,
 } from "@/lib/authz/_shared";
 import { getTaskById } from "@/lib/services/tasks";
 import { Toolbar } from "@/components/layout/toolbar";
 import { TaskViewActions } from "./task-view-actions";
+import { formatDate } from "@/lib/utils";
 
 function formatDuration(min: number): string {
   if (min < 60) return `${min} min`;
@@ -146,8 +146,7 @@ const ViewTaskPage = async ({ params }: Props) => {
               Photo
             </div>
             <p className="text-xs text-muted-foreground">
-              Created{" "}
-              {task.createdAt.toLocaleDateString("en-AU", { timeZone: "UTC" })}
+              Created {formatDate(task.createdAt)}
             </p>
           </div>
         </div>

--- a/app/(app)/orgs/[orgId]/tasks/[taskId]/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/[taskId]/page.tsx
@@ -11,7 +11,11 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { PermissionAction } from "@prisma/client";
 import { requireOrgMemberPage } from "@/lib/authz";
-import { getAuthUserId, getOrgMembership, memberHasPermission } from "@/lib/authz/_shared";
+import {
+  getAuthUserId,
+  getOrgMembership,
+  memberHasPermission,
+} from "@/lib/authz/_shared";
 import { getTaskById } from "@/lib/services/tasks";
 import { Toolbar } from "@/components/layout/toolbar";
 import { TaskViewActions } from "./task-view-actions";
@@ -38,21 +42,21 @@ interface Props {
 const ViewTaskPage = async ({ params }: Props) => {
   const { orgId, taskId } = await params;
 
-  await requireOrgMemberPage(orgId);
+  const { userId } = await requireOrgMemberPage(orgId);
 
-  const [task, userId] = await Promise.all([
+  const [task, membership] = await Promise.all([
     getTaskById(orgId, taskId),
-    getAuthUserId(),
+    getOrgMembership(orgId, userId),
   ]);
   if (!task) notFound();
 
-  let canManage = false;
-  if (userId) {
-    const membership = await getOrgMembership(orgId, userId);
-    if (membership) {
-      canManage = await memberHasPermission(membership.id, orgId, PermissionAction.MANAGE_TASKS);
-    }
-  }
+  const canManage = membership
+    ? await memberHasPermission(
+        membership.id,
+        orgId,
+        PermissionAction.MANAGE_TASKS,
+      )
+    : false;
 
   const eligibleRoles = task.eligibility.map((e) => e.role);
 
@@ -61,7 +65,11 @@ const ViewTaskPage = async ({ params }: Props) => {
       <Toolbar
         rightChildren={
           canManage ? (
-            <TaskViewActions orgId={orgId} taskId={taskId} taskName={task.name} />
+            <TaskViewActions
+              orgId={orgId}
+              taskId={taskId}
+              taskName={task.name}
+            />
           ) : undefined
         }
       >
@@ -81,39 +89,53 @@ const ViewTaskPage = async ({ params }: Props) => {
           {/* Left: task fields */}
           <dl className="flex flex-col gap-4">
             <div>
-              <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">Duration</dt>
+              <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">
+                Duration
+              </dt>
               <dd className="text-sm">{formatDuration(task.durationMin)}</dd>
             </div>
 
             {task.preferredStartTimeMin != null && (
               <div>
-                <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">Preferred start time</dt>
-                <dd className="text-sm">{formatTime(task.preferredStartTimeMin)}</dd>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">
+                  Preferred start time
+                </dt>
+                <dd className="text-sm">
+                  {formatTime(task.preferredStartTimeMin)}
+                </dd>
               </div>
             )}
 
             <div>
-              <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">People required</dt>
+              <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">
+                People required
+              </dt>
               <dd className="text-sm">{task.minPeople}</dd>
             </div>
 
             {(task.minWaitDays != null || task.maxWaitDays != null) && (
               <div>
-                <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">Wait days</dt>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">
+                  Wait days
+                </dt>
                 <dd className="text-sm">
                   {task.minWaitDays != null && task.maxWaitDays != null
                     ? `${task.minWaitDays} – ${task.maxWaitDays} days`
                     : task.minWaitDays != null
-                    ? `Min ${task.minWaitDays} days`
-                    : `Max ${task.maxWaitDays} days`}
+                      ? `Min ${task.minWaitDays} days`
+                      : `Max ${task.maxWaitDays} days`}
                 </dd>
               </div>
             )}
 
             {task.description && (
               <div>
-                <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">Description</dt>
-                <dd className="text-sm whitespace-pre-wrap">{task.description}</dd>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">
+                  Description
+                </dt>
+                <dd className="text-sm whitespace-pre-wrap">
+                  {task.description}
+                </dd>
               </div>
             )}
           </dl>
@@ -124,7 +146,8 @@ const ViewTaskPage = async ({ params }: Props) => {
               Photo
             </div>
             <p className="text-xs text-muted-foreground">
-              Created {task.createdAt.toLocaleDateString("en-AU", { timeZone: "UTC" })}
+              Created{" "}
+              {task.createdAt.toLocaleDateString("en-AU", { timeZone: "UTC" })}
             </p>
           </div>
         </div>

--- a/app/(app)/orgs/[orgId]/tasks/[taskId]/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/[taskId]/page.tsx
@@ -1,9 +1,161 @@
-import React from 'react'
+/**
+ * View Task page — `/orgs/[orgId]/tasks/[taskId]`
+ *
+ * Server component. Any org member can view. Conditionally shows the
+ * Actions dropdown (Edit / Delete) only to members with `MANAGE_TASKS`.
+ * Includes a back-link toolbar, a detail card with all task fields,
+ * and an eligible-roles section.
+ * Returns 404 if the task does not belong to the org.
+ */
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { PermissionAction } from "@prisma/client";
+import { requireOrgMemberPage } from "@/lib/authz";
+import { getAuthUserId, getOrgMembership, memberHasPermission } from "@/lib/authz/_shared";
+import { getTaskById } from "@/lib/services/tasks";
+import { Toolbar } from "@/components/layout/toolbar";
+import { TaskViewActions } from "./task-view-actions";
 
-const Page = () => {
-  return (
-    <div>Page</div>
-  )
+function formatDuration(min: number): string {
+  if (min < 60) return `${min} min`;
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return m > 0 ? `${h} h ${m} min` : `${h} h`;
 }
 
-export default Page
+function formatTime(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  const period = h < 12 ? "am" : "pm";
+  const h12 = h % 12 || 12;
+  return `${h12}:${m.toString().padStart(2, "0")} ${period}`;
+}
+
+interface Props {
+  params: Promise<{ orgId: string; taskId: string }>;
+}
+
+const ViewTaskPage = async ({ params }: Props) => {
+  const { orgId, taskId } = await params;
+
+  await requireOrgMemberPage(orgId);
+
+  const [task, userId] = await Promise.all([
+    getTaskById(orgId, taskId),
+    getAuthUserId(),
+  ]);
+  if (!task) notFound();
+
+  let canManage = false;
+  if (userId) {
+    const membership = await getOrgMembership(orgId, userId);
+    if (membership) {
+      canManage = await memberHasPermission(membership.id, orgId, PermissionAction.MANAGE_TASKS);
+    }
+  }
+
+  const eligibleRoles = task.eligibility.map((e) => e.role);
+
+  return (
+    <>
+      <Toolbar
+        rightChildren={
+          canManage ? (
+            <TaskViewActions orgId={orgId} taskId={taskId} taskName={task.name} />
+          ) : undefined
+        }
+      >
+        <Link
+          href={`/orgs/${orgId}/tasks`}
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← Tasks
+        </Link>
+      </Toolbar>
+
+      <div className="max-w-4xl mx-auto flex flex-col gap-6">
+        <h1 className="text-2xl font-semibold">{task.name}</h1>
+
+        {/* Detail card */}
+        <div className="rounded-lg border bg-card p-6 grid grid-cols-1 md:grid-cols-[1fr_200px] gap-8">
+          {/* Left: task fields */}
+          <dl className="flex flex-col gap-4">
+            <div>
+              <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">Duration</dt>
+              <dd className="text-sm">{formatDuration(task.durationMin)}</dd>
+            </div>
+
+            {task.preferredStartTimeMin != null && (
+              <div>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">Preferred start time</dt>
+                <dd className="text-sm">{formatTime(task.preferredStartTimeMin)}</dd>
+              </div>
+            )}
+
+            <div>
+              <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">People required</dt>
+              <dd className="text-sm">{task.minPeople}</dd>
+            </div>
+
+            {(task.minWaitDays != null || task.maxWaitDays != null) && (
+              <div>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">Wait days</dt>
+                <dd className="text-sm">
+                  {task.minWaitDays != null && task.maxWaitDays != null
+                    ? `${task.minWaitDays} – ${task.maxWaitDays} days`
+                    : task.minWaitDays != null
+                    ? `Min ${task.minWaitDays} days`
+                    : `Max ${task.maxWaitDays} days`}
+                </dd>
+              </div>
+            )}
+
+            {task.description && (
+              <div>
+                <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">Description</dt>
+                <dd className="text-sm whitespace-pre-wrap">{task.description}</dd>
+              </div>
+            )}
+          </dl>
+
+          {/* Right: photo placeholder + created date */}
+          <div className="flex flex-col gap-4">
+            <div className="rounded-md bg-muted aspect-square w-full flex items-center justify-center text-xs text-muted-foreground">
+              Photo
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Created {task.createdAt.toLocaleDateString("en-AU", { timeZone: "UTC" })}
+            </p>
+          </div>
+        </div>
+
+        {/* Eligible roles */}
+        <div className="rounded-lg border bg-card p-6">
+          <h2 className="text-sm font-medium mb-3">Eligible roles</h2>
+          {eligibleRoles.length === 0 ? (
+            <p className="text-sm text-muted-foreground">All roles eligible</p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {eligibleRoles.map((role) => (
+                <span
+                  key={role.id}
+                  className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs"
+                >
+                  {role.color && (
+                    <span
+                      className="inline-block w-2 h-2 rounded-full shrink-0"
+                      style={{ backgroundColor: role.color }}
+                    />
+                  )}
+                  {role.name}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ViewTaskPage;

--- a/app/(app)/orgs/[orgId]/tasks/[taskId]/task-view-actions.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/[taskId]/task-view-actions.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+/**
+ * TaskViewActions — Actions dropdown for the task view page.
+ *
+ * Renders an "Actions ▼" dropdown with:
+ *   - Edit — navigates to the edit page via a Next.js Link.
+ *   - Delete — shows an inline confirmation overlay, then calls
+ *     `deleteTaskAction` and redirects to the tasks list on success.
+ *
+ * Shown only when the viewer holds `MANAGE_TASKS` (gated server-side in the
+ * parent page; this component receives no auth props).
+ */
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ChevronDown } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { deleteTaskAction } from "@/app/actions/tasks";
+
+interface Props {
+  orgId: string;
+  taskId: string;
+  taskName: string;
+}
+
+export function TaskViewActions({ orgId, taskId, taskName }: Props) {
+  const router = useRouter();
+  const [confirming, setConfirming] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      const res = await deleteTaskAction(orgId, taskId);
+      if (res.ok) {
+        router.push(`/orgs/${orgId}/tasks`);
+      } else {
+        toast.error(res.error);
+        setConfirming(false);
+      }
+    });
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" className="gap-1.5 shrink-0">
+            Actions <ChevronDown className="h-3.5 w-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem asChild>
+            <Link href={`/orgs/${orgId}/tasks/${taskId}/edit`}>Edit</Link>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={() => setConfirming(true)}
+          >
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {confirming && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-card border rounded-lg p-6 shadow-xl flex flex-col gap-4 w-80">
+            <p className="text-sm">
+              Are you sure you want to remove <strong>{taskName}</strong>?
+            </p>
+            <div className="flex gap-2 justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setConfirming(false)}
+                disabled={isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleDelete}
+                disabled={isPending}
+              >
+                {isPending ? "Deleting..." : "Confirm"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
@@ -84,7 +84,12 @@ interface TaskTableProps {
   canManageTasks: boolean;
 }
 
-export function TaskTable({ orgId, tasks, roles, canManageTasks }: TaskTableProps) {
+export function TaskTable({
+  orgId,
+  tasks,
+  roles,
+  canManageTasks,
+}: TaskTableProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [search, setSearch] = useState("");
@@ -140,7 +145,13 @@ export function TaskTable({ orgId, tasks, roles, canManageTasks }: TaskTableProp
 
   return (
     <>
-      <Toolbar actions={canManageTasks ? [{ label: "Create", href: `/orgs/${orgId}/tasks/new` }] : undefined}>
+      <Toolbar
+        actions={
+          canManageTasks
+            ? [{ label: "Create", href: `/orgs/${orgId}/tasks/new` }]
+            : undefined
+        }
+      >
         <Input
           aria-label="Search tasks by title"
           placeholder="Search by title..."
@@ -257,48 +268,50 @@ export function TaskTable({ orgId, tasks, roles, canManageTasks }: TaskTableProp
                     )}
                   </td>
                   {canManageTasks && (
-                  <td
-                    className="px-2 py-3 text-right"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7"
-                          disabled={isPending}
-                        >
-                          <MoreHorizontal className="h-4 w-4" />
-                          <span className="sr-only">Task actions</span>
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem
-                          onClick={() =>
-                            router.push(`/orgs/${orgId}/tasks/${task.id}/edit`)
-                          }
-                        >
-                          Edit
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() =>
-                            router.push(
-                              `/orgs/${orgId}/tasks/new?duplicateFrom=${task.id}`,
-                            )
-                          }
-                        >
-                          Duplicate
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          className="text-destructive focus:text-destructive"
-                          onClick={() => setDeleteTarget(task)}
-                        >
-                          Delete
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </td>
+                    <td
+                      className="px-2 py-3 text-right"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            disabled={isPending}
+                          >
+                            <MoreHorizontal className="h-4 w-4" />
+                            <span className="sr-only">Task actions</span>
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={() =>
+                              router.push(
+                                `/orgs/${orgId}/tasks/${task.id}/edit`,
+                              )
+                            }
+                          >
+                            Edit
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() =>
+                              router.push(
+                                `/orgs/${orgId}/tasks/new?duplicateFrom=${task.id}`,
+                              )
+                            }
+                          >
+                            Duplicate
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            className="text-destructive focus:text-destructive"
+                            onClick={() => setDeleteTarget(task)}
+                          >
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </td>
                   )}
                 </tr>
               ))}

--- a/app/(app)/orgs/[orgId]/tasks/new/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/new/page.tsx
@@ -1,3 +1,10 @@
+/**
+ * New Task page — `/orgs/[orgId]/tasks/new`
+ *
+ * Server component. Guards with `MANAGE_TASKS`. Fetches all org roles so the
+ * create form can pre-populate the eligibility selector, then renders the
+ * shared `TaskForm` in create mode.
+ */
 import { requireOrgPermissionPage } from "@/lib/authz";
 import { PermissionAction } from "@prisma/client";
 import { getRoles } from "@/lib/services/roles";

--- a/app/(app)/orgs/[orgId]/tasks/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/page.tsx
@@ -1,7 +1,11 @@
 import { getTasks } from "@/lib/services/tasks";
 import { getRoles } from "@/lib/services/roles";
 import { requireOrgMemberPage } from "@/lib/authz";
-import { getOrgMembership, memberHasPermission, getAuthUserId } from "@/lib/authz/_shared";
+import {
+  getOrgMembership,
+  memberHasPermission,
+  getAuthUserId,
+} from "@/lib/authz/_shared";
 import { PermissionAction } from "@prisma/client";
 import { TaskTable } from "./_components/task-table";
 
@@ -24,12 +28,23 @@ const TasksPage = async ({
   const userId = await getAuthUserId();
   const membership = userId ? await getOrgMembership(orgId, userId) : null;
   const canManageTasks = membership
-    ? await memberHasPermission(membership.id, orgId, PermissionAction.MANAGE_TASKS)
+    ? await memberHasPermission(
+        membership.id,
+        orgId,
+        PermissionAction.MANAGE_TASKS,
+      )
     : false;
 
   const [tasks, roles] = await Promise.all([getTasks(orgId), getRoles(orgId)]);
 
-  return <TaskTable orgId={orgId} tasks={tasks} roles={roles} canManageTasks={canManageTasks} />;
+  return (
+    <TaskTable
+      orgId={orgId}
+      tasks={tasks}
+      roles={roles}
+      canManageTasks={canManageTasks}
+    />
+  );
 };
 
 export default TasksPage;

--- a/app/(app)/orgs/[orgId]/tasks/task-form.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/task-form.tsx
@@ -15,9 +15,20 @@
  * In create mode, eligibility can only be set after the task exists (edit page).
  */
 
-import { useActionState, useEffect, useTransition, useState, useRef } from "react";
+import {
+  useActionState,
+  useEffect,
+  useTransition,
+  useState,
+  useRef,
+} from "react";
 import { toast } from "sonner";
-import { createTaskAction, updateTaskAction, addEligibilityAction, removeEligibilityAction } from "@/app/actions/tasks";
+import {
+  createTaskAction,
+  updateTaskAction,
+  addEligibilityAction,
+  removeEligibilityAction,
+} from "@/app/actions/tasks";
 import type { CreateTaskFormState, TaskFormState } from "@/app/actions/tasks";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -54,7 +65,13 @@ type TaskFormProps =
 
 type EligibilityPanelProps =
   | { mode: "create"; allRoles: Role[] }
-  | { mode: "edit"; orgId: string; taskId: string; allRoles: Role[]; eligibleRoles: Role[] };
+  | {
+      mode: "edit";
+      orgId: string;
+      taskId: string;
+      allRoles: Role[];
+      eligibleRoles: Role[];
+    };
 
 function EligibilityPanel(props: EligibilityPanelProps) {
   const isEdit = props.mode === "edit";
@@ -66,7 +83,8 @@ function EligibilityPanel(props: EligibilityPanelProps) {
 
   const roleIds = new Set(roles.map((r) => r.id));
   const filtered = props.allRoles.filter(
-    (r) => !roleIds.has(r.id) && r.name.toLowerCase().includes(search.toLowerCase()),
+    (r) =>
+      !roleIds.has(r.id) && r.name.toLowerCase().includes(search.toLowerCase()),
   );
 
   const add = (role: Role) => {
@@ -75,7 +93,11 @@ function EligibilityPanel(props: EligibilityPanelProps) {
     inputRef.current?.blur();
     if (isEdit) {
       startTransition(async () => {
-        const res = await addEligibilityAction(props.orgId, props.taskId, role.id);
+        const res = await addEligibilityAction(
+          props.orgId,
+          props.taskId,
+          role.id,
+        );
         if (res.ok) setRoles((prev) => [...prev, role]);
         else toast.error(res.error);
       });
@@ -87,7 +109,11 @@ function EligibilityPanel(props: EligibilityPanelProps) {
   const remove = (roleId: string) => {
     if (isEdit) {
       startTransition(async () => {
-        const res = await removeEligibilityAction(props.orgId, props.taskId, roleId);
+        const res = await removeEligibilityAction(
+          props.orgId,
+          props.taskId,
+          roleId,
+        );
         if (res.ok) setRoles((prev) => prev.filter((r) => r.id !== roleId));
         else toast.error(res.error);
       });
@@ -101,9 +127,10 @@ function EligibilityPanel(props: EligibilityPanelProps) {
       <span className="text-sm font-medium">Eligible roles</span>
 
       {/* Hidden inputs for create mode — picked up by FormData on submit */}
-      {!isEdit && roles.map((role) => (
-        <input key={role.id} type="hidden" name="roleIds" value={role.id} />
-      ))}
+      {!isEdit &&
+        roles.map((role) => (
+          <input key={role.id} type="hidden" name="roleIds" value={role.id} />
+        ))}
 
       {/* Searchable role dropdown */}
       <div className="relative">
@@ -111,7 +138,10 @@ function EligibilityPanel(props: EligibilityPanelProps) {
           ref={inputRef}
           placeholder="Search roles..."
           value={search}
-          onChange={(e) => { setSearch(e.target.value); setOpen(true); }}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setOpen(true);
+          }}
           onFocus={() => setOpen(true)}
           onBlur={() => setTimeout(() => setOpen(false), 150)}
           className="h-8 text-sm"
@@ -124,7 +154,10 @@ function EligibilityPanel(props: EligibilityPanelProps) {
                 key={role.id}
                 type="button"
                 className="w-full text-left px-3 py-2 text-sm hover:bg-accent flex items-center gap-2"
-                onMouseDown={(e) => { e.preventDefault(); add(role); }}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  add(role);
+                }}
               >
                 {role.color && (
                   <span
@@ -147,7 +180,9 @@ function EligibilityPanel(props: EligibilityPanelProps) {
       {/* Current role list */}
       <div className="rounded-md border min-h-20">
         {roles.length === 0 ? (
-          <p className="px-3 py-4 text-sm text-muted-foreground text-center">All roles eligible</p>
+          <p className="px-3 py-4 text-sm text-muted-foreground text-center">
+            All roles eligible
+          </p>
         ) : (
           <ul>
             {roles.map((role) => (
@@ -194,14 +229,22 @@ export function TaskForm(props: TaskFormProps) {
   const [state, dispatch, pending] = useActionState<
     CreateTaskFormState | TaskFormState,
     FormData
-  >(boundAction as (prev: CreateTaskFormState | TaskFormState, fd: FormData) => Promise<CreateTaskFormState | TaskFormState>, null);
+  >(
+    boundAction as (
+      prev: CreateTaskFormState | TaskFormState,
+      fd: FormData,
+    ) => Promise<CreateTaskFormState | TaskFormState>,
+    null,
+  );
 
   const [, startTransition] = useTransition();
 
   useEffect(() => {
     if (!state) return;
     if (!state.ok) {
-      const messages = Object.entries((state as { ok: false; errors: Record<string, string[]> }).errors)
+      const messages = Object.entries(
+        (state as { ok: false; errors: Record<string, string[]> }).errors,
+      )
         .flatMap(([field, errs]) =>
           field === "_" ? errs : errs.map((e) => `${field}: ${e}`),
         )
@@ -220,17 +263,24 @@ export function TaskForm(props: TaskFormProps) {
 
   const err = (field: string): string | null =>
     state && !state.ok
-      ? ((state as { ok: false; errors: Record<string, string[]> }).errors[field]?.[0] ?? null)
+      ? ((state as { ok: false; errors: Record<string, string[]> }).errors[
+          field
+        ]?.[0] ?? null)
       : null;
 
   const dv = isEdit ? props.defaultValues : null;
 
   return (
-    <form onSubmit={handleSubmit} className="grid grid-cols-1 lg:grid-cols-[1fr_280px] gap-8 items-start">
+    <form
+      onSubmit={handleSubmit}
+      className="grid grid-cols-1 lg:grid-cols-[1fr_280px] gap-8 items-start"
+    >
       {/* ── Left: task fields ─────────────────────────────────────────────── */}
       <div className="flex flex-col gap-5">
         {err("_") && (
-          <p role="alert" className="text-sm text-destructive">{err("_")}</p>
+          <p role="alert" className="text-sm text-destructive">
+            {err("_")}
+          </p>
         )}
 
         <div className="flex flex-col gap-1.5">
@@ -248,7 +298,9 @@ export function TaskForm(props: TaskFormProps) {
             aria-describedby={err("title") ? "title-error" : undefined}
           />
           {err("title") && (
-            <p id="title-error" className="text-xs text-destructive">{err("title")}</p>
+            <p id="title-error" className="text-xs text-destructive">
+              {err("title")}
+            </p>
           )}
         </div>
 
@@ -264,10 +316,14 @@ export function TaskForm(props: TaskFormProps) {
             defaultValue={dv?.description ?? undefined}
             className="border rounded-md px-3 py-2 text-sm bg-background resize-none focus:outline-none focus:ring-2 focus:ring-ring"
             aria-invalid={!!err("description")}
-            aria-describedby={err("description") ? "description-error" : undefined}
+            aria-describedby={
+              err("description") ? "description-error" : undefined
+            }
           />
           {err("description") && (
-            <p id="description-error" className="text-xs text-destructive">{err("description")}</p>
+            <p id="description-error" className="text-xs text-destructive">
+              {err("description")}
+            </p>
           )}
         </div>
 
@@ -285,15 +341,22 @@ export function TaskForm(props: TaskFormProps) {
             placeholder="e.g. 60"
             defaultValue={dv?.durationMin}
             aria-invalid={!!err("durationMin")}
-            aria-describedby={err("durationMin") ? "durationMin-error" : undefined}
+            aria-describedby={
+              err("durationMin") ? "durationMin-error" : undefined
+            }
           />
           {err("durationMin") && (
-            <p id="durationMin-error" className="text-xs text-destructive">{err("durationMin")}</p>
+            <p id="durationMin-error" className="text-xs text-destructive">
+              {err("durationMin")}
+            </p>
           )}
         </div>
 
         <div className="flex flex-col gap-1.5">
-          <label htmlFor="preferredStartTimeMin" className="text-sm font-medium">
+          <label
+            htmlFor="preferredStartTimeMin"
+            className="text-sm font-medium"
+          >
             Preferred start time (minutes since midnight)
           </label>
           <Input
@@ -305,10 +368,19 @@ export function TaskForm(props: TaskFormProps) {
             placeholder="e.g. 480 = 8:00 am"
             defaultValue={dv?.preferredStartTimeMin ?? undefined}
             aria-invalid={!!err("preferredStartTimeMin")}
-            aria-describedby={err("preferredStartTimeMin") ? "preferredStartTimeMin-error" : undefined}
+            aria-describedby={
+              err("preferredStartTimeMin")
+                ? "preferredStartTimeMin-error"
+                : undefined
+            }
           />
           {err("preferredStartTimeMin") && (
-            <p id="preferredStartTimeMin-error" className="text-xs text-destructive">{err("preferredStartTimeMin")}</p>
+            <p
+              id="preferredStartTimeMin-error"
+              className="text-xs text-destructive"
+            >
+              {err("preferredStartTimeMin")}
+            </p>
           )}
         </div>
 
@@ -324,10 +396,14 @@ export function TaskForm(props: TaskFormProps) {
             max={50}
             defaultValue={dv?.peopleRequired ?? 1}
             aria-invalid={!!err("peopleRequired")}
-            aria-describedby={err("peopleRequired") ? "peopleRequired-error" : undefined}
+            aria-describedby={
+              err("peopleRequired") ? "peopleRequired-error" : undefined
+            }
           />
           {err("peopleRequired") && (
-            <p id="peopleRequired-error" className="text-xs text-destructive">{err("peopleRequired")}</p>
+            <p id="peopleRequired-error" className="text-xs text-destructive">
+              {err("peopleRequired")}
+            </p>
           )}
         </div>
 
@@ -345,10 +421,14 @@ export function TaskForm(props: TaskFormProps) {
               placeholder="e.g. 7"
               defaultValue={dv?.minWaitDays ?? undefined}
               aria-invalid={!!err("minWaitDays")}
-              aria-describedby={err("minWaitDays") ? "minWaitDays-error" : undefined}
+              aria-describedby={
+                err("minWaitDays") ? "minWaitDays-error" : undefined
+              }
             />
             {err("minWaitDays") && (
-              <p id="minWaitDays-error" className="text-xs text-destructive">{err("minWaitDays")}</p>
+              <p id="minWaitDays-error" className="text-xs text-destructive">
+                {err("minWaitDays")}
+              </p>
             )}
           </div>
           <div className="flex flex-col gap-1.5">
@@ -364,10 +444,14 @@ export function TaskForm(props: TaskFormProps) {
               placeholder="e.g. 14"
               defaultValue={dv?.maxWaitDays ?? undefined}
               aria-invalid={!!err("maxWaitDays")}
-              aria-describedby={err("maxWaitDays") ? "maxWaitDays-error" : undefined}
+              aria-describedby={
+                err("maxWaitDays") ? "maxWaitDays-error" : undefined
+              }
             />
             {err("maxWaitDays") && (
-              <p id="maxWaitDays-error" className="text-xs text-destructive">{err("maxWaitDays")}</p>
+              <p id="maxWaitDays-error" className="text-xs text-destructive">
+                {err("maxWaitDays")}
+              </p>
             )}
           </div>
         </div>
@@ -377,8 +461,12 @@ export function TaskForm(props: TaskFormProps) {
 
         <Button type="submit" disabled={pending}>
           {pending
-            ? isEdit ? "Saving..." : "Creating..."
-            : isEdit ? "Save" : "Create Task"}
+            ? isEdit
+              ? "Saving..."
+              : "Creating..."
+            : isEdit
+              ? "Save"
+              : "Create Task"}
         </Button>
       </div>
 

--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -13,7 +13,14 @@
 
 import { PermissionAction } from "@prisma/client";
 import { requireOrgPermissionAction } from "@/lib/authz";
-import { createTask, deleteTask, updateTask, addTaskEligibility, removeTaskEligibility, setTaskEligibilities } from "@/lib/services/tasks";
+import {
+  createTask,
+  deleteTask,
+  updateTask,
+  addTaskEligibility,
+  removeTaskEligibility,
+  setTaskEligibilities,
+} from "@/lib/services/tasks";
 import { createTaskSchema, updateTaskSchema } from "@/lib/validators/task";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
@@ -62,7 +69,9 @@ export async function createTaskAction(
   }
 
   const task = await createTask(orgId, parsed.data);
-  const roleIds = formData.getAll("roleIds").filter((v): v is string => typeof v === "string");
+  const roleIds = formData
+    .getAll("roleIds")
+    .filter((v): v is string => typeof v === "string");
   if (roleIds.length > 0) {
     await setTaskEligibilities(orgId, task.id, roleIds);
   }
@@ -105,7 +114,10 @@ export async function updateTaskAction(
   _prev: TaskFormState,
   formData: FormData,
 ): Promise<TaskFormState> {
-  const authz = await requireOrgPermissionAction(orgId, PermissionAction.MANAGE_TASKS);
+  const authz = await requireOrgPermissionAction(
+    orgId,
+    PermissionAction.MANAGE_TASKS,
+  );
   if (!authz.ok) return { ok: false, errors: { _: ["Unauthorized"] } };
 
   const num = (key: string) => {
@@ -146,7 +158,10 @@ export async function addEligibilityAction(
   taskId: string,
   roleId: string,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
-  const authz = await requireOrgPermissionAction(orgId, PermissionAction.MANAGE_TASKS);
+  const authz = await requireOrgPermissionAction(
+    orgId,
+    PermissionAction.MANAGE_TASKS,
+  );
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
   const result = await addTaskEligibility(orgId, taskId, roleId);
   if (!result.ok) return { ok: false, error: result.error };
@@ -160,7 +175,10 @@ export async function removeEligibilityAction(
   taskId: string,
   roleId: string,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
-  const authz = await requireOrgPermissionAction(orgId, PermissionAction.MANAGE_TASKS);
+  const authz = await requireOrgPermissionAction(
+    orgId,
+    PermissionAction.MANAGE_TASKS,
+  );
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
   const result = await removeTaskEligibility(orgId, taskId, roleId);
   if (!result.ok) return { ok: false, error: result.error };

--- a/components/layout/toolbar.tsx
+++ b/components/layout/toolbar.tsx
@@ -28,23 +28,24 @@ export function Toolbar({ children, actions, rightChildren }: ToolbarProps) {
     <div className="-mx-6 -mt-6 mb-6 border-b bg-card px-6 py-2 flex items-center justify-between gap-3">
       <div className="flex items-center gap-3 flex-1">{children}</div>
 
-      {rightChildren ?? (actions && actions.length > 0 && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm" className="gap-1.5 shrink-0">
-              Actions
-              <ChevronDown className="h-3.5 w-3.5" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {actions.map((action) => (
-              <DropdownMenuItem key={action.href} asChild>
-                <Link href={action.href}>{action.label}</Link>
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      ))}
+      {rightChildren ??
+        (actions && actions.length > 0 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm" className="gap-1.5 shrink-0">
+                Actions
+                <ChevronDown className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {actions.map((action) => (
+                <DropdownMenuItem key={action.href} asChild>
+                  <Link href={action.href}>{action.label}</Link>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ))}
     </div>
   );
 }

--- a/components/layout/toolbar.tsx
+++ b/components/layout/toolbar.tsx
@@ -19,14 +19,16 @@ interface ToolbarProps {
   children?: ReactNode;
   /** Items for the "Actions ▼" dropdown on the right. */
   actions?: ToolbarAction[];
+  /** Arbitrary right-side content (replaces the actions dropdown when provided). */
+  rightChildren?: ReactNode;
 }
 
-export function Toolbar({ children, actions }: ToolbarProps) {
+export function Toolbar({ children, actions, rightChildren }: ToolbarProps) {
   return (
     <div className="-mx-6 -mt-6 mb-6 border-b bg-card px-6 py-2 flex items-center justify-between gap-3">
       <div className="flex items-center gap-3 flex-1">{children}</div>
 
-      {actions && actions.length > 0 && (
+      {rightChildren ?? (actions && actions.length > 0 && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="outline" size="sm" className="gap-1.5 shrink-0">
@@ -42,7 +44,7 @@ export function Toolbar({ children, actions }: ToolbarProps) {
             ))}
           </DropdownMenuContent>
         </DropdownMenu>
-      )}
+      ))}
     </div>
   );
 }

--- a/lib/services/roles.ts
+++ b/lib/services/roles.ts
@@ -74,7 +74,9 @@ const roleSelect = {
   isDeletable: true,
   isDefault: true,
   permissions: { select: { action: true } },
-  eligibleFor: { select: { task: { select: { id: true, name: true, color: true } } } },
+  eligibleFor: {
+    select: { task: { select: { id: true, name: true, color: true } } },
+  },
 } as const;
 
 /**

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -86,7 +86,8 @@ export async function updateTask(
       maxWaitDays: data.maxWaitDays ?? null,
     },
   });
-  if (count === 0) return { ok: false, error: "Task not found", code: "NOT_FOUND" };
+  if (count === 0)
+    return { ok: false, error: "Task not found", code: "NOT_FOUND" };
   return { ok: true, data: null };
 }
 
@@ -99,9 +100,15 @@ export async function addTaskEligibility(
   taskId: string,
   roleId: string,
 ): Promise<ServiceResult<null>> {
-  const task = await prisma.task.findFirst({ where: { id: taskId, orgId }, select: { id: true } });
+  const task = await prisma.task.findFirst({
+    where: { id: taskId, orgId },
+    select: { id: true },
+  });
   if (!task) return { ok: false, error: "Task not found", code: "NOT_FOUND" };
-  const role = await prisma.role.findFirst({ where: { id: roleId, orgId }, select: { id: true } });
+  const role = await prisma.role.findFirst({
+    where: { id: roleId, orgId },
+    select: { id: true },
+  });
   if (!role) return { ok: false, error: "Role not found", code: "NOT_FOUND" };
   await prisma.taskEligibility.upsert({
     where: { taskId_roleId: { taskId, roleId } },
@@ -119,7 +126,10 @@ export async function removeTaskEligibility(
   taskId: string,
   roleId: string,
 ): Promise<ServiceResult<null>> {
-  const task = await prisma.task.findFirst({ where: { id: taskId, orgId }, select: { id: true } });
+  const task = await prisma.task.findFirst({
+    where: { id: taskId, orgId },
+    select: { id: true },
+  });
   if (!task) return { ok: false, error: "Task not found", code: "NOT_FOUND" };
   await prisma.taskEligibility.deleteMany({ where: { taskId, roleId } });
   return { ok: true, data: null };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -11,3 +11,22 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Formats a Date as a short localised date string.
+ *
+ * Centralised so the locale can be updated in one place if i18n is
+ * introduced. Defaults to `"en-AU"` (dd/mm/yyyy) and UTC to keep
+ * server-rendered output stable regardless of the host's system timezone.
+ *
+ * @param date     - The Date to format.
+ * @param timeZone - IANA timezone string (default `"UTC"`).
+ * @param locale   - BCP 47 locale tag (default `"en-AU"`).
+ */
+export function formatDate(
+  date: Date,
+  timeZone = "UTC",
+  locale = "en-AU",
+): string {
+  return date.toLocaleDateString(locale, { timeZone });
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -28,5 +28,8 @@ export function formatDate(
   timeZone = "UTC",
   locale = "en-AU",
 ): string {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    throw new TypeError("formatDate: expected a valid Date");
+  }
   return date.toLocaleDateString(locale, { timeZone });
 }


### PR DESCRIPTION
… actions (edit/delete with confirmation)

- Add ViewTaskPage server component — any org member can view, MANAGE_TASKS holders see Actions dropdown
- Add TaskViewActions client component — Actions dropdown with Edit link and Delete with inline confirmation overlay
- Add EditTaskPage server component — guarded by MANAGE_TASKS, renders TaskForm in edit mode
- Add NewTaskPage server component — guarded by MANAGE_TASKS, renders TaskForm in create mode with role eligibility
- Add docstrings to all new pages and components
- Extend Toolbar with rightChildren prop for complex right-side content
- Update README: add task view/edit routes, update services/tasks and actions/tasks entries, update project structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task detail page showing full task info, eligible roles, and back link.
  * Task edit page for updating tasks (permission-protected) with role eligibility selector.
  * Actions dropdown on task view with Edit and Delete (confirmation + redirect).

* **Refactor**
  * Toolbar now supports custom right-side content for improved actions placement.

* **Documentation**
  * README updated with new task routes, pages, and server action/service summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->