### PR TITLE
fix: UX improvements (#59, #60, #78)

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -19,7 +19,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         <SidebarInset>
           <NavBar />
           <PageHeader />
-          <main className="flex-1 overflow-auto p-4 sm:p-6">{children}</main>
+          <main className="flex-1 min-h-0 overflow-auto p-4 sm:p-6">{children}</main>
         </SidebarInset>
       </BreadcrumbProvider>
     </SidebarProvider>

--- a/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
@@ -23,6 +23,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import { usePersistedState } from "@/hooks/use-persisted-state";
 import Image from "next/image";
 import Link from "next/link";
 import { ChevronDown, LayoutGrid, List, Search } from "lucide-react";
@@ -139,7 +140,7 @@ export function MembersView({
   orgId: string;
   canManage: boolean;
 }) {
-  const [view, setView] = useState<"card" | "list">("card");
+  const [view, setView] = usePersistedState<"card" | "list">("members:view", "card");
   const [search, setSearch] = useState("");
   const [roleFilter, setRoleFilter] = useState<string | null>(null);
 

--- a/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
@@ -46,6 +46,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { deleteTaskAction } from "@/app/actions/tasks";
+import { usePersistedState } from "@/hooks/use-persisted-state";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -96,10 +97,10 @@ export function TaskTable({
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [search, setSearch] = useState("");
-  const [sort, setSort] = useState<SortOption>("name-asc");
+  const [sort, setSort] = usePersistedState<SortOption>("tasks:sort", "name-asc");
   const [filterRoleId, setFilterRoleId] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Task | null>(null);
-  const [view, setView] = useState<"list" | "card">("list");
+  const [view, setView] = usePersistedState<"list" | "card">("tasks:view", "list");
 
   // Filter by search and role
   let visible = tasks.filter((t) =>

--- a/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
@@ -97,10 +97,27 @@ export function TaskTable({
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [search, setSearch] = useState("");
-  const [sort, setSort] = usePersistedState<SortOption>("tasks:sort", "name-asc");
+  const [sortRaw, setSortRaw] = usePersistedState<SortOption>("tasks:sort", "name-asc");
+  // Validate persisted sort value against SORT_OPTIONS
+  const sort = SORT_OPTIONS.find((o) => o.value === sortRaw)
+    ? sortRaw
+    : "name-asc";
+  const setSort = (value: SortOption) => {
+    // Sanitize updates to only accept values present in SORT_OPTIONS
+    if (SORT_OPTIONS.find((o) => o.value === value)) {
+      setSortRaw(value);
+    }
+  };
   const [filterRoleId, setFilterRoleId] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Task | null>(null);
-  const [view, setView] = usePersistedState<"list" | "card">("tasks:view", "list");
+  const [viewRaw, setViewRaw] = usePersistedState<"list" | "card">("tasks:view", "list");
+  // Validate persisted view value
+  const view = viewRaw === "list" || viewRaw === "card" ? viewRaw : "list";
+  const setView = (value: "list" | "card") => {
+    if (value === "list" || value === "card") {
+      setViewRaw(value);
+    }
+  };
 
   // Filter by search and role
   let visible = tasks.filter((t) =>

--- a/app/(app)/orgs/[orgId]/tasks/task-form.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/task-form.tsx
@@ -245,18 +245,25 @@ function DurationPicker({
   error: string | null;
 }) {
   const [hours, setHours] = useState(Math.floor(defaultValueMin / 60));
-  const [minutes, setMinutes] = useState(defaultValueMin % 60);
+  // Snap minutes to nearest 5-minute step to match select options
+  const [minutes, setMinutes] = useState(() => {
+    const rawMinutes = defaultValueMin % 60;
+    const snapped = Math.round(rawMinutes / 5) * 5;
+    return Math.max(0, Math.min(55, snapped));
+  });
   const totalMin = hours * 60 + minutes;
 
   return (
     <div className="flex items-center gap-2">
       <input type="hidden" name={name} value={totalMin} />
       <select
+        id={name}
         value={hours}
         onChange={(e) => setHours(Number(e.target.value))}
         className="h-9 rounded-md border border-input bg-transparent px-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50"
         aria-label="Hours"
         aria-invalid={!!error}
+        aria-describedby={error ? `${name}-error` : undefined}
       >
         {Array.from({ length: 24 }, (_, i) => (
           <option key={i} value={i}>{i}h</option>
@@ -268,6 +275,7 @@ function DurationPicker({
         className="h-9 rounded-md border border-input bg-transparent px-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50"
         aria-label="Minutes"
         aria-invalid={!!error}
+        aria-describedby={error ? `${name}-error` : undefined}
       >
         {[0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55].map((m) => (
           <option key={m} value={m}>{m}m</option>
@@ -310,6 +318,7 @@ function StartTimePicker({
         value={value}
         onChange={(e) => setValue(e.target.value)}
         aria-invalid={!!error}
+        aria-describedby={error ? `${name}-error` : undefined}
         className="w-40"
       />
     </>

--- a/app/(app)/orgs/[orgId]/tasks/task-form.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/task-form.tsx
@@ -229,6 +229,93 @@ function EligibilityPanel(props: EligibilityPanelProps) {
   );
 }
 
+// ─── Duration picker ──────────────────────────────────────────────────────────
+
+/**
+ * Hours + minutes selects that submit a single hidden `name` input
+ * containing the total minutes (as a string number).
+ */
+function DurationPicker({
+  defaultValueMin,
+  name,
+  error,
+}: {
+  defaultValueMin: number;
+  name: string;
+  error: string | null;
+}) {
+  const [hours, setHours] = useState(Math.floor(defaultValueMin / 60));
+  const [minutes, setMinutes] = useState(defaultValueMin % 60);
+  const totalMin = hours * 60 + minutes;
+
+  return (
+    <div className="flex items-center gap-2">
+      <input type="hidden" name={name} value={totalMin} />
+      <select
+        value={hours}
+        onChange={(e) => setHours(Number(e.target.value))}
+        className="h-9 rounded-md border border-input bg-transparent px-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50"
+        aria-label="Hours"
+        aria-invalid={!!error}
+      >
+        {Array.from({ length: 24 }, (_, i) => (
+          <option key={i} value={i}>{i}h</option>
+        ))}
+      </select>
+      <select
+        value={minutes}
+        onChange={(e) => setMinutes(Number(e.target.value))}
+        className="h-9 rounded-md border border-input bg-transparent px-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50"
+        aria-label="Minutes"
+        aria-invalid={!!error}
+      >
+        {[0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55].map((m) => (
+          <option key={m} value={m}>{m}m</option>
+        ))}
+      </select>
+      <span className="text-xs text-muted-foreground">{totalMin} min total</span>
+    </div>
+  );
+}
+
+/**
+ * A `type="time"` input that submits minutes-since-midnight (or empty string
+ * if the field is cleared) as the hidden `name` input.
+ */
+function StartTimePicker({
+  defaultValueMin,
+  name,
+  error,
+}: {
+  defaultValueMin: number | null;
+  name: string;
+  error: string | null;
+}) {
+  const toHHMM = (min: number) => {
+    const h = Math.floor(min / 60).toString().padStart(2, "0");
+    const m = (min % 60).toString().padStart(2, "0");
+    return `${h}:${m}`;
+  };
+  const [value, setValue] = useState(
+    defaultValueMin != null ? toHHMM(defaultValueMin) : "",
+  );
+  const valueMin = value ? value.split(":").reduce((h, m, i) => h + Number(m) * (i === 0 ? 60 : 1), 0) : "";
+
+  return (
+    <>
+      <input type="hidden" name={name} value={valueMin} />
+      <Input
+        id={name}
+        type="time"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        aria-invalid={!!error}
+        className="w-40"
+      />
+    </>
+  );
+}
+
 // ─── Main form ────────────────────────────────────────────────────────────────
 
 /**
@@ -396,21 +483,12 @@ export function TaskForm(props: TaskFormProps) {
 
         <div className="flex flex-col gap-1.5">
           <label htmlFor="durationMin" className="text-sm font-medium">
-            Duration (minutes) <span className="text-destructive">*</span>
+            Duration <span className="text-destructive">*</span>
           </label>
-          <Input
-            id="durationMin"
+          <DurationPicker
+            defaultValueMin={dv?.durationMin ?? 30}
             name="durationMin"
-            type="number"
-            required
-            min={1}
-            max={1440}
-            placeholder="e.g. 60"
-            defaultValue={dv?.durationMin}
-            aria-invalid={!!err("durationMin")}
-            aria-describedby={
-              err("durationMin") ? "durationMin-error" : undefined
-            }
+            error={err("durationMin")}
           />
           {err("durationMin") && (
             <p id="durationMin-error" className="text-xs text-destructive">
@@ -420,32 +498,16 @@ export function TaskForm(props: TaskFormProps) {
         </div>
 
         <div className="flex flex-col gap-1.5">
-          <label
-            htmlFor="preferredStartTimeMin"
-            className="text-sm font-medium"
-          >
-            Preferred start time (minutes since midnight)
+          <label htmlFor="preferredStartTimeMin" className="text-sm font-medium">
+            Preferred start time
           </label>
-          <Input
-            id="preferredStartTimeMin"
+          <StartTimePicker
+            defaultValueMin={dv?.preferredStartTimeMin ?? null}
             name="preferredStartTimeMin"
-            type="number"
-            min={0}
-            max={1439}
-            placeholder="e.g. 480 = 8:00 am"
-            defaultValue={dv?.preferredStartTimeMin ?? undefined}
-            aria-invalid={!!err("preferredStartTimeMin")}
-            aria-describedby={
-              err("preferredStartTimeMin")
-                ? "preferredStartTimeMin-error"
-                : undefined
-            }
+            error={err("preferredStartTimeMin")}
           />
           {err("preferredStartTimeMin") && (
-            <p
-              id="preferredStartTimeMin-error"
-              className="text-xs text-destructive"
-            >
+            <p id="preferredStartTimeMin-error" className="text-xs text-destructive">
               {err("preferredStartTimeMin")}
             </p>
           )}

--- a/app/(app)/orgs/[orgId]/timetable/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/page.tsx
@@ -17,6 +17,7 @@ import { TimetableClient } from "./timetable-client";
 import { TimetableViewPicker } from "./timetable-view-picker";
 import { TimetableActions } from "./timetable-actions";
 import { RoleFilterButton } from "./role-filter-button";
+import { TimetablePrefRedirect } from "./timetable-pref-redirect";
 import { toLocalDateStr, getMondayDateStr } from "@/lib/date-utils";
 
 export default async function TimetablePage({
@@ -180,6 +181,7 @@ export default async function TimetablePage({
           </div>
         )}
       </Toolbar>
+      <TimetablePrefRedirect orgId={orgId} />
       <TimetableClient
         orgId={orgId}
         instances={coloredInstances}

--- a/app/(app)/orgs/[orgId]/timetable/templates/templates-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/templates-client.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { usePersistedState } from "@/hooks/use-persisted-state";
 import Link from "next/link";
 import { useRouter } from "next/navigation";

--- a/app/(app)/orgs/[orgId]/timetable/templates/templates-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/templates-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { usePersistedState } from "@/hooks/use-persisted-state";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { CalendarDays, LayoutGrid, List, Plus } from "lucide-react";
@@ -22,7 +23,7 @@ interface TemplatesClientProps {
 
 export function TemplatesClient({ orgId, templates }: TemplatesClientProps) {
   const router = useRouter();
-  const [view, setView] = useState<"card" | "list">("card");
+  const [view, setView] = usePersistedState<"card" | "list">("templates:view", "card");
 
   const viewToggle = (
     <div className="flex items-center rounded-md border overflow-hidden">

--- a/app/(app)/orgs/[orgId]/timetable/timetable-pref-redirect.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-pref-redirect.tsx
@@ -15,8 +15,8 @@ export function TimetablePrefRedirect({ orgId }: { orgId: string }) {
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    // Only redirect if neither mode nor span is currently set
-    if (searchParams.has("mode") || searchParams.has("span")) return;
+    const hasMode = searchParams.has("mode");
+    const hasSpan = searchParams.has("span");
 
     let storedMode: string | null = null;
     let storedSpan: string | null = null;
@@ -25,16 +25,23 @@ export function TimetablePrefRedirect({ orgId }: { orgId: string }) {
       storedSpan = localStorage.getItem("timetable:span");
     } catch { /* ignore */ }
 
-    if (!storedMode && !storedSpan) return;
-
     const params = new URLSearchParams(searchParams.toString());
-    if (storedMode === "simple" || storedMode === "calendar") {
+    let changed = false;
+
+    // Only apply stored mode if mode param not already set
+    if (!hasMode && (storedMode === "simple" || storedMode === "calendar")) {
       params.set("mode", storedMode);
+      changed = true;
     }
-    if (storedSpan === "day" || storedSpan === "week") {
+    // Only apply stored span if span param not already set
+    if (!hasSpan && (storedSpan === "day" || storedSpan === "week")) {
       params.set("span", storedSpan);
+      changed = true;
     }
-    router.replace(`/orgs/${orgId}/timetable?${params.toString()}`);
+
+    if (changed) {
+      router.replace(`/orgs/${orgId}/timetable?${params.toString()}`);
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/app/(app)/orgs/[orgId]/timetable/timetable-pref-redirect.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-pref-redirect.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+/**
+ * Reads timetable mode/span preferences from localStorage and redirects to
+ * include them in the URL if the user navigated to the page without explicit
+ * params (e.g. clicking the sidebar link).
+ *
+ * Runs only once on mount — does nothing if mode/span are already in the URL.
+ */
+export function TimetablePrefRedirect({ orgId }: { orgId: string }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    // Only redirect if neither mode nor span is currently set
+    if (searchParams.has("mode") || searchParams.has("span")) return;
+
+    let storedMode: string | null = null;
+    let storedSpan: string | null = null;
+    try {
+      storedMode = localStorage.getItem("timetable:mode");
+      storedSpan = localStorage.getItem("timetable:span");
+    } catch { /* ignore */ }
+
+    if (!storedMode && !storedSpan) return;
+
+    const params = new URLSearchParams(searchParams.toString());
+    if (storedMode === "simple" || storedMode === "calendar") {
+      params.set("mode", storedMode);
+    }
+    if (storedSpan === "day" || storedSpan === "week") {
+      params.set("span", storedSpan);
+    }
+    router.replace(`/orgs/${orgId}/timetable?${params.toString()}`);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null;
+}

--- a/app/(app)/orgs/[orgId]/timetable/timetable-view-picker.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-view-picker.tsx
@@ -24,8 +24,17 @@ export function TimetableViewPicker({
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
-  // Navigate to href using startTransition
-  const navigate = (href: string) => startTransition(() => router.push(href));
+  // Navigate to href using startTransition; also persist the chosen mode/span.
+  const navigate = (href: string, meta?: { mode?: string; span?: string }) =>
+    startTransition(() => {
+      if (meta) {
+        try {
+          if (meta.mode) localStorage.setItem("timetable:mode", meta.mode);
+          if (meta.span) localStorage.setItem("timetable:span", meta.span);
+        } catch { /* ignore */ }
+      }
+      router.push(href);
+    });
 
   const segmentBase = "px-3 py-1 transition-colors cursor-pointer select-none";
   const activeClass = "bg-primary text-primary-foreground";
@@ -44,7 +53,7 @@ export function TimetableViewPicker({
       {/* Day / Week */}
       <div className="flex rounded-md overflow-hidden border text-sm font-medium">
         <button
-          onClick={() => navigate(dayHref)}
+          onClick={() => navigate(dayHref, { span: "day" })}
           aria-current={span === "day" ? "page" : undefined}
           className={cn(
             segmentBase,
@@ -54,7 +63,7 @@ export function TimetableViewPicker({
           Day
         </button>
         <button
-          onClick={() => navigate(weekHref)}
+          onClick={() => navigate(weekHref, { span: "week" })}
           aria-current={span === "week" ? "page" : undefined}
           className={cn(
             segmentBase,
@@ -69,7 +78,7 @@ export function TimetableViewPicker({
       {/* Calendar / Simple */}
       <div className="flex rounded-md overflow-hidden border text-sm font-medium">
         <button
-          onClick={() => navigate(calendarHref)}
+          onClick={() => navigate(calendarHref, { mode: "calendar" })}
           aria-current={mode === "calendar" ? "page" : undefined}
           className={cn(
             segmentBase,
@@ -79,7 +88,7 @@ export function TimetableViewPicker({
           Calendar
         </button>
         <button
-          onClick={() => navigate(simpleHref)}
+          onClick={() => navigate(simpleHref, { mode: "simple" })}
           aria-current={mode === "simple" ? "page" : undefined}
           className={cn(
             segmentBase,

--- a/hooks/use-persisted-state.ts
+++ b/hooks/use-persisted-state.ts
@@ -6,22 +6,33 @@ import { useState, useEffect } from "react";
  * useState with automatic localStorage persistence.
  * Falls back to initialValue if localStorage is unavailable or the stored
  * value cannot be parsed (e.g., shape changed after a deploy).
+ * Initializes with initialValue on first render to avoid SSR/CSR hydration mismatches,
+ * then reads from localStorage after mount.
  */
 export function usePersistedState<T>(
   key: string,
   initialValue: T,
 ): [T, React.Dispatch<React.SetStateAction<T>>] {
-  const [state, setState] = useState<T>(() => {
-    if (typeof window === "undefined") return initialValue;
+  // Initialize with initialValue to avoid SSR hydration mismatch
+  const [state, setState] = useState<T>(initialValue);
+
+  // Read from localStorage after mount (client-side only)
+  useEffect(() => {
+    if (typeof window === "undefined") return;
     try {
       const raw = localStorage.getItem(key);
-      return raw !== null ? (JSON.parse(raw) as T) : initialValue;
+      if (raw !== null) {
+        setState(JSON.parse(raw) as T);
+      }
     } catch {
-      return initialValue;
+      // Ignore parse errors
     }
-  });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Run once after mount
 
+  // Write to localStorage when state changes
   useEffect(() => {
+    if (typeof window === "undefined") return;
     try {
       localStorage.setItem(key, JSON.stringify(state));
     } catch {

--- a/hooks/use-persisted-state.ts
+++ b/hooks/use-persisted-state.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+/**
+ * useState with automatic localStorage persistence.
+ * Falls back to initialValue if localStorage is unavailable or the stored
+ * value cannot be parsed (e.g., shape changed after a deploy).
+ */
+export function usePersistedState<T>(
+  key: string,
+  initialValue: T,
+): [T, React.Dispatch<React.SetStateAction<T>>] {
+  const [state, setState] = useState<T>(() => {
+    if (typeof window === "undefined") return initialValue;
+    try {
+      const raw = localStorage.getItem(key);
+      return raw !== null ? (JSON.parse(raw) as T) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(state));
+    } catch {
+      // Ignore quota exceeded / private browsing errors
+    }
+  }, [key, state]);
+
+  return [state, setState];
+}


### PR DESCRIPTION
## Summary

Closes #59 — **Persist view modes**: timetable mode/span saved to localStorage via `TimetableViewPicker`; a `TimetablePrefRedirect` client component restores the preference on next visit. Tasks, Members, and Templates list view mode (card/list) also persisted via a new `usePersistedState` hook.

Closes #60 — **Scroll-jump-to-top fix**: added `min-h-0` to the app `<main>` element so the flex container has a stable height and scroll position is not reset on content updates.

Closes #78 — **Friendlier time pickers**: the task form now uses an hours + minutes select pair for Duration (instead of a raw number input) and a `type="time"` input for Preferred Start Time (instead of 'minutes since midnight').

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View preferences (list/card) now persist across sessions for members, tasks, and templates.
  * Task sort preferences now persist.
  * Timetable restores view mode and span from preferences and applies them automatically.
  * Task form duration and preferred-start inputs replaced with dedicated pickers for improved usability.
* **Bug Fixes / UI**
  * Layout scrolling behavior improved so page overflow resolves correctly within app containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->