### PR TITLE
fix: route guards, unauthorized toast, franchise redirect, center settings

### DIFF
--- a/app/(app)/orgs/[orgId]/franchisee/page.tsx
+++ b/app/(app)/orgs/[orgId]/franchisee/page.tsx
@@ -8,7 +8,7 @@ export default async function FranchiseePage({
   params: Promise<{ orgId: string }>;
 }) {
   const { orgId } = await params;
-  await requireParentOrgOwnerPage(orgId);
+  await requireParentOrgOwnerPage(orgId, { redirectTo: `/orgs/${orgId}` });
 
   const [franchisees, tokens] = await Promise.all([
     prisma.organization.findMany({

--- a/app/(app)/orgs/[orgId]/layout.tsx
+++ b/app/(app)/orgs/[orgId]/layout.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from "react";
+import { UnauthorizedToast } from "./unauthorized-toast";
+
+/**
+ * Org-scoped layout.
+ *
+ * Wraps all /orgs/[orgId]/** pages with the UnauthorizedToast component so any
+ * redirect that appends ?unauthorized=1 shows feedback regardless of which
+ * sub-page the user lands on.
+ */
+export default function OrgLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Suspense>
+        <UnauthorizedToast />
+      </Suspense>
+      {children}
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/settings/layout.tsx
+++ b/app/(app)/orgs/[orgId]/settings/layout.tsx
@@ -1,0 +1,23 @@
+import { PermissionAction } from "@prisma/client";
+import { requireOrgPermissionPage } from "@/lib/authz";
+
+/**
+ * Layout guard for all settings subroutes.
+ *
+ * Any request to /orgs/[orgId]/settings/** is blocked here if the caller
+ * doesn't hold MANAGE_SETTINGS. This means future settings pages don't need
+ * their own membership/permission boilerplate — they inherit this gate.
+ */
+export default async function SettingsLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ orgId: string }>;
+}) {
+  const { orgId } = await params;
+  await requireOrgPermissionPage(orgId, PermissionAction.MANAGE_SETTINGS, {
+    redirectTo: `/orgs/${orgId}`,
+  });
+  return <>{children}</>;
+}

--- a/app/(app)/orgs/[orgId]/settings/organization/settings-client.tsx
+++ b/app/(app)/orgs/[orgId]/settings/organization/settings-client.tsx
@@ -311,7 +311,7 @@ export function OrgSettingsClient({
   const { orgId } = useParams<{ orgId: string }>();
 
   return (
-    <div className="space-y-6 p-6 max-w-2xl">
+    <div className="space-y-6 p-6 max-w-2xl mx-auto">
       <OrgInfoForm org={org} orgId={orgId} />
       <TransferOwnershipSection
         orgId={orgId}

--- a/app/(app)/orgs/[orgId]/timetable/templates/layout.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/layout.tsx
@@ -1,0 +1,23 @@
+import { PermissionAction } from "@prisma/client";
+import { requireOrgPermissionPage } from "@/lib/authz";
+
+/**
+ * Layout guard for all timetable template subroutes.
+ *
+ * Any request to /orgs/[orgId]/timetable/templates/** is blocked here if the
+ * caller doesn't hold MANAGE_TIMETABLE. Individual pages (list, new, editor)
+ * don't need to repeat this check.
+ */
+export default async function TemplatesLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ orgId: string }>;
+}) {
+  const { orgId } = await params;
+  await requireOrgPermissionPage(orgId, PermissionAction.MANAGE_TIMETABLE, {
+    redirectTo: `/orgs/${orgId}/timetable`,
+  });
+  return <>{children}</>;
+}

--- a/app/(app)/orgs/[orgId]/unauthorized-toast.tsx
+++ b/app/(app)/orgs/[orgId]/unauthorized-toast.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { toast } from "sonner";
 
@@ -12,14 +12,16 @@ import { toast } from "sonner";
 export function UnauthorizedToast() {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const shownRef = useRef(false);
 
   useEffect(() => {
-    if (searchParams.get("unauthorized")) {
+    if (searchParams.get("unauthorized") && !shownRef.current) {
+      shownRef.current = true;
       toast.error("You don't have permission to access that page.");
       // Strip the param from the URL without adding to history
       const url = new URL(window.location.href);
       url.searchParams.delete("unauthorized");
-      router.replace(url.pathname + (url.search || ""));
+      router.replace(url.pathname + url.search + url.hash);
     }
   }, [searchParams, router]);
 

--- a/app/(app)/orgs/[orgId]/unauthorized-toast.tsx
+++ b/app/(app)/orgs/[orgId]/unauthorized-toast.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+/**
+ * Reads ?unauthorized=1 from the URL (placed there by requireOrgPermissionPage
+ * and requireParentOrgOwnerPage on redirect) and fires a Sonner error toast,
+ * then strips the param from history so a hard-refresh doesn't re-show it.
+ */
+export function UnauthorizedToast() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (searchParams.get("unauthorized")) {
+      toast.error("You don't have permission to access that page.");
+      // Strip the param from the URL without adding to history
+      const url = new URL(window.location.href);
+      url.searchParams.delete("unauthorized");
+      router.replace(url.pathname + (url.search || ""));
+    }
+  }, [searchParams, router]);
+
+  return null;
+}

--- a/lib/authz/page.ts
+++ b/lib/authz/page.ts
@@ -60,7 +60,12 @@ export async function requireParentOrgOwnerPage(
 ): Promise<{ userId: string }> {
   const userId = await getAuthUserId();
   if (!userId) redirect("/signin");
-  if (!(await isParentOrgOwner(orgId, userId))) redirect(redirectTo);
+  if (!(await isParentOrgOwner(orgId, userId)))
+    redirect(
+      redirectTo.includes("?")
+        ? `${redirectTo}&unauthorized=1`
+        : `${redirectTo}?unauthorized=1`,
+    );
   return { userId };
 }
 
@@ -83,8 +88,12 @@ export async function requireOrgPermissionPage(
   const membership = await getOrgMembership(orgId, userId);
   if (!membership) redirect(redirectTo ?? `/orgs/${orgId}`);
 
-  if (!(await memberHasPermission(membership.id, orgId, permission)))
-    redirect(redirectTo ?? `/orgs/${orgId}`);
+  if (!(await memberHasPermission(membership.id, orgId, permission))) {
+    const base = redirectTo ?? `/orgs/${orgId}`;
+    redirect(
+      base.includes("?") ? `${base}&unauthorized=1` : `${base}?unauthorized=1`,
+    );
+  }
 
   return { userId };
 }


### PR DESCRIPTION
## Summary

Addresses 5 issues in one batch.

---

### #62 — Settings layout guard
Added `app/(app)/orgs/[orgId]/settings/layout.tsx` that calls `requireOrgPermissionPage(orgId, MANAGE_SETTINGS)` with a redirect to the org overview. All current and future settings subroutes inherit this gate automatically.

### #63 — Templates layout guard
Added `app/(app)/orgs/[orgId]/timetable/templates/layout.tsx` that calls `requireOrgPermissionPage(orgId, MANAGE_TIMETABLE)` with a redirect to `/orgs/[orgId]/timetable`. All template subroutes inherit this.

### #64 — Franchise redirect to org overview
`requireParentOrgOwnerPage` in the franchisee page now redirects to `/orgs/[orgId]` instead of `/` when the user lacks permission.

### #61 — Unauthorized toast
- `requireOrgPermissionPage` and `requireParentOrgOwnerPage` in `lib/authz/page.ts` now append `?unauthorized=1` to the redirect URL on permission-denied.
- New `UnauthorizedToast` client component reads that param, fires a Sonner error toast, then strips the param.
- New `app/(app)/orgs/[orgId]/layout.tsx` mounts the toast so it fires on any org page.

### #79 — Settings/Organization not centered
Added `mx-auto` to the root div in `OrgSettingsClient`.

---

Closes #61, #62, #63, #64, #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an unauthorized-access toast that notifies users when they try to view pages they don’t have permission for.

* **Improvements**
  * Permission guards now consistently redirect to appropriate pages and surface the unauthorized notification when access is denied.
  * Settings panel layout centered for improved visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->