### PR TITLE
fix: notifications and mobile sidebar

### DIFF
--- a/app/actions/invites.ts
+++ b/app/actions/invites.ts
@@ -16,16 +16,20 @@ import { auth } from "@/auth";
 import { revalidatePath } from "next/cache";
 import {
   markInvitesSeen,
+  markNotificationsSeen,
   acceptMemberInvite,
   declineMemberInvite,
   declineFranchiseInvite,
 } from "@/lib/services/invites";
 
-/** Marks all unseen invites for the current user as seen. No-ops when not signed in. */
+/** Marks all unseen invites and notifications for the current user as seen. */
 export async function markInvitesSeenAction(): Promise<void> {
   const session = await auth();
   if (!session?.user?.id) return;
-  await markInvitesSeen(session.user.id);
+  await Promise.all([
+    markInvitesSeen(session.user.id),
+    markNotificationsSeen(session.user.id),
+  ]);
 }
 
 /**

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -13,6 +13,8 @@ import { NotificationPanel } from "@/components/layout/notification-panel";
 import {
   getInvitesForUser,
   getUnseenInviteCount,
+  getNotificationsForUser,
+  getUnseenNotificationCount,
 } from "@/lib/services/invites";
 import {
   DropdownMenu,
@@ -54,15 +56,17 @@ export const NavBar = async () => {
         })
     : [];
 
-  const [invites, unseenCount] = user?.id
+  const [invites, unseenCount, notifications, unseenNotifCount] = user?.id
     ? await Promise.all([
         getInvitesForUser(user.id),
         getUnseenInviteCount(user.id),
+        getNotificationsForUser(user.id),
+        getUnseenNotificationCount(user.id),
       ]).catch((error) => {
         console.error("Failed to load invites for navbar", error);
-        return [[], 0] as [never[], number];
+        return [[], 0, [], 0] as [never[], number, never[], number];
       })
-    : [[], 0];
+    : [[], 0, [], 0];
 
   return (
     <header className="h-14 border-b border-border bg-card flex items-center justify-between px-4">
@@ -79,7 +83,7 @@ export const NavBar = async () => {
       {/* Right: notifications and user menu */}
       <div className="flex items-center gap-2">
         {/* Notification bell */}
-        <NotificationPanel invites={invites} unseenCount={unseenCount} />
+        <NotificationPanel invites={invites} unseenCount={unseenCount + unseenNotifCount} notifications={notifications} />
 
         {/* User avatar — only rendered when a user is signed in */}
         {user && (

--- a/components/layout/notification-panel.tsx
+++ b/components/layout/notification-panel.tsx
@@ -320,35 +320,6 @@ function NotificationList({
     </div>
   );
 }
-        </button>
-      </div>
-
-      {/* Scrollable list */}
-      <div className="flex-1 overflow-y-auto divide-y divide-border/60">
-        {visible.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full py-12 gap-2 text-muted-foreground">
-            <Bell className="size-8 opacity-20" />
-            <p className="text-sm">
-              {onlyUnread ? "No unread notifications" : "No notifications"}
-            </p>
-          </div>
-        ) : (
-          visible.map((invite) => (
-            <InviteCard key={invite.id} invite={invite} onAction={onAction} />
-          ))
-        )}
-      </div>
-
-      {/* Footer */}
-      <div className="border-t px-4 py-2.5">
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          <History className="size-3" />
-          History
-        </div>
-      </div>
-    </div>
-  );
-}
 
 export function NotificationPanel({
   invites,

--- a/components/layout/notification-panel.tsx
+++ b/components/layout/notification-panel.tsx
@@ -41,7 +41,7 @@ import {
   declineMemberInviteAction,
   declineFranchiseInviteAction,
 } from "@/app/actions/invites";
-import type { InviteItem } from "@/lib/services/invites";
+import type { InviteItem, NotificationItem } from "@/lib/services/invites";
 
 function formatRelativeTime(date: Date): string {
   const now = Date.now();
@@ -53,6 +53,30 @@ function formatRelativeTime(date: Date): string {
   if (mins < 60) return `${mins}m ago`;
   if (hours < 24) return `${hours}h ago`;
   return `${days}d ago`;
+}
+
+function NotificationCard({ notification }: { notification: NotificationItem }) {
+  return (
+    <div
+      className={cn(
+        "relative flex gap-3 px-4 py-3.5 transition-colors",
+        !notification.seenAt && "bg-primary/3",
+      )}
+    >
+      {!notification.seenAt && (
+        <span className="absolute left-1.5 top-1/2 -translate-y-1/2 h-1.5 w-1.5 rounded-full bg-primary" />
+      )}
+      <div className="shrink-0 h-9 w-9 rounded-full bg-emerald-500/15 flex items-center justify-center text-emerald-600 dark:text-emerald-400 ring-1 ring-border">
+        <Check className="size-4" />
+      </div>
+      <div className="flex-1 min-w-0 space-y-0.5">
+        <p className="text-sm leading-snug">{notification.message}</p>
+        <span className="text-[10px] text-muted-foreground">
+          {formatRelativeTime(notification.createdAt)}
+        </span>
+      </div>
+    </div>
+  );
 }
 
 function InviteCard({
@@ -222,16 +246,31 @@ function InviteCard({
 
 function NotificationList({
   invites,
+  notifications,
   onAction,
 }: {
   invites: InviteItem[];
+  notifications: NotificationItem[];
   onAction: () => void;
 }) {
   const [onlyUnread, setOnlyUnread] = useState(false);
 
-  const visible = onlyUnread
+  const visibleInvites = onlyUnread
     ? invites.filter((i) => !i.seenAt && i.status === "PENDING")
     : invites;
+
+  const visibleNotifs = onlyUnread
+    ? notifications.filter((n) => !n.seenAt)
+    : notifications;
+
+  // Merge and sort by date descending so all items appear in chronological order.
+  type AnyItem =
+    | { kind: "invite"; data: InviteItem }
+    | { kind: "notif"; data: NotificationItem };
+  const merged: AnyItem[] = [
+    ...visibleInvites.map((i) => ({ kind: "invite" as const, data: i })),
+    ...visibleNotifs.map((n) => ({ kind: "notif" as const, data: n })),
+  ].sort((a, b) => new Date(b.data.createdAt).getTime() - new Date(a.data.createdAt).getTime());
 
   return (
     <div className="flex flex-col h-full">
@@ -248,6 +287,39 @@ function NotificationList({
           )}
         >
           Unread only
+        </button>
+      </div>
+
+      {/* Scrollable list */}
+      <div className="flex-1 overflow-y-auto divide-y divide-border/60">
+        {merged.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full py-12 gap-2 text-muted-foreground">
+            <Bell className="size-8 opacity-20" />
+            <p className="text-sm">
+              {onlyUnread ? "No unread notifications" : "No notifications"}
+            </p>
+          </div>
+        ) : (
+          merged.map((item) =>
+            item.kind === "notif" ? (
+              <NotificationCard key={`n-${item.data.id}`} notification={item.data} />
+            ) : (
+              <InviteCard key={`i-${item.data.id}`} invite={item.data} onAction={onAction} />
+            ),
+          )
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="border-t px-4 py-2.5">
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <History className="size-3" />
+          History
+        </div>
+      </div>
+    </div>
+  );
+}
         </button>
       </div>
 
@@ -281,9 +353,11 @@ function NotificationList({
 export function NotificationPanel({
   invites,
   unseenCount,
+  notifications,
 }: {
   invites: InviteItem[];
   unseenCount: number;
+  notifications: NotificationItem[];
 }) {
   const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
@@ -291,9 +365,12 @@ export function NotificationPanel({
 
   async function handleOpen(next: boolean) {
     setOpen(next);
-    if (next && unseenCount > 0) {
-      await markInvitesSeenAction();
+    if (next) {
+      // Always refresh so any new invites are fetched from the server.
       router.refresh();
+      if (unseenCount > 0) {
+        await markInvitesSeenAction();
+      }
     }
   }
 
@@ -323,15 +400,15 @@ export function NotificationPanel({
       <Sheet open={open} onOpenChange={handleOpen}>
         <SheetTrigger asChild>{BellButton}</SheetTrigger>
         <SheetContent
-          side="bottom"
-          className="h-[85dvh] p-0 flex flex-col rounded-t-2xl"
+          side="top"
+          className="h-[85dvh] p-0 flex flex-col rounded-b-2xl"
         >
           <SheetHeader className="sr-only">
             <SheetTitle>Notifications</SheetTitle>
           </SheetHeader>
           {/* Drag handle */}
           <div className="w-10 h-1 rounded-full bg-muted-foreground/20 mx-auto mt-3 mb-0 shrink-0" />
-          <NotificationList invites={invites} onAction={handleAction} />
+          <NotificationList invites={invites} notifications={notifications} onAction={handleAction} />
         </SheetContent>
       </Sheet>
     );
@@ -345,7 +422,7 @@ export function NotificationPanel({
         sideOffset={8}
         className="w-95 h-120 p-0 flex flex-col overflow-hidden shadow-xl"
       >
-        <NotificationList invites={invites} onAction={handleAction} />
+        <NotificationList invites={invites} notifications={notifications} onAction={handleAction} />
       </PopoverContent>
     </Popover>
   );

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -183,6 +183,13 @@ export function AppSidebar() {
   const closeSidebar = () => {
     if (isMobile) setOpenMobile(false);
   };
+  // Keep the sidebar open when navigating within the same org (org ↔ settings).
+  // Only close it when the destination is outside the current org context.
+  const handleNavClick = (url: string) => {
+    if (!isMobile) return;
+    if (orgId && url.startsWith(`/orgs/${orgId}`)) return;
+    setOpenMobile(false);
+  };
   const [parentOwnerStatus, setParentOwnerStatus] = useState<{
     orgId: string | null;
     isParentOwner: boolean;
@@ -274,7 +281,7 @@ export function AppSidebar() {
                           <span>{item.title}</span>
                         </>
                       ) : (
-                        <Link href={item.url} onClick={closeSidebar}>
+                        <Link href={item.url} onClick={() => handleNavClick(item.url)}>
                           <item.icon />
                           <span>{item.title}</span>
                         </Link>
@@ -365,7 +372,7 @@ export function AppSidebar() {
               {footerItems.map((item) => (
                 <SidebarMenuItem key={item.title}>
                   <SidebarMenuButton asChild isActive={isActiveItem(item.url)}>
-                    <Link href={item.url} onClick={closeSidebar}>
+                    <Link href={item.url} onClick={() => handleNavClick(item.url)}>
                       <item.icon />
                       <span>{item.title}</span>
                     </Link>

--- a/lib/services/invites.ts
+++ b/lib/services/invites.ts
@@ -299,16 +299,21 @@ export async function acceptMemberInvite(
 
   // Notify the inviter that their invite was accepted.
   if (invite.invitedById) {
-    const acceptingUser = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { name: true },
-    });
-    await prisma.notification.create({
-      data: {
-        userId: invite.invitedById,
-        message: `${acceptingUser?.name ?? "Someone"} accepted your invitation to ${invite.orgName}.`,
-      },
-    });
+    try {
+      const acceptingUser = await prisma.user.findUnique({
+        where: { id: userId },
+        select: { name: true },
+      });
+      await prisma.notification.create({
+        data: {
+          userId: invite.invitedById,
+          message: `${acceptingUser?.name ?? "Someone"} accepted your invitation to ${invite.orgName}.`,
+        },
+      });
+    } catch (error) {
+      // Log the error but don't fail the invite acceptance
+      console.error("Failed to create notification for invite acceptance:", error);
+    }
   }
 
   return { ok: true, data: null };

--- a/lib/services/invites.ts
+++ b/lib/services/invites.ts
@@ -17,6 +17,13 @@ export type InviteItem = {
   metadata: unknown;
 };
 
+export type NotificationItem = {
+  id: string;
+  message: string;
+  seenAt: Date | null;
+  createdAt: Date;
+};
+
 /**
  * Returns all invites visible in the notification panel for a user:
  * - All PENDING invites (always shown)
@@ -78,6 +85,39 @@ export async function getUnseenInviteCount(userId: string): Promise<number> {
 export async function markInvitesSeen(userId: string): Promise<void> {
   await prisma.invite.updateMany({
     where: { recipientId: userId, seenAt: null },
+    data: { seenAt: new Date() },
+  });
+}
+
+/**
+ * Returns in-app notifications for a user (newest first), limited to 30.
+ */
+export async function getNotificationsForUser(
+  userId: string,
+): Promise<NotificationItem[]> {
+  return prisma.notification.findMany({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+    take: 30,
+    select: { id: true, message: true, seenAt: true, createdAt: true },
+  });
+}
+
+/**
+ * Returns the count of unseen notifications for a user.
+ */
+export async function getUnseenNotificationCount(
+  userId: string,
+): Promise<number> {
+  return prisma.notification.count({
+    where: { userId, seenAt: null },
+  });
+}
+
+/** Marks all unseen notifications for a user as seen. */
+export async function markNotificationsSeen(userId: string): Promise<void> {
+  await prisma.notification.updateMany({
+    where: { userId, seenAt: null },
     data: { seenAt: new Date() },
   });
 }
@@ -255,6 +295,20 @@ export async function acceptMemberInvite(
         };
     }
     throw e;
+  }
+
+  // Notify the inviter that their invite was accepted.
+  if (invite.invitedById) {
+    const acceptingUser = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { name: true },
+    });
+    await prisma.notification.create({
+      data: {
+        userId: invite.invitedById,
+        message: `${acceptingUser?.name ?? "Someone"} accepted your invitation to ${invite.orgName}.`,
+      },
+    });
   }
 
   return { ok: true, data: null };

--- a/prisma/migrations/20260417031022_add_notifications/migration.sql
+++ b/prisma/migrations/20260417031022_add_notifications/migration.sql
@@ -1,6 +1,3 @@
--- DropIndex
-DROP INDEX "invite_pending_unique";
-
 -- CreateTable
 CREATE TABLE "Notification" (
     "id" TEXT NOT NULL,
@@ -17,3 +14,8 @@ CREATE INDEX "Notification_userId_idx" ON "Notification"("userId");
 
 -- AddForeignKey
 ALTER TABLE "Notification" ADD CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Recreate partial unique index for pending invites
+-- This index ensures that a user cannot have multiple pending invites for the same org and type
+-- Note: This is a raw SQL index that prisma migrate may attempt to drop in future migrations
+CREATE UNIQUE INDEX "invite_pending_unique" ON "Invite"("orgId", "recipientId", "type") WHERE "status" = 'PENDING';

--- a/prisma/migrations/20260417031022_add_notifications/migration.sql
+++ b/prisma/migrations/20260417031022_add_notifications/migration.sql
@@ -1,0 +1,19 @@
+-- DropIndex
+DROP INDEX "invite_pending_unique";
+
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "seenAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Notification_userId_idx" ON "Notification"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,6 +107,7 @@ model User {
   ownedOrgs                 Organization[] @relation("OrgOwner")
   sentInvites               Invite[]       @relation("SentInvites")
   receivedInvites           Invite[]       @relation("ReceivedInvites")
+  receivedNotifications     Notification[] @relation("ReceivedNotifications")
 
   accounts      Account[]
   sessions      Session[]
@@ -489,4 +490,27 @@ model Invite {
   @@index([orgId])
   @@index([recipientId])
   @@index([invitedById])
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NOTIFICATIONS
+// Simple in-app notification records created by server-side events.
+// ─────────────────────────────────────────────────────────────────────────────
+
+model Notification {
+  id        String   @id @default(cuid())
+
+  /// The user who should see this notification.
+  userId    String
+  user      User     @relation("ReceivedNotifications", fields: [userId], references: [id], onDelete: Cascade)
+
+  /// Short human-readable message, e.g. "Alice accepted your invitation to Acme Corp."
+  message   String
+
+  /// When the user opened/dismissed the notification.
+  seenAt    DateTime?
+
+  createdAt DateTime @default(now())
+
+  @@index([userId])
 }


### PR DESCRIPTION
## Summary

Closes #80 — Mobile notification panel now anchors at the top (Sheet side=top, rounded-b-2xl)
Closes #81 — Bell click always calls `router.refresh()` to pick up newly arrived invites
Closes #82 — Inviting user gets an in-app notification when their member invite is accepted (new `Notification` model + Prisma migration)
Closes #84 — Mobile sidebar stays open when navigating within the same org (org ↔ settings); only closes when leaving the org context entirely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app notifications: users receive and view notifications with message, timestamp, and read status.
  * Unified notification panel: invites and notifications are merged, sortable by date, with unread indicators and a combined unseen badge count.

* **Improvements**
  * Opening the panel refreshes content and marks items seen when applicable.
  * Mobile panel layout and sidebar navigation behavior improved for better UX when navigating within an organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->