### PR TITLE
fix: rate limiting polish (Sentry logging, type comment, Retry-After headers)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -78,17 +78,34 @@ function getIp(req: NextRequest): string {
 // ─── Fail-open wrapper for rate limiting ────────────────────────────────────
 // Returns true (allow) when the limiter is not configured or on Redis errors.
 
+type LimitResult = Awaited<ReturnType<Ratelimit["limit"]>>;
+
 async function safeLimit(
   limiter: Ratelimit | null,
   key: string
-): Promise<{ success: boolean }> {
-  if (!limiter) return { success: true };
+): Promise<LimitResult> {
+  if (!limiter) return { success: true, limit: 0, remaining: 0, reset: 0, pending: Promise.resolve() };
   try {
     return await limiter.limit(key);
   } catch (error) {
     Sentry.logger.error("Rate limiter error (failing open)", { error });
-    return { success: true };
+    return { success: true, limit: 0, remaining: 0, reset: 0, pending: Promise.resolve() };
   }
+}
+
+function tooManyRequests(result: LimitResult) {
+  return NextResponse.json(
+    { error: "Too many requests" },
+    {
+      status: 429,
+      headers: {
+        "Retry-After": String(Math.max(0, Math.ceil((result.reset - Date.now()) / 1000))),
+        "X-RateLimit-Limit": String(result.limit),
+        "X-RateLimit-Remaining": "0",
+        "X-RateLimit-Reset": String(result.reset),
+      },
+    }
+  );
 }
 
 // ─── Proxy entry point ───────────────────────────────────────────────────────
@@ -104,18 +121,14 @@ export default async function proxy(req: NextRequest) {
       pathname.startsWith("/api/auth/signin/")
     ) {
       // OAuth flow — no session exists yet, key by IP
-      const { success } = await safeLimit(authRatelimit, getIp(req));
-      if (!success) {
-        return NextResponse.json({ error: "Too many requests" }, { status: 429 });
-      }
+      const authResult = await safeLimit(authRatelimit, getIp(req));
+      if (!authResult.success) return tooManyRequests(authResult);
     } else if (!pathname.startsWith("/api/auth/")) {
       // Authenticated API (non-auth routes) — key by user ID from JWT, fall back to IP
       const token = await getToken({ req, secret: process.env.AUTH_SECRET! });
       const key = token?.sub ?? getIp(req);
-      const { success } = await safeLimit(apiRatelimit, key);
-      if (!success) {
-        return NextResponse.json({ error: "Too many requests" }, { status: 429 });
-      }
+      const apiResult = await safeLimit(apiRatelimit, key);
+      if (!apiResult.success) return tooManyRequests(apiResult);
     }
     return NextResponse.next();
   }
@@ -124,10 +137,8 @@ export default async function proxy(req: NextRequest) {
   if (req.method === "POST" && req.headers.has("next-action")) {
     const token = await getToken({ req, secret: process.env.AUTH_SECRET! });
     const key = token?.sub ?? getIp(req);
-    const { success } = await safeLimit(apiRatelimit, key);
-    if (!success) {
-      return NextResponse.json({ error: "Too many requests" }, { status: 429 });
-    }
+    const actionResult = await safeLimit(apiRatelimit, key);
+    if (!actionResult.success) return tooManyRequests(actionResult);
   }
 
   // 3. App routes — enforce auth and attach x-pathname header

--- a/proxy.ts
+++ b/proxy.ts
@@ -131,6 +131,7 @@ export default async function proxy(req: NextRequest) {
   }
 
   // 3. App routes — enforce auth and attach x-pathname header
+  // TODO: tighten type when next-auth exports a public middleware type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (authProxy as any)(req);
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,7 @@
 
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
+import * as Sentry from "@sentry/nextjs";
 import { authConfig } from "@/auth.config";
 import NextAuth from "next-auth";
 import { getToken } from "next-auth/jwt";
@@ -85,7 +86,7 @@ async function safeLimit(
   try {
     return await limiter.limit(key);
   } catch (error) {
-    console.error("Rate limiter error (failing open):", error);
+    Sentry.logger.error("Rate limiter error (failing open)", { error });
     return { success: true };
   }
 }


### PR DESCRIPTION
## What Changed

Follow-up polish commits on top of the merged rate limiting feature (#118).

- **`console.error` → `Sentry.logger.error`** in `safeLimit` catch block — consistent with the rest of the codebase
- **TODO comment** on `(authProxy as any)` cast — documents that the `any` is intentional until next-auth exports a public middleware type
- **`Retry-After` + `X-RateLimit-*` headers** on all 429 responses — polite API behaviour; uses `limit`, `remaining`, and `reset` fields from the Upstash result

## Why

Consistency and RFC 6585 compliance for rate limit responses.

Closes #

## Type

- [ ] 🐛 Bug fix
- [x] ✨ Enhancement / Feature
- [ ] 🔧 Refactor
- [ ] 📝 Documentation
- [ ] 🎨 UI / Styling

## How to Test

1. Trigger a 429 (see #118 test steps)
2. Confirm response includes `Retry-After`, `X-RateLimit-Limit`, `X-RateLimit-Remaining: 0`, `X-RateLimit-Reset` headers
3. Confirm Sentry receives a rate limiter error event if Redis goes down

## Screenshots / Recordings

N/A

## Checklist

- [ ] Tested on desktop (Chrome)
- [ ] Tested on mobile (iPhone Safari)
- [ ] No lint errors (`pnpm lint`)
- [ ] Build passes (`pnpm build`)
- [ ] Smoke test updated (if applicable)

## Smoke Test Issues Resolved

- [ ] #