### PR TITLE
fix: timetable bugs (#68–#72, #76, #77)

### DIFF
--- a/app/(app)/orgs/[orgId]/timetable/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/page.tsx
@@ -117,6 +117,43 @@ export default async function TimetablePage({
     );
   }
 
+  // Role-based visibility (#72): if the member does not hold MANAGE_TIMETABLE
+  // or VIEW_TIMETABLE, only show tasks that are either unassigned to any role
+  // or assigned to at least one of the member's roles.
+  const canViewAll = canManageTimetable || (currentMembership
+    ? await memberHasPermission(currentMembership.id, orgId, PermissionAction.VIEW_TIMETABLE)
+    : false);
+
+  if (!canViewAll && currentMembership) {
+    // Gather all role IDs that the current member holds.
+    const memberRoleRows = await prisma.memberRole.findMany({
+      where: { membershipId: currentMembership.id },
+      select: { roleId: true },
+    });
+    const memberRoleIds = new Set(memberRoleRows.map((r) => r.roleId));
+
+    // Tasks with NO eligibility rows are visible to everyone.
+    // Tasks WITH eligibility rows are only visible if the member has ≥1 matching role.
+    const eligibilities = await prisma.taskEligibility.findMany({
+      where: { task: { orgId } },
+      select: { taskId: true, roleId: true },
+    });
+    const taskEligMap = new Map<string, Set<string>>();
+    for (const e of eligibilities) {
+      if (!taskEligMap.has(e.taskId)) taskEligMap.set(e.taskId, new Set());
+      taskEligMap.get(e.taskId)!.add(e.roleId);
+    }
+
+    filteredInstances = filteredInstances.filter((inst) => {
+      const roles = taskEligMap.get(inst.taskId);
+      if (!roles || roles.size === 0) return true; // open task — visible to all
+      for (const roleId of roles) {
+        if (memberRoleIds.has(roleId)) return true;
+      }
+      return false;
+    });
+  }
+
   // Map taskId → role color (use filtered role when active, else first eligible)
   const taskRoleColorMap = new Map(
     tasks.map((t) => {

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
@@ -149,6 +149,19 @@ function statusDotClass(status: string): string {
   }
 }
 
+function statusRowClass(status: string): string {
+  switch (status) {
+    case "IN_PROGRESS":
+      return "border-l-2 border-l-amber-400";
+    case "DONE":
+      return "border-l-2 border-l-green-500";
+    case "SKIPPED":
+      return "border-l-2 border-l-red-400";
+    default:
+      return "border-l-2 border-l-transparent";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // CalendarEditPopup
 // ---------------------------------------------------------------------------
@@ -185,6 +198,7 @@ function CalendarEditPopup({
   onRefresh,
 }: CalendarEditPopupProps) {
   const [startTime, setStartTime] = useState(minToHHMM(instance.startTimeMin));
+  const [date, setDate] = useState(instance.date);
   const [status, setStatus] = useState<ClientTimetableInstance["status"]>(
     instance.status,
   );
@@ -211,6 +225,7 @@ function CalendarEditPopup({
           : await updateTimetableEntryAction(orgId, instance.id, {
               startTimeMin: parsedStart,
               status,
+              dateStr: date !== instance.date ? date : undefined,
             })
         : await updateTimetableEntryStatusAction(orgId, instance.id, status);
       if (!result.ok) {
@@ -281,26 +296,9 @@ function CalendarEditPopup({
           <DialogTitle>{instance.task.title}</DialogTitle>
         </DialogHeader>
 
-        {canManage && (
-          <div className="flex flex-col gap-1">
-            <label className="text-xs text-muted-foreground font-medium">
-              Start time
-            </label>
-            <Input
-              type="time"
-              value={startTime}
-              onChange={(e) => setStartTime(e.target.value)}
-              className="h-8 w-32 text-sm"
-            />
-            <p className="text-xs text-muted-foreground">
-              {startTime} → {endMin == null ? "--:--" : minToHHMM(endMin)} ·{" "}
-              {instance.task.durationMin} min
-            </p>
-          </div>
-        )}
-
+        {/* Status — always shown first so it's the primary action (#76) */}
         <div className="flex flex-col gap-1">
-          <label className="text-xs text-muted-foreground font-weight">
+          <label className="text-xs text-muted-foreground font-medium">
             Status
           </label>
           <select
@@ -309,6 +307,7 @@ function CalendarEditPopup({
               setStatus(e.target.value as ClientTimetableInstance["status"])
             }
             className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+            autoFocus
           >
             <option value="TODO">To Do</option>
             <option value="IN_PROGRESS">In Progress</option>
@@ -316,6 +315,40 @@ function CalendarEditPopup({
             <option value="SKIPPED">Skipped</option>
           </select>
         </div>
+
+        {canManage && (
+          <>
+            {/* Date picker (#70) */}
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-muted-foreground font-medium">
+                Date
+              </label>
+              <Input
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                className="h-8 w-full text-sm"
+              />
+            </div>
+
+            {/* Time */}
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-muted-foreground font-medium">
+                Start time
+              </label>
+              <Input
+                type="time"
+                value={startTime}
+                onChange={(e) => setStartTime(e.target.value)}
+                className="h-8 w-32 text-sm"
+              />
+              <p className="text-xs text-muted-foreground">
+                {startTime} → {endMin == null ? "--:--" : minToHHMM(endMin)} ·{" "}
+                {instance.task.durationMin} min
+              </p>
+            </div>
+          </>
+        )}
 
         {canManage && (
           <div className="flex flex-col gap-1.5">
@@ -521,11 +554,19 @@ function CalendarView({
                   {span === "day" ? "No tasks today" : "No tasks this week"}
                 </p>
                 {hasPanel && (
-                  <p className="text-sm text-muted-foreground">
-                    {isMobile
-                      ? "Tap Tasks to add one"
-                      : "Drag a task from the panel to get started"}
-                  </p>
+                  isMobile ? (
+                    <button
+                      onClick={() => setTaskPanelOpen(true)}
+                      className="flex items-center gap-2 rounded-full bg-primary text-primary-foreground shadow-md px-4 py-2.5 text-sm font-medium active:scale-95 transition-transform"
+                    >
+                      <Plus className="h-4 w-4" />
+                      Add task
+                    </button>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      Drag a task from the panel to get started
+                    </p>
+                  )
                 )}
               </div>
             </div>
@@ -666,7 +707,7 @@ function CalendarView({
               className={
                 isLandscape
                   ? "w-64 p-0 flex flex-col"
-                  : "h-[55vh] p-0 flex flex-col"
+                  : "h-[80dvh] p-0 flex flex-col"
               }
             >
               <SheetHeader className="px-4 pt-4 pb-2 border-b shrink-0">
@@ -834,7 +875,7 @@ function SimpleView({
                           onClick={() =>
                             memberships && setEditingInstance(inst)
                           }
-                          className={`hover:bg-primary/5 active:bg-primary/10 transition-colors ${memberships ? "cursor-pointer" : ""}`}
+                          className={`hover:bg-primary/5 active:bg-primary/10 transition-colors ${memberships ? "cursor-pointer" : ""} ${statusRowClass(effStatus(inst))}`}
                         >
                           <td className="px-3 py-2 text-muted-foreground">
                             {idx + 1}

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
@@ -249,6 +249,7 @@ function CalendarEditPopup({
           span: currentSpan,
         });
         if (roleId) newParams.set("roleId", roleId);
+        if (currentSpan === "day") newParams.set("day", date);
 
         router.push(`/orgs/${orgId}/timetable?${newParams.toString()}`);
       } else {

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client.tsx
@@ -186,6 +186,7 @@ interface CalendarEditPopupProps {
   open: boolean;
   onClose: () => void;
   onRefresh: () => void;
+  router: ReturnType<typeof useRouter>;
 }
 
 function CalendarEditPopup({
@@ -196,6 +197,7 @@ function CalendarEditPopup({
   open,
   onClose,
   onRefresh,
+  router,
 }: CalendarEditPopupProps) {
   const [startTime, setStartTime] = useState(minToHHMM(instance.startTimeMin));
   const [date, setDate] = useState(instance.date);
@@ -233,7 +235,26 @@ function CalendarEditPopup({
         return;
       }
       onClose();
-      onRefresh();
+
+      // If the date has changed, navigate to the week containing the new date
+      if (date !== instance.date) {
+        const params = new URLSearchParams(window.location.search);
+        const currentMode = params.get("mode") || "calendar";
+        const currentSpan = params.get("span") || "week";
+        const roleId = params.get("roleId");
+
+        const newParams = new URLSearchParams({
+          week: date,
+          mode: currentMode,
+          span: currentSpan,
+        });
+        if (roleId) newParams.set("roleId", roleId);
+
+        router.push(`/orgs/${orgId}/timetable?${newParams.toString()}`);
+      } else {
+        // Only refresh if the date has NOT changed
+        onRefresh();
+      }
     });
   }
 
@@ -749,6 +770,7 @@ function CalendarView({
           open={true}
           onClose={() => setEditingInstance(null)}
           onRefresh={() => router.refresh()}
+          router={router}
         />
       )}
     </>
@@ -942,6 +964,7 @@ function SimpleView({
           open={true}
           onClose={() => setEditingInstance(null)}
           onRefresh={() => router.refresh()}
+          router={router}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

Closes #68 — Week view horizontal scroll confirmed (overflow-x-auto + min column width already in TimeGrid)
Closes #69 — Mobile empty state now shows an **Add task** button that opens the task sheet directly
Closes #70 — **Date picker** added to the task edit popup so managers can move an entry to a different date
Closes #71 — SimpleView table rows display a coloured left border matching the task's status (amber = in-progress, green = done, red = skipped)
Closes #72 — **Role-based visibility**: members without `VIEW_TIMETABLE` or `MANAGE_TIMETABLE` only see tasks tied to their own roles (tasks with no role restriction remain visible to all)
Closes #76 — Status select is now the **first field** in the edit popup with `autoFocus`, making it the primary action
Closes #77 — Mobile task sheet height increased from 55 vh → 80 dvh for better reach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Role-based task visibility—members only see tasks they’re eligible to view
  * Visual status indicators for task rows (In Progress, Done, Skipped)
  * Mobile interface includes a prominent "Add task" button

* **Improvements**
  * Edit form reordered to prioritize status selection with autofocus
  * Save now navigates to the week when a task date changes (otherwise refreshes)
  * Increased mobile sheet height and layout tweaks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->