### PR TITLE
fix: UI quick wins (roles, members, tasks, org creation)

### DIFF
--- a/app/(app)/orgs/[orgId]/memberships/[memberId]/_components/member-toolbar-actions.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/[memberId]/_components/member-toolbar-actions.tsx
@@ -2,16 +2,8 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronDown } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -35,8 +27,9 @@ interface MemberToolbarActionsProps {
 }
 
 /**
- * Actions dropdown for toolbar on the member detail and edit pages.
- * Handles Restrict/Unrestrict and Delete with confirmation dialogs.
+ * Inline action buttons shown in the toolbar on the member detail and edit
+ * pages. Replaces the previous "Actions" dropdown with explicit buttons for
+ * Restrict/Unrestrict and Delete so actions are immediately discoverable.
  */
 export function MemberToolbarActions({
   orgId,
@@ -77,30 +70,25 @@ export function MemberToolbarActions({
 
   return (
     <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1.5"
-            disabled={isPending}
-          >
-            Actions <ChevronDown className="h-3.5 w-3.5" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem onSelect={() => setRestrictOpen(true)}>
-            {isRestricted ? "Unrestrict" : "Restrict"}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onSelect={() => setDeleteOpen(true)}
-            className="text-destructive focus:text-destructive"
-          >
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <div className="flex items-center gap-2 ml-auto">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={isPending}
+          onClick={() => setRestrictOpen(true)}
+        >
+          {isRestricted ? "Unrestrict" : "Restrict"}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={isPending}
+          onClick={() => setDeleteOpen(true)}
+          className="text-destructive hover:text-destructive border-destructive/30 hover:bg-destructive/10"
+        >
+          Delete
+        </Button>
+      </div>
 
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <AlertDialogContent>

--- a/app/(app)/orgs/[orgId]/memberships/_components/member-form.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/member-form.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { RolePicker } from "./role-picker";
@@ -62,7 +63,6 @@ export function MemberForm({
   function handleSubmit() {
     const next: Record<string, string> = {};
     if (mode === "create" && !email.trim()) next.email = "Email is required";
-    if (roleIds.length === 0) next.roles = "At least one role is required";
     if (Object.keys(next).length > 0) {
       setErrors(next);
       return;
@@ -94,7 +94,8 @@ export function MemberForm({
           setErrors({ _: result.error });
           return;
         }
-        router.refresh();
+        toast.success(`${name ?? "Member"} updated.`);
+        router.push(`/orgs/${orgId}/memberships/${userId}`);
       }
     });
   }
@@ -171,9 +172,7 @@ export function MemberForm({
 
       {/* Roles */}
       <div className="flex flex-col gap-2">
-        <label className="text-sm font-medium">
-          Roles <span className="text-destructive">*</span>
-        </label>
+        <label className="text-sm font-medium">Roles</label>
         <RolePicker
           allRoles={allRoles}
           selectedIds={roleIds}

--- a/app/(app)/orgs/[orgId]/settings/roles/_components/role-form.tsx
+++ b/app/(app)/orgs/[orgId]/settings/roles/_components/role-form.tsx
@@ -126,7 +126,7 @@ export function RoleForm({ orgId, role, tasks }: RoleFormProps) {
             checked={useColor}
             onChange={(e) => setUseColor(e.target.checked)}
             disabled={isPending}
-            className="h-4 w-4 rounded"
+            className="h-4 w-4 rounded accent-primary border border-input bg-background cursor-pointer"
           />
           Use custom color
         </label>
@@ -155,7 +155,7 @@ export function RoleForm({ orgId, role, tasks }: RoleFormProps) {
                 checked={permissions.includes(action)}
                 onChange={() => togglePermission(action)}
                 disabled={isPending}
-                className="h-4 w-4 rounded"
+                className="h-4 w-4 rounded accent-primary border border-input bg-background cursor-pointer shrink-0"
               />
               {formatPermissionLabel(action)}
             </label>

--- a/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
@@ -407,7 +407,7 @@ export function TaskTable({
                     if (e.target !== e.currentTarget) return;
                     router.push(`/orgs/${orgId}/tasks/${task.id}`);
                   }}
-                  className="border-b last:border-0 hover:bg-primary/5 cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                  className="border-b last:border-0 hover:bg-primary/5 active:bg-muted cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
                 >
                   <td className="px-4 py-3 font-medium">
                     <div className="flex items-center gap-2">

--- a/app/(app)/orgs/[orgId]/tasks/task-form.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/task-form.tsx
@@ -22,6 +22,7 @@ import {
   useState,
   useRef,
 } from "react";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import {
   createTaskAction,
@@ -248,6 +249,7 @@ function EligibilityPanel(props: EligibilityPanelProps) {
  */
 export function TaskForm(props: TaskFormProps) {
   const isEdit = props.mode === "edit";
+  const router = useRouter();
 
   const dv = isEdit ? props.defaultValues : null;
 
@@ -294,9 +296,10 @@ export function TaskForm(props: TaskFormProps) {
         .join("\n");
       toast.error(messages || "Something went wrong");
     } else if (isEdit) {
-      toast.success("Task saved");
+      toast.success("Task saved.");
+      router.push(`/orgs/${props.orgId}/tasks/${props.taskId}`);
     }
-  }, [state, isEdit]);
+  }, [state, isEdit, router, props]);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/app/(app)/orgs/new/new-org-client.tsx
+++ b/app/(app)/orgs/new/new-org-client.tsx
@@ -58,7 +58,7 @@ function ScheduleFields({
 
   return (
     <>
-      <div className="flex gap-3">
+      <div className="flex flex-col sm:flex-row gap-3">
         <div className="flex flex-col gap-1.5 flex-1">
           <label className="text-sm font-medium" htmlFor="timezone">
             Time Zone
@@ -82,7 +82,7 @@ function ScheduleFields({
         </div>
       </div>
 
-      <div className="flex gap-3">
+      <div className="flex flex-col sm:flex-row gap-3">
         <div className="flex flex-col gap-1.5 flex-1">
           <label className="text-sm font-medium" htmlFor="openTime">
             Start Time

--- a/app/actions/memberships.ts
+++ b/app/actions/memberships.ts
@@ -38,8 +38,18 @@ export async function sendMemberInviteAction(
     return { ok: false, error: issue.message, field };
   }
 
-  const { email: rawEmail, roleIds, workingDays } = parsed.data;
+  const { email: rawEmail, workingDays } = parsed.data;
+  let { roleIds } = parsed.data;
   const email = rawEmail.trim().toLowerCase();
+
+  // If no roles selected, fall back to the org's default member role.
+  if (roleIds.length === 0) {
+    const defaultRole = await prisma.role.findFirst({
+      where: { orgId, isDefault: true },
+      select: { id: true },
+    });
+    if (defaultRole) roleIds = [defaultRole.id];
+  }
 
   const recipient = await prisma.user.findUnique({
     where: { email },

--- a/app/actions/orgs.ts
+++ b/app/actions/orgs.ts
@@ -123,6 +123,9 @@ export async function transferOrgOwnership(
 
   try {
     await transferOrgOwnershipService(orgId, userId, parsed.data.newOwnerId);
+    // Revalidate the org's own pages as well as the root layout so both the
+    // outgoing and incoming owner see updated sidebar state immediately.
+    revalidatePath(`/orgs/${orgId}`, "layout");
     revalidatePath("/", "layout");
     redirect("/");
   } catch (err) {

--- a/lib/services/orgs.ts
+++ b/lib/services/orgs.ts
@@ -24,8 +24,10 @@ import {
  *  from the enum so it stays in sync whenever the schema adds new actions. */
 const ownerPermissions = Object.values(PermissionAction);
 
-/** Permissions granted to the default Member role on a fresh org. */
-const memberPermissions: PermissionAction[] = [PermissionAction.VIEW_TIMETABLE];
+/** Permissions granted to the default Member role on a fresh org.
+ *  Intentionally empty — admins assign permissions explicitly via Roles.
+ */
+const memberPermissions: PermissionAction[] = [];
 
 /**
  * Creates the default Owner + Member roles for a brand-new standalone org
@@ -70,8 +72,13 @@ async function bootstrapRoles(tx: Tx, orgId: string, userId: string) {
     data: { orgId, userId, workingDays: [] },
   });
 
-  await tx.memberRole.create({
-    data: { membershipId: membership.id, roleId: ownerRole.id },
+  // Creator receives both Owner (for permissions) and Default Member
+  // (so they appear in the members list like everyone else).
+  await tx.memberRole.createMany({
+    data: [
+      { membershipId: membership.id, roleId: ownerRole.id },
+      { membershipId: membership.id, roleId: memberRole.id },
+    ],
   });
 
   return { ownerRole, memberRole, membership };

--- a/lib/validators/membership.ts
+++ b/lib/validators/membership.ts
@@ -14,7 +14,7 @@ export const deleteMembershipSchema = z.object({
 
 export const sendMemberInviteSchema = z.object({
   email: z.string().email("Invalid email address").min(1, "Email is required"),
-  roleIds: z.array(z.string().cuid()).min(1, "At least one role is required"),
+  roleIds: z.array(z.string().cuid()).default([]),
   workingDays: z.array(
     z.enum(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]),
   ),


### PR DESCRIPTION
## Summary

Closes #67 — Default member role starts with zero permissions (not VIEW_TIMETABLE)
Closes #66 — Org creator assigned both Owner + Default Member roles at creation
Closes #87 — Invite role is now optional; falls back to the org's default member role
Closes #83 — Role form checkboxes use `accent-primary` + `border` so they're visible on any background
Closes #73 — Task list rows show `active:bg-muted` press-highlight feedback on tap/click
Closes #85 — Member edit saves redirect to the member's profile page and show a success toast
Closes #86 — Member toolbar "Actions" dropdown replaced with explicit Restrict/Delete buttons
Closes #65 — Create org/franchise schedule fields stack vertically on mobile
Closes #74 — Task edit form navigates back to the task detail page on success
Closes #75 — Verified all toolbar action buttons are correctly right-aligned (no code changes needed)
Closes #88 — `transferOrgOwnership` now revalidates org-scoped paths before redirect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Member invitations now support optional role selection with automatic default role assignment.

* **Improvements**
  * Replaced member actions dropdown menu with direct inline buttons for faster access.
  * Added success notifications and improved navigation flow after member and task updates.
  * Enhanced responsive layouts for schedule fields on mobile devices.
  * Added visual feedback for active table row interactions.

* **Style**
  * Updated checkbox and table row styling for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->