### PR TITLE
Feat/sentry logging

### DIFF
--- a/lib/services/assignees.ts
+++ b/lib/services/assignees.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import type { ServiceResult } from "./types";
@@ -42,6 +43,7 @@ export async function createAssignee(
     const assignee = await prisma.timetableEntryAssignee.create({
       data: { timetableEntryId: taskInstanceId, membershipId },
     });
+    Sentry.logger.info("Assignee added", { orgId, taskInstanceId, membershipId });
     return { ok: true, data: assignee };
   } catch (e) {
     if (
@@ -78,6 +80,7 @@ export async function deleteAssignee(
     return { ok: false, error: "Assignee not found", code: "NOT_FOUND" };
 
   await prisma.timetableEntryAssignee.delete({ where: { id: link.id } });
+  Sentry.logger.info("Assignee removed", { orgId, taskInstanceId, membershipId });
   return { ok: true, data: null };
 }
 

--- a/lib/services/bots.ts
+++ b/lib/services/bots.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/prisma";
 import { Prisma, InviteType } from "@prisma/client";
 import type { ServiceResult } from "./types";
@@ -78,6 +79,7 @@ export async function createBot(
     });
   });
 
+  Sentry.logger.info("Bot created", { orgId, membershipId: bot.id, botName: data.botName });
   return { ok: true, data: bot };
 }
 
@@ -122,6 +124,7 @@ export async function deleteBot(
     }),
     prisma.membership.delete({ where: { id: membershipId } }),
   ]);
+  Sentry.logger.info("Bot deleted", { orgId, membershipId });
   return { ok: true, data: null };
 }
 
@@ -174,6 +177,7 @@ export async function memberToBot(
     select: botSelect,
   });
 
+  Sentry.logger.info("Member converted to bot", { orgId, membershipId });
   return { ok: true, data: updated };
 }
 
@@ -231,6 +235,7 @@ export async function botToMember(
       where: { id: membershipId },
       data: { userId, botName: null },
     });
+    Sentry.logger.info("Bot converted to member", { orgId, membershipId, userId });
     return { ok: true, data: updated };
   } catch (e) {
     if (
@@ -288,5 +293,6 @@ export async function updateBot(
     );
   });
 
+  Sentry.logger.info("Bot updated", { orgId, membershipId });
   return { ok: true, data: null };
 }

--- a/lib/services/franchise.ts
+++ b/lib/services/franchise.ts
@@ -307,7 +307,7 @@ export async function createFranchiseToken(
     }
   });
 
-  Sentry.logger.info("Franchise token created", { orgId, invitedById: inviterId, email });
+  Sentry.logger.info("Franchise token created", { orgId, invitedById: inviterId, userId: user.id });
   return { ok: true, data: undefined };
 }
 
@@ -449,6 +449,6 @@ export async function changeFranchiseeOwner(
     };
   }
 
-  Sentry.logger.info("Franchisee owner changed", { parentOrgId: orgId, childOrgId, newOwnerEmail });
+  Sentry.logger.info("Franchisee owner changed", { parentOrgId: orgId, childOrgId, newOwnerId: newOwner.id });
   return { ok: true, data: undefined };
 }

--- a/lib/services/franchise.ts
+++ b/lib/services/franchise.ts
@@ -11,6 +11,7 @@
  */
 
 import { InviteType } from "@prisma/client";
+import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/prisma";
 import { ROLE_KEYS } from "@/lib/rbac";
 import type { ServiceResult } from "./types";
@@ -306,6 +307,7 @@ export async function createFranchiseToken(
     }
   });
 
+  Sentry.logger.info("Franchise token created", { orgId, invitedById: inviterId, email });
   return { ok: true, data: undefined };
 }
 
@@ -332,6 +334,7 @@ export async function deleteFranchiseToken(
     });
   });
 
+  Sentry.logger.info("Franchise token deleted", { orgId, tokenId });
   return { ok: true, data: undefined };
 }
 
@@ -357,6 +360,7 @@ export async function extendFranchiseToken(
     data: { expiresAt: newExpiry },
   });
 
+  Sentry.logger.info("Franchise token extended", { orgId, tokenId });
   return { ok: true, data: undefined };
 }
 
@@ -371,6 +375,7 @@ export async function removeFranchisee(
   if (count === 0)
     return { ok: false, error: "Franchisee not found", code: "NOT_FOUND" };
 
+  Sentry.logger.info("Franchisee removed", { parentOrgId: orgId, childOrgId });
   return { ok: true, data: undefined };
 }
 
@@ -444,5 +449,6 @@ export async function changeFranchiseeOwner(
     };
   }
 
+  Sentry.logger.info("Franchisee owner changed", { parentOrgId: orgId, childOrgId, newOwnerEmail });
   return { ok: true, data: undefined };
 }

--- a/lib/services/invites.ts
+++ b/lib/services/invites.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { InviteType } from "@prisma/client";
 import { ROLE_KEYS } from "@/lib/rbac";
 import { prisma } from "@/lib/prisma";
@@ -221,6 +222,7 @@ export async function createMemberInvite(
     throw e;
   }
 
+  Sentry.logger.info("Member invite created", { orgId, invitedById, recipientId });
   return { ok: true, data: null };
 }
 
@@ -289,6 +291,7 @@ export async function acceptMemberInvite(
   }
 
   await notifyInviteAccepted(invite, userId);
+  Sentry.logger.info("Member invite accepted", { inviteId, userId, orgId: invite.orgId });
   return { ok: true, data: null };
 }
 
@@ -377,6 +380,7 @@ export async function acceptBotSlotInvite(
   }
 
   await notifyInviteAccepted(invite, userId);
+  Sentry.logger.info("Bot-slot invite accepted", { inviteId, userId, orgId: invite.orgId });
   return { ok: true, data: null };
 }
 
@@ -400,6 +404,7 @@ export async function declineBotSlotInvite(
   if (updated.count === 0)
     return { ok: false, error: "Invite not found or already handled", code: "NOT_FOUND" };
 
+  Sentry.logger.info("Bot-slot invite declined", { inviteId, userId });
   return { ok: true, data: null };
 }
 
@@ -421,7 +426,7 @@ async function notifyInviteAccepted(
       },
     });
   } catch (error) {
-    console.error("Failed to create notification for invite acceptance:", error);
+    Sentry.logger.error("Failed to create notification for invite acceptance", { error, acceptingUserId });
   }
 }
 
@@ -449,6 +454,7 @@ export async function declineMemberInvite(
       code: "NOT_FOUND",
     };
 
+  Sentry.logger.info("Member invite declined", { inviteId, userId });
   return { ok: true, data: null };
 }
 
@@ -505,5 +511,6 @@ export async function declineFranchiseInvite(
     throw e;
   }
 
+  Sentry.logger.info("Franchise invite declined", { inviteId, userId, orgId: invite.orgId });
   return { ok: true, data: null };
 }

--- a/lib/services/memberships.ts
+++ b/lib/services/memberships.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/prisma";
 import { Prisma, InviteType } from "@prisma/client";
 import type { CreateMembershipInput } from "@/lib/validators/membership";
@@ -42,6 +43,7 @@ export async function createMembership(
       });
       return m;
     });
+    Sentry.logger.info("Membership created", { orgId, userId: data.userId, roleId: data.roleId });
     return { ok: true, data: membership };
   } catch (e) {
     if (e instanceof Prisma.PrismaClientKnownRequestError) {
@@ -119,6 +121,7 @@ export async function deleteMembership(
     });
     await tx.membership.delete({ where: { id: membershipId } });
   });
+  Sentry.logger.info("Membership deleted", { orgId, membershipId });
   return { ok: true, data: null };
 }
 
@@ -208,6 +211,7 @@ export async function updateMembership(
     );
   });
 
+  Sentry.logger.info("Membership updated", { orgId, membershipId });
   return { ok: true, data: null };
 }
 
@@ -229,5 +233,6 @@ export async function setMembershipStatus(
     where: { id: membershipId },
     data: { status },
   });
+  Sentry.logger.info("Membership status updated", { orgId, membershipId, status });
   return { ok: true, data: null };
 }

--- a/lib/services/orgs.ts
+++ b/lib/services/orgs.ts
@@ -226,6 +226,7 @@ export async function joinFranchise(
   });
   Sentry.logger.info("Franchise joined", { orgId: result.org.id, userId });
   return result;
+}
 
 /**
  * Updates an org's location and schedule settings.

--- a/lib/services/orgs.ts
+++ b/lib/services/orgs.ts
@@ -4,6 +4,7 @@
  * Every function that mutates is wrapped in a Prisma transaction so partial
  * writes are impossible: either everything succeeds or nothing is persisted.
  */
+import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/prisma";
 import { PermissionAction } from "@prisma/client";
 import { ROLE_KEYS } from "@/lib/rbac";
@@ -96,7 +97,7 @@ async function bootstrapRoles(tx: Tx, orgId: string, userId: string) {
  * All steps are atomic — if any step fails, nothing is persisted.
  */
 export async function createOrg(userId: string, data: CreateOrgInput) {
-  return prisma.$transaction(async (tx) => {
+  const result = await prisma.$transaction(async (tx) => {
     const org = await tx.organization.create({
       data: {
         name: data.title,
@@ -117,6 +118,8 @@ export async function createOrg(userId: string, data: CreateOrgInput) {
 
     return { org, ownerRole, memberRole, membership };
   });
+  Sentry.logger.info("Org created", { orgId: result.org.id, userId, name: result.org.name });
+  return result;
 }
 
 /**
@@ -144,7 +147,7 @@ export async function joinFranchise(
   userEmail: string,
   data: JoinFranchiseInput,
 ) {
-  return prisma.$transaction(async (tx) => {
+  const result = await prisma.$transaction(async (tx) => {
     const [token, user] = await Promise.all([
       tx.franchiseToken.findUnique({
         where: { token: data.token },
@@ -221,7 +224,8 @@ export async function joinFranchise(
 
     return { org, clonedRoles, membership };
   });
-}
+  Sentry.logger.info("Franchise joined", { orgId: result.org.id, userId });
+  return result;
 
 /**
  * Updates an org's location and schedule settings.
@@ -310,6 +314,7 @@ export async function transferOrgOwnership(
       data: { ownerId: newOwnerId },
     });
   });
+  Sentry.logger.info("Org ownership transferred", { orgId, from: currentOwnerId, to: newOwnerId });
 }
 
 /**
@@ -336,6 +341,7 @@ export async function deleteOrg(
     throw new Error("Confirmation name does not match");
 
   await prisma.organization.delete({ where: { id: orgId } });
+  Sentry.logger.info("Org deleted", { orgId, deletedBy: currentOwnerId });
 }
 
 /**

--- a/lib/services/roles.ts
+++ b/lib/services/roles.ts
@@ -5,6 +5,7 @@
  * automatically when an org is created (Owner, Default Member) and cannot be
  * deleted. Custom roles can be created freely and removed here.
  */
+import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/prisma";
 import { PermissionAction } from "@prisma/client";
 import { ROLE_KEYS } from "@/lib/rbac";
@@ -61,6 +62,7 @@ export async function deleteRole(
     };
 
   await prisma.role.delete({ where: { id: roleId } });
+  Sentry.logger.info("Role deleted", { orgId, roleId });
   return { ok: true, data: null };
 }
 
@@ -161,6 +163,7 @@ export async function createRole(
     };
   }
 
+  Sentry.logger.info("Role created", { orgId, roleId: role.id });
   return { ok: true, data: role };
 }
 
@@ -241,5 +244,6 @@ export async function updateRole(
     };
   }
 
+  Sentry.logger.info("Role updated", { orgId, roleId });
   return { ok: true, data: updated };
 }

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/prisma";
 import type { ServiceResult } from "./types";
 import type { CreateTaskInput, UpdateTaskInput } from "@/lib/validators/task";
@@ -7,7 +8,7 @@ import type { CreateTaskInput, UpdateTaskInput } from "@/lib/validators/task";
  * Optional fields are null-coalesced so callers never need to handle `undefined`.
  */
 export async function createTask(orgId: string, data: CreateTaskInput) {
-  return prisma.task.create({
+  const task = await prisma.task.create({
     data: {
       orgId,
       name: data.title,
@@ -20,6 +21,8 @@ export async function createTask(orgId: string, data: CreateTaskInput) {
       maxWaitDays: data.maxWaitDays ?? null,
     },
   });
+  Sentry.logger.info("Task created", { orgId, taskId: task.id });
+  return task;
 }
 
 /**
@@ -33,6 +36,7 @@ export async function deleteTask(
   const { count } = await prisma.task.deleteMany({ where: { id, orgId } });
   if (count === 0)
     return { ok: false, error: "Task not found", code: "NOT_FOUND" };
+  Sentry.logger.info("Task deleted", { orgId, taskId: id });
   return { ok: true, data: null };
 }
 
@@ -90,6 +94,7 @@ export async function updateTask(
   });
   if (count === 0)
     return { ok: false, error: "Task not found", code: "NOT_FOUND" };
+  Sentry.logger.info("Task updated", { orgId, taskId });
   return { ok: true, data: null };
 }
 

--- a/lib/services/templates.ts
+++ b/lib/services/templates.ts
@@ -2,6 +2,7 @@
  * @file templates.ts
  * Service functions for reading and mutating timetable templates and their entries.
  */
+import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import type { ServiceResult } from "./types";
@@ -69,6 +70,7 @@ export async function createTemplate(
     data: { orgId, name, cycleLengthDays },
     select: { id: true },
   });
+  Sentry.logger.info("Template created", { orgId, templateId: template.id, name });
   return { ok: true, data: template };
 }
 
@@ -111,6 +113,7 @@ export async function addTemplateInstance(
   await prisma.templateEntry.create({
     data: { taskId, templateId, dayIndex, startTimeMin, endTimeMin },
   });
+  Sentry.logger.info("Template instance added", { orgId, templateId, taskId });
   return { ok: true, data: null };
 }
 
@@ -128,6 +131,7 @@ export async function removeTemplateInstance(
   if (!entry) return { ok: false, error: "Not found", code: "NOT_FOUND" };
 
   await prisma.templateEntry.delete({ where: { id: instanceId } });
+  Sentry.logger.info("Template instance removed", { orgId, instanceId });
   return { ok: true, data: null };
 }
 
@@ -189,8 +193,7 @@ export async function updateTemplateInstance(
         ),
       }),
     },
-  });
-  return { ok: true, data: null };
+  });  Sentry.logger.info("Template instance updated", { orgId, instanceId });  return { ok: true, data: null };
 }
 
 /**
@@ -232,6 +235,7 @@ export async function updateTemplateDays(
   if (updated.count === 0) {
     return { ok: false, error: "Template not found", code: "NOT_FOUND" };
   }
+  Sentry.logger.info("Template cycle length updated", { orgId, templateId, cycleLengthDays });
   return { ok: true, data: null };
 }
 
@@ -268,6 +272,7 @@ export async function addTemplateInstanceAssignee(
     create: { templateEntryId: instanceId, membershipId },
     update: {},
   });
+  Sentry.logger.info("Template instance assignee added", { orgId, instanceId, membershipId });
   return { ok: true, data: null };
 }
 
@@ -290,6 +295,7 @@ export async function removeTemplateInstanceAssignee(
   if (!assignee) return { ok: false, error: "Not found", code: "NOT_FOUND" };
 
   await prisma.templateEntryAssignee.delete({ where: { id: assignee.id } });
+  Sentry.logger.info("Template instance assignee removed", { orgId, instanceId, membershipId });
   return { ok: true, data: null };
 }
 
@@ -465,6 +471,7 @@ export async function applyTemplate(
     }
   });
 
+  Sentry.logger.info("Template applied", { orgId, templateId, startDateStr, cycleRepeats, created: createData.length });
   return { ok: true, data: { created: createData.length } };
 }
 
@@ -487,6 +494,7 @@ export async function renameTemplate(
     if (updated.count === 0)
       return { ok: false, error: "Template not found", code: "NOT_FOUND" };
 
+    Sentry.logger.info("Template renamed", { orgId, templateId });
     return { ok: true, data: null };
   } catch (error) {
     if (
@@ -552,6 +560,7 @@ export async function duplicateTemplate(
         select: { id: true },
       });
 
+      Sentry.logger.info("Template duplicated", { orgId, sourceTemplateId: templateId, newTemplateId: copy.id });
       return { ok: true, data: { id: copy.id } };
     } catch (error) {
       if (
@@ -593,5 +602,6 @@ export async function deleteTemplate(
   if (deleted.count === 0)
     return { ok: false, error: "Template not found", code: "NOT_FOUND" };
 
+  Sentry.logger.info("Template deleted", { orgId, templateId });
   return { ok: true, data: null };
 }

--- a/lib/services/timetable-entries.ts
+++ b/lib/services/timetable-entries.ts
@@ -13,6 +13,7 @@
  *   subject to UTC conversion — only live `TimetableEntry` rows use UTC.
  * - `getTimetableEntries` is the primary read path for the calendar view.
  */
+import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/prisma";
 import { Prisma, EntryStatus } from "@prisma/client";
 import type { ServiceResult } from "./types";
@@ -78,6 +79,7 @@ export async function createTimetableEntryFromInput(
         endTimeMin,
       },
     });
+    Sentry.logger.info("Timetable entry created", { orgId, entryId: entry.id, taskId: data.taskId });
     return { ok: true, data: entry };
   } catch (e) {
     if (e instanceof Prisma.PrismaClientKnownRequestError) {
@@ -189,6 +191,7 @@ export async function updateTimetableEntryStatus(
       return item;
     });
 
+    Sentry.logger.info("Timetable entry status updated", { orgId, entryId: taskInstanceId, status });
     return { ok: true, data: entry };
   } catch (e) {
     if (e instanceof Error && (e as { code?: string }).code === "NOT_FOUND") {
@@ -319,6 +322,7 @@ export async function createTimetableEntry(
       endTimeMin,
     },
   });
+  Sentry.logger.info("Timetable entry created", { orgId, entryId: entry.id, taskId });
   return { ok: true, data: entry };
 }
 
@@ -376,6 +380,7 @@ export async function updateTimetableEntry(
     where: { id: entryId },
     data,
   });
+  Sentry.logger.info("Timetable entry updated", { orgId, entryId });
   return { ok: true, data: updated };
 }
 
@@ -393,6 +398,7 @@ export async function deleteTimetableEntry(
   if (!entry) return { ok: false, error: "Entry not found", code: "NOT_FOUND" };
 
   await prisma.timetableEntry.delete({ where: { id: entryId } });
+  Sentry.logger.info("Timetable entry deleted", { orgId, entryId });
   return { ok: true, data: null };
 }
 
@@ -428,6 +434,7 @@ export async function addTimetableEntryAssignee(
     create: { timetableEntryId: entryId, membershipId },
     update: {},
   });
+  Sentry.logger.info("Timetable entry assignee added", { orgId, entryId, membershipId });
   return { ok: true, data: null };
 }
 
@@ -450,6 +457,7 @@ export async function removeTimetableEntryAssignee(
   if (!assignee) return { ok: false, error: "Not found", code: "NOT_FOUND" };
 
   await prisma.timetableEntryAssignee.delete({ where: { id: assignee.id } });
+  Sentry.logger.info("Timetable entry assignee removed", { orgId, entryId, membershipId });
   return { ok: true, data: null };
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2197,7 +2197,7 @@ function confirm(): void {
   let parsedUrl: URL;
   try {
     parsedUrl = new URL(dbUrl);
-  } catch (error) {
+  } catch {
     console.error("  ❌ ERROR: DATABASE_URL is not a valid URL.");
     console.error("  Aborted — nothing was changed.\n");
     process.exit(1);

--- a/scripts/seed-walkers-doughnuts.ts
+++ b/scripts/seed-walkers-doughnuts.ts
@@ -400,7 +400,7 @@ async function main() {
   console.log(`  ✓ Org created (id: ${org.id})`);
 
   console.log("→ Creating roles...");
-  const [roleOwner, _roleDefault] = await Promise.all([
+  const [roleOwner] = await Promise.all([
     prisma.role.create({
       data: {
         orgId: org.id,


### PR DESCRIPTION
## What Changed
Adds `@sentry/nextjs` SDK setup and structured logging across the entire service layer.

**SDK setup (`feat/add-sentry`, merged #114):**
- Installed `@sentry/nextjs` via the Sentry wizard
- Added `sentry.server.config.ts`, `sentry.edge.config.ts`, `instrumentation.ts`, `instrumentation-client.ts`, `app/global-error.tsx`
- Configured `withSentryConfig` in `next.config.ts`
- Enabled `enableLogs: true`, `tracesSampleRate: 1`, session replay

**Structured logging (`feat/sentry-logging`):**
- Added `Sentry.logger.info` on every success path across all 10 service files: `invites.ts`, `memberships.ts`, `orgs.ts`, `franchise.ts`, `roles.ts`, `tasks.ts`, `timetable-entries.ts`, `templates.ts`, `bots.ts`, `assignees.ts`
- Added `Sentry.logger.error` for the swallowed catch in `notifyInviteAccepted`
- Fixed unused catch binding lint errors in `seed.ts` and `seed-walkers-doughnuts.ts`

## Why
Gives us visibility into errors and key business events (org created, invites sent/accepted, timetable changes, etc.) in the Sentry dashboard — both for production debugging and auditing.

Closes #

## Type
- [ ] 🐛 Bug fix
- [x] ✨ Enhancement / Feature
- [ ] 🔧 Refactor
- [ ] 📝 Documentation
- [ ] 🎨 UI / Styling

## How to Test
1. Trigger any write operation (create org, accept invite, add timetable entry, etc.)
2. Check the **Logs** tab in Sentry — structured log lines should appear with context fields (orgId, userId, etc.)
3. Trigger an unhandled error — it should automatically appear as an error event in Sentry without any manual `captureException` call

## Screenshots / Recordings
N/A — no UI changes

## Checklist
- [ ] Tested on desktop (Chrome)
- [ ] Tested on mobile (iPhone Safari)
- [ ] No lint errors (`pnpm lint`)
- [ ] Build passes (`pnpm build`)
- [ ] Smoke test updated (if applicable)

## Smoke Test Issues Resolved
- [ ] #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added operational logging across many backend services to improve observability of org, membership, invite, bot, task, template, timetable, and assignee changes
  * Replaced console error usage with structured logging for certain invite flows
  * Minor seed/script cleanups and small refactors to improve maintainability and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->