### PR TITLE
feat(sidebar): unify nav item, toolbar, and navbar height to h-12

### DIFF
--- a/__tests__/e2e/orgs.spec.ts
+++ b/__tests__/e2e/orgs.spec.ts
@@ -8,11 +8,6 @@ import { test, expect } from "@playwright/test";
  * independent — no assumptions about seeded data.
  */
 
-// The active breadcrumb crumb has aria-current="page" so tests can
-// use getByRole("link") or a targeted selector instead of the raw DOM
-// structure. We still use `nav span` here as the crumb is a <span> (not a
-// link) when it is the current page.
-
 const ORG_NAME = `E2E Org ${Date.now()}`;
 
 test("create org → lands on timetable → org name visible in navbar", async ({
@@ -31,9 +26,6 @@ test("create org → lands on timetable → org name visible in navbar", async (
 
   // Org name should appear in the navbar org switcher
   await expect(page.getByRole("button", { name: ORG_NAME })).toBeVisible();
-
-  // Breadcrumb should show "Timetable" as the active page
-  await expect(page.locator("[aria-current='page']")).toHaveText("Timetable");
 });
 
 test("delete org → redirected to /", async ({ page }) => {

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,21 +1,25 @@
 import { AppSidebar, GlobalSidebarProvider } from "@/components/layout/sidebar";
 import { NavBar } from "@/components/layout/navbar";
+import { PageSidebarProvider, PageSidebarSlot } from "@/components/layout/page-sidebar-context";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
-    <GlobalSidebarProvider>
-      {/* Full-height flex column: navbar on top, sidebar+content row below */}
-      <div className="h-dvh flex flex-col">
-        <NavBar />
-        <div className="flex flex-1 min-h-0 overflow-hidden">
-          <AppSidebar />
-          <div className="flex flex-col flex-1 overflow-hidden">
-            <main className="flex-1 min-h-0 overflow-auto flex flex-col p-4 sm:p-6">
-              {children}
-            </main>
+    <PageSidebarProvider>
+      <GlobalSidebarProvider>
+        {/* Full-height flex column: navbar on top, sidebar+content row below */}
+        <div className="h-dvh flex flex-col">
+          <NavBar />
+          <div className="flex flex-1 min-h-0 overflow-hidden">
+            <AppSidebar />
+            <PageSidebarSlot />
+            <div className="flex flex-col flex-1 overflow-hidden">
+              <main className="flex-1 min-h-0 overflow-auto flex flex-col p-4 sm:p-6">
+                {children}
+              </main>
+            </div>
           </div>
         </div>
-      </div>
-    </GlobalSidebarProvider>
+      </GlobalSidebarProvider>
+    </PageSidebarProvider>
   );
 }

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,48 +1,21 @@
-/**
- * Authenticated app shell layout.
- *
- * Scroll containment strategy:
- * - `h-dvh` on `SidebarProvider` constrains the layout to the viewport so the body never scrolls.
- * - `overflow-hidden` on `SidebarInset` scopes clipping to the right-hand column only
- *   (sidebar is unaffected), preventing navbar items from being clipped at high zoom levels.
- * - `<main>` (`overflow-auto flex-1 min-h-0`) is the actual scroll container.
- *
- * Fixed-toolbar pattern for child pages:
- * Wrap content in `<div className="flex flex-col h-full">`. Place `<Toolbar>` at the top
- * (static), then a `<div className="flex-1 overflow-auto -mx-4 sm:-mx-6 …">` for the
- * scrollable list. Negative horizontal margins cancel `<main>`'s padding so the list
- * extends edge-to-edge; padding is re-applied inside the div.
- */
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
-import { AppSidebar } from "@/components/layout/sidebar";
+import { AppSidebar, GlobalSidebarProvider } from "@/components/layout/sidebar";
 import { NavBar } from "@/components/layout/navbar";
-import { PageHeader } from "@/components/layout/page-header";
-import { BreadcrumbProvider } from "@/components/layout/breadcrumb-context";
 
-/**
- * Authenticated app shell shared by all pages under `(app)/`.
- *
- * Composes the collapsible sidebar, top navbar (server component), and the
- * purple breadcrumb header into a standard two-column layout. Page content
- * is rendered inside `<main>` via the `children` slot.
- *
- * `h-dvh overflow-hidden` on SidebarProvider constrains the shell to the
- * viewport height so that `<main>` (overflow-auto) is the scroll container —
- * not the body. This makes `sticky` positioning work inside <main>.
- */
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
-    <SidebarProvider className="h-dvh">
-      <BreadcrumbProvider>
-        <AppSidebar />
-        <SidebarInset className="overflow-hidden">
-          <NavBar />
-          <PageHeader />
-          <main className="flex-1 min-h-0 overflow-auto flex flex-col p-4 sm:p-6">
-            {children}
-          </main>
-        </SidebarInset>
-      </BreadcrumbProvider>
-    </SidebarProvider>
+    <GlobalSidebarProvider>
+      {/* Full-height flex column: navbar on top, sidebar+content row below */}
+      <div className="h-dvh flex flex-col">
+        <NavBar />
+        <div className="flex flex-1 min-h-0 overflow-hidden">
+          <AppSidebar />
+          <div className="flex flex-col flex-1 overflow-hidden">
+            <main className="flex-1 min-h-0 overflow-auto flex flex-col p-4 sm:p-6">
+              {children}
+            </main>
+          </div>
+        </div>
+      </div>
+    </GlobalSidebarProvider>
   );
 }

--- a/app/(app)/orgs/(organizations)/_components/org-management-nav.tsx
+++ b/app/(app)/orgs/(organizations)/_components/org-management-nav.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { Building2, PlusCircle, Network, Mail } from "lucide-react";
+import { SidebarNavItem } from "@/components/layout/sidebar-nav-item";
+
+const items = [
+  { title: "Create", url: "/orgs/new", icon: PlusCircle, disabled: false },
+  { title: "Join", url: "/orgs/join", icon: Network, disabled: false },
+  { title: "Invite", url: "/orgs/invite", icon: Mail, disabled: true },
+  { title: "List", url: "/orgs", icon: Building2, disabled: true },
+];
+
+export function OrgManagementNav() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="flex flex-col flex-1 overflow-y-auto">
+      <div className="h-12 flex items-center px-4 border-b border-border shrink-0">
+        <span className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider">Organizations</span>
+      </div>
+      {items.map(({ title, url, icon, disabled }) => (
+        <SidebarNavItem
+          key={url}
+          title={title}
+          url={url}
+          icon={icon}
+          disabled={disabled}
+          isActive={pathname === url}
+        />
+      ))}
+    </aside>
+  );
+}

--- a/app/(app)/orgs/(organizations)/invite/page.tsx
+++ b/app/(app)/orgs/(organizations)/invite/page.tsx
@@ -1,0 +1,8 @@
+export default function InvitePage() {
+  return (
+    <div className="max-w-md">
+      <h1 className="text-xl font-semibold mb-1">Invitations</h1>
+      <p className="text-sm text-muted-foreground">Coming soon.</p>
+    </div>
+  );
+}

--- a/app/(app)/orgs/(organizations)/join/join-franchise-client.tsx
+++ b/app/(app)/orgs/(organizations)/join/join-franchise-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,7 +9,7 @@ import { Separator } from "@/components/ui/separator";
 import { TimezoneSelect } from "@/components/ui/timezone-select";
 import { TIMEZONES } from "@/lib/timezones";
 import { SegmentedControl } from "@/components/ui/segmented-control";
-import { createOrg } from "@/app/actions/orgs";
+import { joinFranchise } from "@/app/actions/orgs";
 
 function timeToMinutes(time: string) {
   const [h, m] = time.split(":").map(Number);
@@ -28,7 +28,6 @@ const ALL_DAYS = [
 
 type DayKey = (typeof ALL_DAYS)[number]["key"];
 
-/** Shared schedule fields used by both Create and Join forms */
 function ScheduleFields({
   timezone,
   setTimezone,
@@ -123,25 +122,8 @@ function useScheduleState() {
   const [address, setAddress] = useState("");
   const [openTime, setOpenTime] = useState("");
   const [closeTime, setCloseTime] = useState("");
-  const [days, setDays] = useState<DayKey[]>([
-    "mon",
-    "tue",
-    "wed",
-    "thu",
-    "fri",
-  ]);
-  return {
-    timezone,
-    setTimezone,
-    address,
-    setAddress,
-    openTime,
-    setOpenTime,
-    closeTime,
-    setCloseTime,
-    days,
-    setDays,
-  };
+  const [days, setDays] = useState<DayKey[]>(["mon", "tue", "wed", "thu", "fri"]);
+  return { timezone, setTimezone, address, setAddress, openTime, setOpenTime, closeTime, setCloseTime, days, setDays };
 }
 
 function buildSchedulePayload(s: ReturnType<typeof useScheduleState>) {
@@ -159,22 +141,25 @@ function buildSchedulePayload(s: ReturnType<typeof useScheduleState>) {
   };
 }
 
-// ─── Create Org Form ────────────────────────────────────────────────────────
-
-export default function NewOrgPage() {
+export default function JoinFranchisePage() {
   const router = useRouter();
-  const [title, setTitle] = useState("");
+  const searchParams = useSearchParams();
+  const initialToken = searchParams.get("token") ?? "";
+
+  const [manualToken, setManualToken] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const schedule = useScheduleState();
+
+  const effectiveToken = initialToken || manualToken;
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setLoading(true);
     try {
-      const result = await createOrg({
-        title,
+      const result = await joinFranchise({
+        token: effectiveToken,
         ...buildSchedulePayload(schedule),
       });
       if (!result.ok) {
@@ -191,45 +176,49 @@ export default function NewOrgPage() {
 
   return (
     <div className="max-w-md mx-auto mt-12 pb-16">
-      <h1 className="text-xl font-semibold mb-1">Create Organization</h1>
+      <h1 className="text-xl font-semibold mb-1">Join Franchise</h1>
       <p className="text-sm text-muted-foreground mb-6">
-        Set up a new standalone or parent organization.
+        Join an existing franchise using your invite token. Your org name and
+        role structure will be set up automatically.
       </p>
 
       <div className="rounded-xl border bg-card p-6 shadow-sm">
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium" htmlFor="title">
-              Org Name <span className="text-destructive">*</span>
-            </label>
-            <Input
-              id="title"
-              placeholder="e.g. Acme Corp"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              required
-            />
-          </div>
+          {!initialToken && (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium" htmlFor="token">
+                Invite Link / Token <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="token"
+                placeholder="Paste your invite link or token"
+                value={manualToken}
+                onChange={(e) => setManualToken(e.target.value)}
+                required
+              />
+              <p className="text-xs text-muted-foreground">
+                Tokens expire after 1 hour and can only be used once.
+              </p>
+            </div>
+          )}
 
           <ScheduleFields {...schedule} />
 
           {error && <p className="text-sm text-destructive">{error}</p>}
 
           <Button type="submit" disabled={loading}>
-            {loading ? "Creating..." : "Create Organization"}
+            {loading ? "Joining..." : "Join Franchise"}
           </Button>
 
           <Separator />
 
           <div className="text-center">
-            <span className="text-sm text-muted-foreground">
-              Have an invite token?{" "}
-            </span>
+            <span className="text-sm text-muted-foreground">Starting fresh? </span>
             <Link
-              href="/orgs/join"
+              href="/orgs/new"
               className="text-sm font-medium text-primary hover:underline"
             >
-              Join a Franchise instead
+              Create an Organization instead
             </Link>
           </div>
         </form>

--- a/app/(app)/orgs/(organizations)/join/join-franchise-client.tsx
+++ b/app/(app)/orgs/(organizations)/join/join-franchise-client.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { TimezoneSelect } from "@/components/ui/timezone-select";
-import { TIMEZONES } from "@/lib/timezones";
+import type { TimezoneOption } from "@/lib/timezones";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { joinFranchise } from "@/app/actions/orgs";
 
@@ -39,6 +39,7 @@ function ScheduleFields({
   setCloseTime,
   days,
   setDays,
+  timezones,
 }: {
   timezone: string;
   setTimezone: (v: string) => void;
@@ -50,6 +51,7 @@ function ScheduleFields({
   setCloseTime: (v: string) => void;
   days: DayKey[];
   setDays: (v: DayKey[]) => void;
+  timezones: TimezoneOption[];
 }) {
   return (
     <>
@@ -61,7 +63,7 @@ function ScheduleFields({
           <TimezoneSelect
             value={timezone}
             onChange={setTimezone}
-            timezones={TIMEZONES}
+            timezones={timezones}
             className="w-full"
           />
         </div>
@@ -141,7 +143,7 @@ function buildSchedulePayload(s: ReturnType<typeof useScheduleState>) {
   };
 }
 
-export default function JoinFranchisePage() {
+export default function JoinFranchisePage({ timezones }: { timezones: TimezoneOption[] }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const initialToken = searchParams.get("token") ?? "";
@@ -167,8 +169,8 @@ export default function JoinFranchisePage() {
         return;
       }
       router.push(`/orgs/${result.orgId}/timetable`);
-    } catch {
-      setError("Something went wrong");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
     } finally {
       setLoading(false);
     }
@@ -202,7 +204,7 @@ export default function JoinFranchisePage() {
             </div>
           )}
 
-          <ScheduleFields {...schedule} />
+          <ScheduleFields {...schedule} timezones={timezones} />
 
           {error && <p className="text-sm text-destructive">{error}</p>}
 

--- a/app/(app)/orgs/(organizations)/join/page.tsx
+++ b/app/(app)/orgs/(organizations)/join/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from "react";
+import JoinFranchisePage from "./join-franchise-client";
+
+export default function Page() {
+  return (
+    <Suspense>
+      <JoinFranchisePage />
+    </Suspense>
+  );
+}

--- a/app/(app)/orgs/(organizations)/join/page.tsx
+++ b/app/(app)/orgs/(organizations)/join/page.tsx
@@ -1,10 +1,11 @@
 import { Suspense } from "react";
+import { TIMEZONES } from "@/lib/timezones";
 import JoinFranchisePage from "./join-franchise-client";
 
 export default function Page() {
   return (
-    <Suspense>
-      <JoinFranchisePage />
+    <Suspense fallback={<div className="max-w-md mx-auto mt-12 pb-16"><div className="rounded-xl border bg-card p-6 shadow-sm h-[500px]" /></div>}>
+      <JoinFranchisePage timezones={TIMEZONES} />
     </Suspense>
   );
 }

--- a/app/(app)/orgs/(organizations)/layout.tsx
+++ b/app/(app)/orgs/(organizations)/layout.tsx
@@ -1,0 +1,15 @@
+import { RegisterPageSidebar } from "@/components/layout/page-sidebar-context";
+import { OrgManagementNav } from "./_components/org-management-nav";
+
+export default function OrganizationsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <RegisterPageSidebar content={<OrgManagementNav />} />
+      {children}
+    </>
+  );
+}

--- a/app/(app)/orgs/(organizations)/new/new-org-client.tsx
+++ b/app/(app)/orgs/(organizations)/new/new-org-client.tsx
@@ -62,6 +62,7 @@ function ScheduleFields({
             Time Zone
           </label>
           <TimezoneSelect
+            id="timezone"
             value={timezone}
             onChange={setTimezone}
             timezones={timezones}
@@ -175,8 +176,14 @@ export default function NewOrgPage({ timezones }: { timezones: TimezoneOption[] 
     setError(null);
     setLoading(true);
     try {
+      const trimmedTitle = title.trim();
+      if (!trimmedTitle) {
+        setError("Organization name is required");
+        setLoading(false);
+        return;
+      }
       const result = await createOrg({
-        title,
+        title: trimmedTitle,
         ...buildSchedulePayload(schedule),
       });
       if (!result.ok) {

--- a/app/(app)/orgs/(organizations)/new/new-org-client.tsx
+++ b/app/(app)/orgs/(organizations)/new/new-org-client.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { TimezoneSelect } from "@/components/ui/timezone-select";
-import { TIMEZONES } from "@/lib/timezones";
+import type { TimezoneOption } from "@/lib/timezones";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { createOrg } from "@/app/actions/orgs";
 
@@ -40,6 +40,7 @@ function ScheduleFields({
   setCloseTime,
   days,
   setDays,
+  timezones,
 }: {
   timezone: string;
   setTimezone: (v: string) => void;
@@ -51,6 +52,7 @@ function ScheduleFields({
   setCloseTime: (v: string) => void;
   days: DayKey[];
   setDays: (v: DayKey[]) => void;
+  timezones: TimezoneOption[];
 }) {
   return (
     <>
@@ -62,7 +64,7 @@ function ScheduleFields({
           <TimezoneSelect
             value={timezone}
             onChange={setTimezone}
-            timezones={TIMEZONES}
+            timezones={timezones}
             className="w-full"
           />
         </div>
@@ -161,7 +163,7 @@ function buildSchedulePayload(s: ReturnType<typeof useScheduleState>) {
 
 // ─── Create Org Form ────────────────────────────────────────────────────────
 
-export default function NewOrgPage() {
+export default function NewOrgPage({ timezones }: { timezones: TimezoneOption[] }) {
   const router = useRouter();
   const [title, setTitle] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -182,8 +184,8 @@ export default function NewOrgPage() {
         return;
       }
       router.push(`/orgs/${result.orgId}/timetable`);
-    } catch {
-      setError("Something went wrong");
+    } catch (error) {
+      setError(error instanceof Error ? error.message : "Something went wrong");
     } finally {
       setLoading(false);
     }
@@ -211,7 +213,7 @@ export default function NewOrgPage() {
             />
           </div>
 
-          <ScheduleFields {...schedule} />
+          <ScheduleFields {...schedule} timezones={timezones} />
 
           {error && <p className="text-sm text-destructive">{error}</p>}
 

--- a/app/(app)/orgs/(organizations)/new/new-org-client.tsx
+++ b/app/(app)/orgs/(organizations)/new/new-org-client.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { TimezoneSelect } from "@/components/ui/timezone-select";
-import type { TimezoneOption } from "@/lib/timezones";
+import { TIMEZONES } from "@/lib/timezones";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { createOrg, joinFranchise } from "@/app/actions/orgs";
 
@@ -31,7 +31,6 @@ type DayKey = (typeof ALL_DAYS)[number]["key"];
 function ScheduleFields({
   timezone,
   setTimezone,
-  timezones,
   address,
   setAddress,
   openTime,
@@ -43,7 +42,6 @@ function ScheduleFields({
 }: {
   timezone: string;
   setTimezone: (v: string) => void;
-  timezones: TimezoneOption[];
   address: string;
   setAddress: (v: string) => void;
   openTime: string;
@@ -63,7 +61,7 @@ function ScheduleFields({
           <TimezoneSelect
             value={timezone}
             onChange={setTimezone}
-            timezones={timezones}
+            timezones={TIMEZONES}
             className="w-full"
           />
         </div>
@@ -162,7 +160,7 @@ function buildSchedulePayload(s: ReturnType<typeof useScheduleState>) {
 
 // ─── Create Org Form ────────────────────────────────────────────────────────
 
-function CreateOrgForm({ onSwitch, timezones }: { onSwitch: () => void; timezones: TimezoneOption[] }) {
+function CreateOrgForm({ onSwitch }: { onSwitch: () => void }) {
   const router = useRouter();
   const [title, setTitle] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -205,7 +203,7 @@ function CreateOrgForm({ onSwitch, timezones }: { onSwitch: () => void; timezone
         />
       </div>
 
-      <ScheduleFields {...schedule} timezones={timezones} />
+      <ScheduleFields {...schedule} />
 
       {error && <p className="text-sm text-destructive">{error}</p>}
 
@@ -236,11 +234,9 @@ function CreateOrgForm({ onSwitch, timezones }: { onSwitch: () => void; timezone
 function JoinFranchiseForm({
   onSwitch,
   initialToken = "",
-  timezones,
 }: {
   onSwitch: () => void;
   initialToken?: string;
-  timezones: TimezoneOption[];
 }) {
   const router = useRouter();
   const [manualToken, setManualToken] = useState("");
@@ -291,7 +287,7 @@ function JoinFranchiseForm({
         </div>
       )}
 
-      <ScheduleFields {...schedule} timezones={timezones} />
+      <ScheduleFields {...schedule} />
 
       {error && <p className="text-sm text-destructive">{error}</p>}
 
@@ -317,7 +313,7 @@ function JoinFranchiseForm({
 
 // ─── Page ────────────────────────────────────────────────────────────────────
 
-export default function NewOrgPage({ timezones }: { timezones: TimezoneOption[] }) {
+export default function NewOrgPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const hasTokenParam = searchParams.has("token");
@@ -345,12 +341,11 @@ export default function NewOrgPage({ timezones }: { timezones: TimezoneOption[] 
 
       <div className="rounded-xl border bg-card p-6 shadow-sm">
         {mode === "create" ? (
-          <CreateOrgForm onSwitch={switchToJoin} timezones={timezones} />
+          <CreateOrgForm onSwitch={switchToJoin} />
         ) : (
           <JoinFranchiseForm
             onSwitch={switchToCreate}
             initialToken={initialToken}
-            timezones={timezones}
           />
         )}
       </div>

--- a/app/(app)/orgs/(organizations)/new/page.tsx
+++ b/app/(app)/orgs/(organizations)/new/page.tsx
@@ -1,11 +1,10 @@
 import { Suspense } from "react";
 import NewOrgPage from "./new-org-client";
-import { TIMEZONES } from "@/lib/timezones";
 
 export default function Page() {
   return (
     <Suspense>
-      <NewOrgPage timezones={TIMEZONES} />
+      <NewOrgPage />
     </Suspense>
   );
 }

--- a/app/(app)/orgs/(organizations)/new/page.tsx
+++ b/app/(app)/orgs/(organizations)/new/page.tsx
@@ -1,10 +1,11 @@
 import { Suspense } from "react";
+import { TIMEZONES } from "@/lib/timezones";
 import NewOrgPage from "./new-org-client";
 
 export default function Page() {
   return (
     <Suspense>
-      <NewOrgPage />
+      <NewOrgPage timezones={TIMEZONES} />
     </Suspense>
   );
 }

--- a/app/(app)/orgs/(organizations)/page.tsx
+++ b/app/(app)/orgs/(organizations)/page.tsx
@@ -1,0 +1,8 @@
+export default function OrgsListPage() {
+  return (
+    <div className="max-w-md">
+      <h1 className="text-xl font-semibold mb-1">Organizations</h1>
+      <p className="text-sm text-muted-foreground">Coming soon.</p>
+    </div>
+  );
+}

--- a/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
@@ -243,7 +243,7 @@ export function MembersView({
         </div>
       </Toolbar>
 
-      <div className="flex-1 overflow-auto -mx-4 sm:-mx-6 px-4 sm:px-6 pt-4 sm:pt-6 pb-4 sm:pb-6 -mt-4 sm:-mt-6">
+      <div className="flex-1 overflow-auto -mx-4 sm:-mx-6 px-4 sm:px-6 pt-4 sm:pt-6 pb-4 sm:pb-6">
         {filtered.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             {members.length === 0

--- a/app/(app)/orgs/[orgId]/settings/_components/settings-nav.tsx
+++ b/app/(app)/orgs/[orgId]/settings/_components/settings-nav.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useParams, usePathname } from "next/navigation";
+import { Building2, ShieldCheck, Calendar, Bell } from "lucide-react";
+import { SidebarNavItem } from "@/components/layout/sidebar-nav-item";
+
+export function SettingsNav() {
+  const { orgId } = useParams<{ orgId: string }>();
+  const pathname = usePathname();
+
+  const items = [
+    { title: "Organization", url: `/orgs/${orgId}/settings/organization`, icon: Building2, disabled: false },
+    { title: "Roles", url: `/orgs/${orgId}/settings/roles`, icon: ShieldCheck, disabled: false },
+    { title: "Timetable", url: `/orgs/${orgId}/settings/timetable`, icon: Calendar, disabled: true },
+    { title: "Notification", url: `/orgs/${orgId}/settings/notification`, icon: Bell, disabled: true },
+  ];
+
+  return (
+    <aside className="flex flex-col flex-1 overflow-y-auto">
+      <div className="h-12 flex items-center px-4 border-b border-border shrink-0">
+        <span className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider">Settings</span>
+      </div>
+      {items.map(({ title, url, icon, disabled }) => (
+        <SidebarNavItem
+          key={url}
+          title={title}
+          url={url}
+          icon={icon}
+          disabled={disabled}
+          isActive={pathname === url || pathname.startsWith(`${url}/`)}
+        />
+      ))}
+    </aside>
+  );
+}

--- a/app/(app)/orgs/[orgId]/settings/layout.tsx
+++ b/app/(app)/orgs/[orgId]/settings/layout.tsx
@@ -1,5 +1,7 @@
 import { PermissionAction } from "@prisma/client";
 import { requireOrgPermissionPage } from "@/lib/authz";
+import { RegisterPageSidebar } from "@/components/layout/page-sidebar-context";
+import { SettingsNav } from "./_components/settings-nav";
 
 /**
  * Layout guard for all settings subroutes.
@@ -19,5 +21,10 @@ export default async function SettingsLayout({
   await requireOrgPermissionPage(orgId, PermissionAction.MANAGE_SETTINGS, {
     redirectTo: `/orgs/${orgId}`,
   });
-  return <>{children}</>;
+  return (
+    <>
+      <RegisterPageSidebar content={<SettingsNav />} />
+      {children}
+    </>
+  );
 }

--- a/app/(app)/orgs/[orgId]/settings/roles/page.tsx
+++ b/app/(app)/orgs/[orgId]/settings/roles/page.tsx
@@ -27,7 +27,7 @@ export default async function RolesPage({
   return (
     <>
       <Toolbar>
-        <div />
+        <div className="flex-1" />
         <Button asChild size="sm">
           <Link href={`/orgs/${orgId}/settings/roles/new`}>+ Add Role</Link>
         </Button>

--- a/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
@@ -273,7 +273,7 @@ export function TaskTable({
         </div>
       </Toolbar>
 
-      <div className="flex-1 overflow-auto -mx-4 sm:-mx-6 px-4 sm:px-6 pt-4 sm:pt-6 pb-4 sm:pb-6 -mt-4 sm:-mt-6">
+      <div className="flex-1 overflow-auto -mx-4 sm:-mx-6 px-4 sm:px-6 pt-4 sm:pt-6 pb-4 sm:pb-6">
         {visible.length === 0 ? (
           <div className="flex items-center justify-center border py-24">
             <div className="flex flex-col items-center gap-3 text-center">

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client/index.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client/index.tsx
@@ -162,7 +162,7 @@ export function TimetableClient({
   return (
     <div className={`flex flex-col${fillHeight ? " flex-1 min-h-0" : ""}`}>
       {/* Combined toolbar */}
-      <div className="-mx-4 -mt-4 mb-4 border-b bg-card px-4 h-12 shrink-0 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:-mx-6 sm:-mt-6 sm:mb-4 sm:px-6">
+      <div className="-mx-4 -mt-4 mb-4 border-b bg-card px-4 min-h-12 py-3 shrink-0 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:-mx-6 sm:-mt-6 sm:mb-4 sm:px-6">
         {/* Row 1 (always): prev / date label / next + Today */}
         <div className="flex items-center gap-2">
           <div className="flex items-center gap-0.5">

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client/index.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client/index.tsx
@@ -162,7 +162,7 @@ export function TimetableClient({
   return (
     <div className={`flex flex-col${fillHeight ? " flex-1 min-h-0" : ""}`}>
       {/* Combined toolbar */}
-      <div className="-mx-4 -mt-4 mb-4 border-b bg-card px-4 py-2 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:-mx-6 sm:-mt-6 sm:mb-4 sm:px-6">
+      <div className="-mx-4 -mt-4 mb-4 border-b bg-card px-4 h-12 shrink-0 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:-mx-6 sm:-mt-6 sm:mb-4 sm:px-6">
         {/* Row 1 (always): prev / date label / next + Today */}
         <div className="flex items-center gap-2">
           <div className="flex items-center gap-0.5">

--- a/app/(app)/orgs/new/new-org-client.tsx
+++ b/app/(app)/orgs/new/new-org-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,7 +9,6 @@ import { TimezoneSelect } from "@/components/ui/timezone-select";
 import type { TimezoneOption } from "@/lib/timezones";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { createOrg, joinFranchise } from "@/app/actions/orgs";
-import { useBreadcrumbOverride } from "@/components/layout/breadcrumb-context";
 
 function timeToMinutes(time: string) {
   const [h, m] = time.split(":").map(Number);
@@ -324,12 +323,6 @@ export default function NewOrgPage({ timezones }: { timezones: TimezoneOption[] 
   const hasTokenParam = searchParams.has("token");
   const initialToken = searchParams.get("token") ?? "";
   const mode = hasTokenParam ? "join" : "create";
-  const { setOverride } = useBreadcrumbOverride();
-
-  useEffect(() => {
-    setOverride(mode === "join" ? "Join Franchise" : "Create Organization");
-    return () => setOverride(null);
-  }, [mode, setOverride]);
 
   function switchToJoin() {
     router.push("/orgs/new?token=");

--- a/components/layout/breadcrumb-context.tsx
+++ b/components/layout/breadcrumb-context.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+// REMOVED FROM PROJECT — breadcrumb feature was removed. File kept for reference.
+// Not imported or used anywhere. Safe to delete in a future cleanup.
+
 /**
  * Breadcrumb override context.
  *

--- a/components/layout/mobile-sidebar-context.tsx
+++ b/components/layout/mobile-sidebar-context.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+type MobileSidebarCtxValue = {
+  open: boolean;
+  setOpen: (v: boolean) => void;
+};
+
+export const MobileSidebarCtx = createContext<MobileSidebarCtxValue>({
+  open: false,
+  setOpen: () => {},
+});
+
+export function GlobalSidebarProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <MobileSidebarCtx.Provider value={{ open, setOpen }}>
+      {children}
+    </MobileSidebarCtx.Provider>
+  );
+}
+
+export function useMobileSidebar() {
+  return useContext(MobileSidebarCtx);
+}

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -4,11 +4,8 @@ import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import { Button } from "@/components/ui/button";
 import { OrgSwitcher } from "@/components/layout/org-switcher";
-import {
-  NavbarSidebarTrigger,
-  NavbarLogo,
-  NavbarLogoSpacer,
-} from "@/components/layout/navbar-sidebar-trigger";
+import { MobileSidebarTrigger } from "@/components/layout/sidebar";
+import { Logo } from "@/components/layout/logo";
 import { NotificationPanel } from "@/components/notifications";
 import {
   getInvitesForUser,
@@ -70,18 +67,19 @@ export const NavBar = async () => {
 
   return (
     <header
-      className="sticky top-0 z-20 min-h-14 border-b border-border bg-card flex items-end justify-between px-4 pb-0"
+      className="sticky top-0 z-20 min-h-14 border-b border-border bg-card flex items-end justify-between pr-4 pl-0 pb-0"
       style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}
     >
       {/* inner row always 3.5rem (h-14) tall */}
       <div className="flex w-full items-center justify-between h-14">
-        {/* Left: sidebar toggle, app title, org switcher */}
+        {/* Left: logo + mobile menu trigger + org switcher */}
         <div className="flex items-center gap-2 min-w-0">
-          <NavbarSidebarTrigger />
-          <span className="hidden sm:contents">
-            <NavbarLogo />
-            <NavbarLogoSpacer />
-          </span>
+          <Button variant="ghost" asChild className="h-auto px-2 py-1.5 rounded-md hidden md:flex">
+            <Link href="/">
+              <Logo className="text-foreground" />
+            </Link>
+          </Button>
+          <MobileSidebarTrigger />
           <OrgSwitcher orgs={orgs} />
         </div>
 

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -67,16 +67,16 @@ export const NavBar = async () => {
 
   return (
     <header
-      className="sticky top-0 z-20 min-h-14 border-b border-border bg-card flex items-end justify-between pr-4 pl-0 pb-0"
+      className="sticky top-0 z-20 min-h-12 border-b border-border bg-card flex items-end justify-between pr-4 pl-0 pb-0"
       style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}
     >
-      {/* inner row always 3.5rem (h-14) tall */}
-      <div className="flex w-full items-center justify-between h-14">
+      {/* inner row always 3rem (h-12) tall */}
+      <div className="flex w-full items-center justify-between h-12">
         {/* Left: logo + mobile menu trigger + org switcher */}
-        <div className="flex items-center gap-2 min-w-0">
-          <Button variant="ghost" asChild className="h-auto px-2 py-1.5 rounded-md hidden md:flex">
+        <div className="flex items-center gap-2 min-w-0 pl-3 md:pl-0">
+          <Button variant="ghost" asChild className="h-auto px-2 py-1.5 rounded-md hidden md:flex hover:bg-blue-100 hover:text-blue-700 transition-colors">
             <Link href="/">
-              <Logo className="text-foreground" />
+              <Logo className="text-current" />
             </Link>
           </Button>
           <MobileSidebarTrigger />

--- a/components/layout/page-header.tsx
+++ b/components/layout/page-header.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+// REMOVED FROM PROJECT — breadcrumb/page-header feature was removed. File kept for reference.
+// Not imported or used anywhere. Safe to delete in a future cleanup.
+
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
@@ -166,7 +169,7 @@ export function PageHeader() {
   if (baseCrumbs.length === 0) return null;
 
   return (
-    <div className="sticky top-(--safe-header-height) z-10 border-b bg-card px-6 py-2.5">
+    <div className="border-b bg-card px-6 py-2.5">
       <nav className="flex items-center gap-1 text-sm">
         {crumbs.map((crumb, i) => {
           const isLast = i === crumbs.length - 1;

--- a/components/layout/page-sidebar-context.tsx
+++ b/components/layout/page-sidebar-context.tsx
@@ -73,7 +73,7 @@ export function PageSidebarSlot() {
 
       {/* Mobile: overlay anchored right of the AppSidebar icon strip */}
       {open && (
-        <div className="md:hidden fixed inset-y-0 left-12 z-50 flex flex-col w-[260px] bg-sidebar border-r border-border overflow-hidden">
+        <div className="md:hidden fixed inset-y-0 left-12 z-50 flex flex-col w-[260px] bg-sidebar border-r border-border overflow-y-auto max-h-screen">
           {sidebar}
         </div>
       )}

--- a/components/layout/page-sidebar-context.tsx
+++ b/components/layout/page-sidebar-context.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { createContext, useContext, useState, useEffect, type ReactNode } from "react";
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { useMobileSidebar } from "@/components/layout/mobile-sidebar-context";
+import { usePersistedState } from "@/hooks/use-persisted-state";
+
+type PageSidebarCtxValue = {
+  sidebar: ReactNode | null;
+  setSidebar: (node: ReactNode | null) => void;
+};
+
+const PageSidebarCtx = createContext<PageSidebarCtxValue>({
+  sidebar: null,
+  setSidebar: () => {},
+});
+
+export function PageSidebarProvider({ children }: { children: ReactNode }) {
+  const [sidebar, setSidebar] = useState<ReactNode | null>(null);
+  return (
+    <PageSidebarCtx.Provider value={{ sidebar, setSidebar }}>
+      {children}
+    </PageSidebarCtx.Provider>
+  );
+}
+
+/** Returns whether a page sidebar is currently registered. */
+export function useHasPageSidebar() {
+  return useContext(PageSidebarCtx).sidebar !== null;
+}
+
+/**
+ * Renders the registered page sidebar.
+ * - Desktop: inline in the flex layout
+ * - Mobile: fixed overlay at left-12 (right next to AppSidebar) when hamburger is open
+ */
+export function PageSidebarSlot() {
+  const { sidebar } = useContext(PageSidebarCtx);
+  const { open } = useMobileSidebar();
+  const [collapsed, setCollapsed] = usePersistedState("page-sidebar-collapsed", false);
+
+  if (!sidebar) return null;
+
+  return (
+    <>
+      {/* Desktop */}
+      {collapsed ? (
+        /* Collapsed: zero-width, button floats over content */
+        <div className="hidden md:block relative w-0 shrink-0">
+          <button
+            onClick={() => setCollapsed(false)}
+            className="absolute top-0 left-0 z-10 flex items-center justify-center w-12 h-12 rounded-none bg-sidebar border-r border-b border-border text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+            aria-label="Expand sidebar"
+          >
+            <PanelLeftOpen className="h-5 w-5" />
+          </button>
+        </div>
+      ) : (
+        /* Expanded: in-flow panel, button floats absolute over content */
+        <div className="hidden md:flex flex-col relative w-[260px] shrink-0 border-r border-border bg-sidebar overflow-hidden">
+          <div className="flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
+            {sidebar}
+          </div>
+          <button
+            onClick={() => setCollapsed(true)}
+            className="absolute top-0 right-0 z-10 flex items-center justify-center w-12 h-12 rounded-none border-b border-l border-border text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+            aria-label="Collapse sidebar"
+          >
+            <PanelLeftClose className="h-5 w-5" />
+          </button>
+        </div>
+      )}
+
+      {/* Mobile: overlay anchored right of the AppSidebar icon strip */}
+      {open && (
+        <div className="md:hidden fixed inset-y-0 left-12 z-50 flex flex-col w-[260px] bg-sidebar border-r border-border overflow-hidden">
+          {sidebar}
+        </div>
+      )}
+    </>
+  );
+}
+
+/**
+ * Register a page-level sidebar from any layout.
+ * Clears automatically when the layout unmounts (route group change).
+ */
+export function RegisterPageSidebar({ content }: { content: ReactNode }) {
+  const { setSidebar } = useContext(PageSidebarCtx);
+  useEffect(() => {
+    setSidebar(content);
+    return () => setSidebar(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return null;
+}

--- a/components/layout/page-sidebar-context.tsx
+++ b/components/layout/page-sidebar-context.tsx
@@ -90,7 +90,6 @@ export function RegisterPageSidebar({ content }: { content: ReactNode }) {
   useEffect(() => {
     setSidebar(content);
     return () => setSidebar(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [content, setSidebar]);
   return null;
 }

--- a/components/layout/sidebar-nav-item.tsx
+++ b/components/layout/sidebar-nav-item.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import type { ComponentType } from "react";
+
+type SidebarNavItemProps = {
+  title: string;
+  url: string;
+  icon: ComponentType<{ className?: string }>;
+  disabled?: boolean;
+  isActive: boolean;
+  /** "app" = fixed w-12 icon wrapper for the collapsible global sidebar.
+   *  "page" = standard px-3 gap layout for full-width page sidebars. */
+  variant?: "app" | "page";
+  onClick?: () => void;
+};
+
+export function SidebarNavItem({
+  title,
+  url,
+  icon: Icon,
+  disabled,
+  isActive,
+  variant = "page",
+  onClick,
+}: SidebarNavItemProps) {
+  const active = "bg-sidebar-primary text-sidebar-primary-foreground font-medium";
+  const hover = "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground";
+
+  if (variant === "app") {
+    const base = "flex items-center h-12 w-full overflow-hidden rounded-none transition-colors";
+    const inner = (
+      <>
+        <span className="w-12 flex items-center justify-center shrink-0">
+          <Icon className="h-5 w-5" />
+        </span>
+        <span className="whitespace-nowrap text-sm pr-3">
+          {title}
+        </span>
+      </>
+    );
+    if (disabled) return <div className={cn(base, "opacity-40 pointer-events-none text-sidebar-foreground")}>{inner}</div>;
+    return (
+      <Link href={url} onClick={onClick} className={cn(base, isActive ? active : cn("text-sidebar-foreground", hover))}>
+        {inner}
+      </Link>
+    );
+  }
+
+  // page variant
+  const base = "flex items-center gap-2.5 h-12 px-4 text-sm transition-colors";
+  const inner = (
+    <>
+      <Icon className="h-5 w-5 shrink-0" />
+      <span className="truncate">{title}</span>
+    </>
+  );
+  if (disabled) {
+    return (
+      <div className={cn(base, "opacity-40 pointer-events-none text-sidebar-foreground")}>
+        {inner}
+      </div>
+    );
+  }
+  return (
+    <Link
+      href={url}
+      onClick={onClick}
+      className={cn(base, isActive ? active : cn("text-sidebar-foreground", hover))}
+    >
+      {inner}
+    </Link>
+  );
+}

--- a/components/layout/sidebar-nav-item.tsx
+++ b/components/layout/sidebar-nav-item.tsx
@@ -40,9 +40,9 @@ export function SidebarNavItem({
         </span>
       </>
     );
-    if (disabled) return <div className={cn(base, "opacity-40 pointer-events-none text-sidebar-foreground")}>{inner}</div>;
+    if (disabled) return <div className={cn(base, "opacity-40 pointer-events-none text-sidebar-foreground")} role="link" aria-disabled="true">{inner}</div>;
     return (
-      <Link href={url} onClick={onClick} className={cn(base, isActive ? active : cn("text-sidebar-foreground", hover))}>
+      <Link href={url} onClick={onClick} className={cn(base, isActive ? active : cn("text-sidebar-foreground", hover))} aria-current={isActive ? "page" : undefined}>
         {inner}
       </Link>
     );
@@ -58,7 +58,7 @@ export function SidebarNavItem({
   );
   if (disabled) {
     return (
-      <div className={cn(base, "opacity-40 pointer-events-none text-sidebar-foreground")}>
+      <div className={cn(base, "opacity-40 pointer-events-none text-sidebar-foreground")} role="link" aria-disabled="true">
         {inner}
       </div>
     );
@@ -68,6 +68,7 @@ export function SidebarNavItem({
       href={url}
       onClick={onClick}
       className={cn(base, isActive ? active : cn("text-sidebar-foreground", hover))}
+      aria-current={isActive ? "page" : undefined}
     >
       {inner}
     </Link>

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, createContext, useContext } from "react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
-import { Logo } from "@/components/layout/logo";
+import { cn } from "@/lib/utils";
 import {
   LayoutDashboard,
   Building2,
@@ -24,25 +24,46 @@ import {
   ShieldCheck,
   Bell,
   Network,
-  PanelLeftClose,
+  HeartHandshake,
+  X,
+  Menu,
 } from "lucide-react";
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarFooter,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarHeader,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  SidebarMenuSub,
-  SidebarMenuSubButton,
-  SidebarMenuSubItem,
-  SidebarSeparator,
-  useSidebar,
-} from "@/components/ui/sidebar";
-import { cn } from "@/lib/utils";
+
+// ─── Mobile sidebar context ───────────────────────────────────────────────────
+
+const MobileSidebarCtx = createContext<{
+  open: boolean;
+  setOpen: (v: boolean) => void;
+}>({ open: false, setOpen: () => {} });
+
+export function GlobalSidebarProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <MobileSidebarCtx.Provider value={{ open, setOpen }}>
+      {children}
+    </MobileSidebarCtx.Provider>
+  );
+}
+
+/** Hamburger trigger rendered in the navbar on mobile. */
+export function MobileSidebarTrigger() {
+  const { setOpen } = useContext(MobileSidebarCtx);
+  return (
+    <button
+      onClick={() => setOpen(true)}
+      aria-label="Open menu"
+      className="md:hidden rounded-md p-1.5 text-foreground/70 hover:text-foreground hover:bg-accent transition-colors"
+    >
+      <Menu className="h-5 w-5" />
+    </button>
+  );
+}
+
+// ─── Nav data ─────────────────────────────────────────────────────────────────
 
 type NavItem = {
   title: string;
@@ -51,11 +72,96 @@ type NavItem = {
   disabled?: boolean;
 };
 
+function getOrgItems(orgId: string): NavItem[] {
+  return [
+    // TODO: remove `disabled: true` when overview page is implemented
+    { title: "Overview", url: `/orgs/${orgId}`, icon: Building2, disabled: true },
+    { title: "Timetable", url: `/orgs/${orgId}/timetable`, icon: Calendar },
+    { title: "Tasks", url: `/orgs/${orgId}/tasks`, icon: ListTodo },
+    { title: "Members", url: `/orgs/${orgId}/memberships`, icon: Users },
+    // TODO: remove `disabled: true` when progress page is implemented
+    { title: "Progress", url: `/orgs/${orgId}/progress`, icon: BarChart2, disabled: true },
+  ];
+}
+
+function getSettingsItems(orgId: string): NavItem[] {
+  return [
+    { title: "Back to Org", url: `/orgs/${orgId}/timetable`, icon: ChevronLeft },
+    { title: "Organization", url: `/orgs/${orgId}/settings/organization`, icon: Building2 },
+    { title: "Roles", url: `/orgs/${orgId}/settings/roles`, icon: ShieldCheck },
+    // TODO: remove `disabled: true` when settings timetable page is implemented
+    { title: "Timetable", url: `/orgs/${orgId}/settings/timetable`, icon: Calendar, disabled: true },
+    // TODO: remove `disabled: true` when settings notification page is implemented
+    { title: "Notification", url: `/orgs/${orgId}/settings/notification`, icon: Bell, disabled: true },
+  ];
+}
+
+function getNavItems(orgId: string, pathname: string): NavItem[] {
+  if (pathname.startsWith(`/orgs/${orgId}/settings`)) return getSettingsItems(orgId);
+  if (pathname.startsWith(`/orgs/${orgId}`)) return getOrgItems(orgId);
+  return [];
+}
+
+function getFooterItems(
+  orgId: string,
+  pathname: string,
+  isParentOwner: boolean,
+  parentOrgId: string | null,
+): NavItem[] {
+  if (pathname.startsWith(`/orgs/${orgId}/settings`)) return [];
+  const franchiseeOrgId = isParentOwner ? orgId : parentOrgId;
+  return [
+    ...(franchiseeOrgId
+      ? [{ title: "Franchisee", url: `/orgs/${franchiseeOrgId}/franchisee`, icon: Network }]
+      : []),
+    { title: "Settings", url: `/orgs/${orgId}/settings`, icon: Settings },
+  ];
+}
+
+// ─── Nav item components ──────────────────────────────────────────────────────
+
 /**
- * A collapsible nav section with a chevron toggle.
- * Used in the global (no-org) sidebar for the Organizations and Help groups.
+ * A single nav row. The icon wrapper is always `w-12` wide so the icon stays
+ * centred in the collapsed (icon-only) strip. The text flows after it and is
+ * clipped by the parent's `overflow-hidden` when collapsed.
  */
-function NavCollapsible({
+function NavRow({
+  title,
+  url,
+  icon: Icon,
+  disabled,
+  isActive,
+  onClick,
+}: NavItem & { isActive: boolean; onClick?: () => void }) {
+  const base =
+    "flex items-center h-9 w-full overflow-hidden rounded-md transition-colors";
+  const active = "bg-sidebar-accent text-sidebar-accent-foreground font-medium";
+  const hover = "hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground";
+  const dis = "opacity-40 pointer-events-none";
+
+  const inner = (
+    <>
+      <span className="w-12 flex items-center justify-center shrink-0">
+        <Icon className="h-4 w-4 text-sidebar-foreground" />
+      </span>
+      <span className="whitespace-nowrap text-sm pr-3 text-sidebar-foreground">
+        {title}
+      </span>
+    </>
+  );
+
+  if (disabled) return <div className={cn(base, dis)}>{inner}</div>;
+  return (
+    <Link href={url} onClick={onClick} className={cn(base, isActive ? active : hover)}>
+      {inner}
+    </Link>
+  );
+}
+
+/**
+ * A collapsible nav section. Only visible/usable when the sidebar is expanded.
+ */
+function NavCollapsibleRow({
   icon: Icon,
   label,
   defaultOpen = false,
@@ -67,144 +173,83 @@ function NavCollapsible({
   children: React.ReactNode;
 }) {
   const [open, setOpen] = useState(defaultOpen);
-  const subMenuId = `sidebar-section-${label.toLowerCase().replace(/\s+/g, "-")}`;
   return (
-    <SidebarMenuItem>
-      <SidebarMenuButton
+    <div>
+      <button
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
-        aria-controls={subMenuId}
+        className="flex items-center h-9 w-full overflow-hidden rounded-md hover:bg-sidebar-accent/70 transition-colors"
       >
-        <Icon />
-        <span>{label}</span>
+        <span className="w-12 flex items-center justify-center shrink-0">
+          <Icon className="h-4 w-4 text-sidebar-foreground" />
+        </span>
+        <span className="whitespace-nowrap text-sm text-sidebar-foreground">
+          {label}
+        </span>
         <ChevronRight
           className={cn(
-            "ml-auto transition-transform duration-200",
+            "h-4 w-4 shrink-0 transition-transform duration-200 text-sidebar-foreground ml-auto mr-3",
             open && "rotate-90",
           )}
         />
-      </SidebarMenuButton>
-      {open && <SidebarMenuSub id={subMenuId}>{children}</SidebarMenuSub>}
-    </SidebarMenuItem>
+      </button>
+      {open && <div className="pl-10 flex flex-col gap-0.5 pb-1">{children}</div>}
+    </div>
   );
 }
 
-function getOrgItems(orgId: string): NavItem[] {
-  return [
-    // TODO: remove `disabled: true` when overview page is implemented
-    {
-      title: "Overview",
-      url: `/orgs/${orgId}`,
-      icon: Building2,
-      disabled: true,
-    },
-    { title: "Timetable", url: `/orgs/${orgId}/timetable`, icon: Calendar },
-    { title: "Tasks", url: `/orgs/${orgId}/tasks`, icon: ListTodo },
-    { title: "Members", url: `/orgs/${orgId}/memberships`, icon: Users },
-    {
-      title: "Progress",
-      url: `/orgs/${orgId}/progress`,
-      icon: BarChart2,
-      disabled: true,
-    },
-  ];
+function SubRow({
+  href,
+  icon: Icon,
+  label,
+  isActive,
+  onClick,
+  disabled,
+}: {
+  href?: string;
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  isActive?: boolean;
+  onClick?: () => void;
+  disabled?: boolean;
+}) {
+  const base =
+    "flex items-center gap-2 h-8 px-2 rounded-md text-xs transition-colors text-sidebar-foreground whitespace-nowrap w-full";
+  const active = "bg-sidebar-accent text-sidebar-accent-foreground font-medium";
+  const hover = "hover:bg-sidebar-accent/70";
+  const dis = "opacity-40 pointer-events-none";
+  const inner = (
+    <>
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <span>{label}</span>
+    </>
+  );
+  if (disabled) return <div className={cn(base, dis)}>{inner}</div>;
+  if (!href) return <div className={cn(base, hover)}>{inner}</div>;
+  return (
+    <Link href={href} onClick={onClick} className={cn(base, isActive ? active : hover)}>
+      {inner}
+    </Link>
+  );
 }
 
-function getSettingsItems(orgId: string): NavItem[] {
-  return [
-    {
-      title: "Back to Org",
-      url: `/orgs/${orgId}/timetable`,
-      icon: ChevronLeft,
-    },
-    {
-      title: "Organization",
-      url: `/orgs/${orgId}/settings/organization`,
-      icon: Building2,
-    },
-    { title: "Roles", url: `/orgs/${orgId}/settings/roles`, icon: ShieldCheck },
-    {
-      // TODO: remove `disabled: true` when settings timetable page is implemented
-      title: "Timetable",
-      url: `/orgs/${orgId}/settings/timetable`,
-      icon: Calendar,
-      disabled: true,
-    },
-    {
-      // TODO: remove `disabled: true` when settings notification page is implemented
-      title: "Notification",
-      url: `/orgs/${orgId}/settings/notification`,
-      icon: Bell,
-      disabled: true,
-    },
-  ];
-}
+// ─── AppSidebar ───────────────────────────────────────────────────────────────
 
 /**
- * Returns the correct nav items for the current org context.
- * Derives the active mode from pathname so the component doesn't need to.
- */
-function getNavItems(orgId: string, pathname: string): NavItem[] {
-  if (pathname.startsWith(`/orgs/${orgId}/settings`))
-    return getSettingsItems(orgId);
-  return getOrgItems(orgId);
-}
-
-/**
- * Returns footer items (e.g. Settings) when inside an org but not in settings.
- * Empty array otherwise so the footer is hidden.
- */
-function getFooterItems(
-  orgId: string,
-  pathname: string,
-  isParentOwner: boolean,
-  parentOrgId: string | null,
-): NavItem[] {
-  if (pathname.startsWith(`/orgs/${orgId}/settings`)) return [];
-  const franchiseeOrgId = isParentOwner ? orgId : parentOrgId;
-  return [
-    ...(franchiseeOrgId
-      ? [
-          {
-            title: "Franchisee",
-            url: `/orgs/${franchiseeOrgId}/franchisee`,
-            icon: Network,
-          },
-        ]
-      : []),
-    { title: "Settings", url: `/orgs/${orgId}/settings`, icon: Settings },
-  ];
-}
-
-/**
- * Collapsible sidebar rendered in the app layout.
+ * Global sidebar rendered in the app layout.
  *
- * Behaviour:
- * - Outside an org: shows the global workspace nav with collapsible sections
- *   (Organizations with Create + Invitations, and Help with sub-links).
- * - Inside an org: switches to org-scoped nav and shows footer items (e.g. Settings).
- * - Active page is highlighted via `isActive`, derived from the current pathname.
+ * Desktop: a w-12 spacer holds space in the flex layout. An `absolute`-
+ * positioned panel sits over it and expands to w-52 on hover, overlaying
+ * the page content. Icons are always centred in the 48px strip.
+ *
+ * Mobile: hidden by default. A full-screen overlay is toggled via
+ * GlobalSidebarProvider / MobileSidebarTrigger.
  */
 export function AppSidebar() {
-  // orgId is present on any /orgs/[orgId]/... route, undefined otherwise
   const { orgId } = useParams<{ orgId?: string }>();
   const pathname = usePathname();
-  const { toggleSidebar, isMobile, setOpenMobile } = useSidebar();
-  const closeSidebar = () => {
-    if (isMobile) setOpenMobile(false);
-  };
-  // Keep the sidebar open when navigating within the same org (org ↔ settings).
-  // Only close it when the destination is outside the current org context.
-  const handleNavClick = (url: string) => {
-    if (!isMobile) return;
-    if (orgId) {
-      const inSettings = pathname.startsWith(`/orgs/${orgId}/settings`);
-      const goingToSettings = url.startsWith(`/orgs/${orgId}/settings`);
-      // Keep sidebar open only when toggling between org ↔ settings
-      if (inSettings !== goingToSettings) return;
-    }
-    setOpenMobile(false);
-  };
+  const { open: mobileOpen, setOpen: setMobileOpen } = useContext(MobileSidebarCtx);
+
   const [parentOwnerStatus, setParentOwnerStatus] = useState<{
     orgId: string | null;
     isParentOwner: boolean;
@@ -230,7 +275,6 @@ export function AppSidebar() {
     return () => controller.abort();
   }, [orgId]);
 
-  // Only true when the stored status is for the current org (prevents stale flash on org switch)
   const isParentOwner =
     parentOwnerStatus.orgId === orgId && parentOwnerStatus.isParentOwner;
   const parentOrgId =
@@ -241,169 +285,107 @@ export function AppSidebar() {
     ? getFooterItems(orgId, pathname, isParentOwner, parentOrgId)
     : [];
 
-  /**
-   * Returns true when a nav item should be highlighted.
-   * - Org overview uses exact match so it doesn't light up on every org page.
-   * - All other items use prefix matching so nested pages (e.g. /tasks/new)
-   *   still highlight their parent section.
-   */
   const isActiveItem = (url: string) => {
     if (orgId && url === `/orgs/${orgId}`) return pathname === url;
     return pathname === url || pathname.startsWith(`${url}/`);
   };
 
-  return (
-    <Sidebar collapsible="offcanvas">
-      <SidebarHeader className="px-4 py-4">
-        <div className="flex items-center justify-between">
-          <Link
-            href="/"
-            className="rounded-lg px-2 py-1 -mx-2 -my-1 hover:bg-primary/8 hover:ring-1 hover:ring-primary/30 transition-all"
-          >
-            <Logo className="text-sidebar-foreground" />
-          </Link>
-          <button
-            onClick={toggleSidebar}
-            aria-label="Close sidebar"
-            className="cursor-pointer rounded-md p-1.5 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
-          >
-            <PanelLeftClose className="h-4 w-4" />
-          </button>
+  const navContent = (mobile: boolean) => {
+    const close = mobile ? () => setMobileOpen(false) : undefined;
+    return (
+      <>
+        <div className="flex-1 overflow-y-auto overflow-x-hidden py-1">
+          <div className="flex flex-col gap-0.5">
+            {orgId ? (
+              navItems.map((item) => (
+                <NavRow
+                  key={item.title}
+                  {...item}
+                  isActive={isActiveItem(item.url)}
+                  onClick={close}
+                />
+              ))
+            ) : (
+              <>
+                <NavRow
+                  title="Workspace"
+                  url="/"
+                  icon={LayoutDashboard}
+                  isActive={pathname === "/"}
+                  onClick={close}
+                />
+                <NavCollapsibleRow icon={Building2} label="Organizations" defaultOpen>
+                  <SubRow icon={ListCheckIcon} label="List" disabled />
+                  <SubRow
+                    icon={PlusCircle}
+                    label="Create"
+                    href="/orgs/new"
+                    isActive={isActiveItem("/orgs/new")}
+                    onClick={close}
+                  />
+                  <SubRow icon={Mail} label="Invitations" disabled />
+                </NavCollapsibleRow>
+                <NavCollapsibleRow icon={HelpCircle} label="Help">
+                  <SubRow icon={BookOpen} label="Instructions" disabled />
+                  <SubRow icon={Info} label="About" disabled />
+                  <SubRow icon={Phone} label="Contact" disabled />
+                </NavCollapsibleRow>
+              </>
+            )}
+          </div>
         </div>
-      </SidebarHeader>
-
-      <SidebarContent>
-        <SidebarGroup>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {orgId ? (
-                // ── Org / Settings nav (mutually exclusive, same shape) ──
-                navItems.map((item) => (
-                  <SidebarMenuItem key={item.title}>
-                    <SidebarMenuButton
-                      asChild={!item.disabled}
-                      isActive={isActiveItem(item.url)}
-                      disabled={item.disabled}
-                      className={
-                        item.disabled
-                          ? "opacity-40 cursor-not-allowed pointer-events-none"
-                          : ""
-                      }
-                    >
-                      {item.disabled ? (
-                        <>
-                          <item.icon />
-                          <span>{item.title}</span>
-                        </>
-                      ) : (
-                        <Link
-                          href={item.url}
-                          onClick={() => handleNavClick(item.url)}
-                        >
-                          <item.icon />
-                          <span>{item.title}</span>
-                        </Link>
-                      )}
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                ))
-              ) : (
-                // ── Global workspace nav ─────────────────────────────────
-                <>
-                  {/* Workspace */}
-                  <SidebarMenuItem>
-                    <SidebarMenuButton asChild isActive={pathname === "/"}>
-                      <Link href="/" onClick={closeSidebar}>
-                        <LayoutDashboard />
-                        <span>Workspace</span>
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-
-                  {/* Organizations — collapsible, open by default */}
-                  <NavCollapsible
-                    icon={Building2}
-                    label="Organizations"
-                    defaultOpen
-                  >
-                    <SidebarMenuSubItem>
-                      {/* List — stub until feature is implemented */}
-                      <SidebarMenuSubButton title="Coming soon">
-                        <ListCheckIcon />
-                        <span>List</span>
-                      </SidebarMenuSubButton>
-                    </SidebarMenuSubItem>
-                    <SidebarMenuSubItem>
-                      <SidebarMenuSubButton
-                        asChild
-                        isActive={isActiveItem("/orgs/new")}
-                      >
-                        <Link href="/orgs/new" onClick={closeSidebar}>
-                          <PlusCircle />
-                          <span>Create</span>
-                        </Link>
-                      </SidebarMenuSubButton>
-                    </SidebarMenuSubItem>
-                    <SidebarMenuSubItem>
-                      {/* Invitations — stub until feature is implemented */}
-                      <SidebarMenuSubButton title="Coming soon">
-                        <Mail />
-                        <span>Invitations</span>
-                      </SidebarMenuSubButton>
-                    </SidebarMenuSubItem>
-                  </NavCollapsible>
-
-                  {/* Help — collapsible, closed by default */}
-                  <NavCollapsible icon={HelpCircle} label="Help">
-                    <SidebarMenuSubItem>
-                      <SidebarMenuSubButton title="Coming soon">
-                        <BookOpen />
-                        <span>Instructions</span>
-                      </SidebarMenuSubButton>
-                    </SidebarMenuSubItem>
-                    <SidebarMenuSubItem>
-                      <SidebarMenuSubButton title="Coming soon">
-                        <Info />
-                        <span>About</span>
-                      </SidebarMenuSubButton>
-                    </SidebarMenuSubItem>
-                    <SidebarMenuSubItem>
-                      <SidebarMenuSubButton title="Coming soon">
-                        <Phone />
-                        <span>Contact</span>
-                      </SidebarMenuSubButton>
-                    </SidebarMenuSubItem>
-                  </NavCollapsible>
-                </>
-              )}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      </SidebarContent>
-
-      {/* Settings footer — only inside an org and not in settings */}
-      {footerItems.length > 0 && (
-        <>
-          <SidebarSeparator className="border-dashed" />
-          <SidebarFooter>
-            <SidebarMenu>
+        {footerItems.length > 0 && (
+          <div className="border-t border-sidebar-border py-1">
+            <div className="flex flex-col gap-0.5">
               {footerItems.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild isActive={isActiveItem(item.url)}>
-                    <Link
-                      href={item.url}
-                      onClick={() => handleNavClick(item.url)}
-                    >
-                      <item.icon />
-                      <span>{item.title}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
+                <NavRow
+                  key={item.title}
+                  {...item}
+                  isActive={isActiveItem(item.url)}
+                  onClick={close}
+                />
               ))}
-            </SidebarMenu>
-          </SidebarFooter>
-        </>
+            </div>
+          </div>
+        )}
+      </>
+    );
+  };
+
+  return (
+    <>
+      {/* ── Desktop: spacer + absolute overlay panel ── */}
+      <div className="hidden md:block relative w-12 shrink-0">
+        <div className="absolute inset-y-0 left-0 z-30 flex flex-col w-12 hover:w-52 transition-[width] duration-200 bg-sidebar border-r border-sidebar-border overflow-hidden">
+          {navContent(false)}
+        </div>
+      </div>
+
+      {/* ── Mobile: full-screen overlay ── */}
+      {mobileOpen && (
+        <div className="md:hidden fixed inset-0 z-50 flex">
+          <div className="w-64 bg-sidebar flex flex-col overflow-hidden">
+            <div className="flex items-center justify-between h-14 px-4 border-b border-sidebar-border shrink-0">
+              <span className="flex items-center gap-2 text-sm font-semibold text-sidebar-foreground select-none">
+                <span className="flex items-center justify-center rounded-full border-2 border-current p-1.5">
+                  <HeartHandshake className="h-4 w-4" strokeWidth={1.75} />
+                </span>
+                FriendChise
+              </span>
+              <button
+                onClick={() => setMobileOpen(false)}
+                aria-label="Close menu"
+                className="rounded-md p-1.5 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            {navContent(true)}
+          </div>
+          {/* Backdrop */}
+          <div className="flex-1 bg-black/40" onClick={() => setMobileOpen(false)} />
+        </div>
       )}
-    </Sidebar>
+    </>
   );
 }

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, createContext, useContext } from "react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
+import { Logo } from "@/components/layout/logo";
 import { cn } from "@/lib/utils";
 import {
   LayoutDashboard,
@@ -24,7 +25,6 @@ import {
   ShieldCheck,
   Bell,
   Network,
-  HeartHandshake,
   X,
   Menu,
 } from "lucide-react";
@@ -366,12 +366,12 @@ export function AppSidebar() {
         <div className="md:hidden fixed inset-0 z-50 flex">
           <div className="w-64 bg-sidebar flex flex-col overflow-hidden">
             <div className="flex items-center justify-between h-14 px-4 border-b border-sidebar-border shrink-0">
-              <span className="flex items-center gap-2 text-sm font-semibold text-sidebar-foreground select-none">
-                <span className="flex items-center justify-center rounded-full border-2 border-current p-1.5">
-                  <HeartHandshake className="h-4 w-4" strokeWidth={1.75} />
-                </span>
-                FriendChise
-              </span>
+              <Link
+                href="/"
+                onClick={() => setMobileOpen(false)}
+              >
+                <Logo className="text-sidebar-foreground" />
+              </Link>
               <button
                 onClick={() => setMobileOpen(false)}
                 aria-label="Close menu"

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useState, useEffect, createContext, useContext } from "react";
+import { useState, useEffect, useContext } from "react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
-import { Logo } from "@/components/layout/logo";
 import { cn } from "@/lib/utils";
 import {
   LayoutDashboard,
@@ -13,48 +12,24 @@ import {
   Calendar,
   BarChart2,
   Settings,
-  PlusCircle,
-  Mail,
   HelpCircle,
-  BookOpen,
-  Info,
-  Phone,
-  ChevronRight,
-  ChevronLeft,
-  ListCheckIcon,
-  ShieldCheck,
-  Bell,
   Network,
-  X,
   Menu,
+  HeartHandshake,
 } from "lucide-react";
+import { MobileSidebarCtx, useMobileSidebar, GlobalSidebarProvider } from "./mobile-sidebar-context";
+import { useHasPageSidebar } from "./page-sidebar-context";
+import { Logo } from "./logo";
+import { SidebarNavItem } from "./sidebar-nav-item";
 
-// ─── Mobile sidebar context ───────────────────────────────────────────────────
-
-const MobileSidebarCtx = createContext<{
-  open: boolean;
-  setOpen: (v: boolean) => void;
-}>({ open: false, setOpen: () => {} });
-
-export function GlobalSidebarProvider({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const [open, setOpen] = useState(false);
-  return (
-    <MobileSidebarCtx.Provider value={{ open, setOpen }}>
-      {children}
-    </MobileSidebarCtx.Provider>
-  );
-}
+export { GlobalSidebarProvider, useMobileSidebar };
 
 /** Hamburger trigger rendered in the navbar on mobile. */
 export function MobileSidebarTrigger() {
-  const { setOpen } = useContext(MobileSidebarCtx);
+  const { open, setOpen } = useContext(MobileSidebarCtx);
   return (
     <button
-      onClick={() => setOpen(true)}
+      onClick={() => setOpen(!open)}
       aria-label="Open menu"
       className="md:hidden rounded-md p-1.5 text-foreground/70 hover:text-foreground hover:bg-accent transition-colors"
     >
@@ -74,8 +49,7 @@ type NavItem = {
 
 function getOrgItems(orgId: string): NavItem[] {
   return [
-    // TODO: remove `disabled: true` when overview page is implemented
-    { title: "Overview", url: `/orgs/${orgId}`, icon: Building2, disabled: true },
+    { title: "Overview", url: `/orgs/${orgId}`, icon: Building2 },
     { title: "Timetable", url: `/orgs/${orgId}/timetable`, icon: Calendar },
     { title: "Tasks", url: `/orgs/${orgId}/tasks`, icon: ListTodo },
     { title: "Members", url: `/orgs/${orgId}/memberships`, icon: Users },
@@ -84,20 +58,7 @@ function getOrgItems(orgId: string): NavItem[] {
   ];
 }
 
-function getSettingsItems(orgId: string): NavItem[] {
-  return [
-    { title: "Back to Org", url: `/orgs/${orgId}/timetable`, icon: ChevronLeft },
-    { title: "Organization", url: `/orgs/${orgId}/settings/organization`, icon: Building2 },
-    { title: "Roles", url: `/orgs/${orgId}/settings/roles`, icon: ShieldCheck },
-    // TODO: remove `disabled: true` when settings timetable page is implemented
-    { title: "Timetable", url: `/orgs/${orgId}/settings/timetable`, icon: Calendar, disabled: true },
-    // TODO: remove `disabled: true` when settings notification page is implemented
-    { title: "Notification", url: `/orgs/${orgId}/settings/notification`, icon: Bell, disabled: true },
-  ];
-}
-
 function getNavItems(orgId: string, pathname: string): NavItem[] {
-  if (pathname.startsWith(`/orgs/${orgId}/settings`)) return getSettingsItems(orgId);
   if (pathname.startsWith(`/orgs/${orgId}`)) return getOrgItems(orgId);
   return [];
 }
@@ -108,7 +69,6 @@ function getFooterItems(
   isParentOwner: boolean,
   parentOrgId: string | null,
 ): NavItem[] {
-  if (pathname.startsWith(`/orgs/${orgId}/settings`)) return [];
   const franchiseeOrgId = isParentOwner ? orgId : parentOrgId;
   return [
     ...(franchiseeOrgId
@@ -120,118 +80,7 @@ function getFooterItems(
 
 // ─── Nav item components ──────────────────────────────────────────────────────
 
-/**
- * A single nav row. The icon wrapper is always `w-12` wide so the icon stays
- * centred in the collapsed (icon-only) strip. The text flows after it and is
- * clipped by the parent's `overflow-hidden` when collapsed.
- */
-function NavRow({
-  title,
-  url,
-  icon: Icon,
-  disabled,
-  isActive,
-  onClick,
-}: NavItem & { isActive: boolean; onClick?: () => void }) {
-  const base =
-    "flex items-center h-9 w-full overflow-hidden rounded-md transition-colors";
-  const active = "bg-sidebar-accent text-sidebar-accent-foreground font-medium";
-  const hover = "hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground";
-  const dis = "opacity-40 pointer-events-none";
-
-  const inner = (
-    <>
-      <span className="w-12 flex items-center justify-center shrink-0">
-        <Icon className="h-4 w-4 text-sidebar-foreground" />
-      </span>
-      <span className="whitespace-nowrap text-sm pr-3 text-sidebar-foreground">
-        {title}
-      </span>
-    </>
-  );
-
-  if (disabled) return <div className={cn(base, dis)}>{inner}</div>;
-  return (
-    <Link href={url} onClick={onClick} className={cn(base, isActive ? active : hover)}>
-      {inner}
-    </Link>
-  );
-}
-
-/**
- * A collapsible nav section. Only visible/usable when the sidebar is expanded.
- */
-function NavCollapsibleRow({
-  icon: Icon,
-  label,
-  defaultOpen = false,
-  children,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  defaultOpen?: boolean;
-  children: React.ReactNode;
-}) {
-  const [open, setOpen] = useState(defaultOpen);
-  return (
-    <div>
-      <button
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        className="flex items-center h-9 w-full overflow-hidden rounded-md hover:bg-sidebar-accent/70 transition-colors"
-      >
-        <span className="w-12 flex items-center justify-center shrink-0">
-          <Icon className="h-4 w-4 text-sidebar-foreground" />
-        </span>
-        <span className="whitespace-nowrap text-sm text-sidebar-foreground">
-          {label}
-        </span>
-        <ChevronRight
-          className={cn(
-            "h-4 w-4 shrink-0 transition-transform duration-200 text-sidebar-foreground ml-auto mr-3",
-            open && "rotate-90",
-          )}
-        />
-      </button>
-      {open && <div className="pl-10 flex flex-col gap-0.5 pb-1">{children}</div>}
-    </div>
-  );
-}
-
-function SubRow({
-  href,
-  icon: Icon,
-  label,
-  isActive,
-  onClick,
-  disabled,
-}: {
-  href?: string;
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  isActive?: boolean;
-  onClick?: () => void;
-  disabled?: boolean;
-}) {
-  const base =
-    "flex items-center gap-2 h-8 px-2 rounded-md text-xs transition-colors text-sidebar-foreground whitespace-nowrap w-full";
-  const active = "bg-sidebar-accent text-sidebar-accent-foreground font-medium";
-  const hover = "hover:bg-sidebar-accent/70";
-  const dis = "opacity-40 pointer-events-none";
-  const inner = (
-    <>
-      <Icon className="h-3.5 w-3.5 shrink-0" />
-      <span>{label}</span>
-    </>
-  );
-  if (disabled) return <div className={cn(base, dis)}>{inner}</div>;
-  if (!href) return <div className={cn(base, hover)}>{inner}</div>;
-  return (
-    <Link href={href} onClick={onClick} className={cn(base, isActive ? active : hover)}>
-      {inner}
-    </Link>
-  );
-}
+// (Shared SidebarNavItem imported from ./sidebar-nav-item)
 
 // ─── AppSidebar ───────────────────────────────────────────────────────────────
 
@@ -248,7 +97,13 @@ function SubRow({
 export function AppSidebar() {
   const { orgId } = useParams<{ orgId?: string }>();
   const pathname = usePathname();
-  const { open: mobileOpen, setOpen: setMobileOpen } = useContext(MobileSidebarCtx);
+  const { open, setOpen } = useContext(MobileSidebarCtx);
+  const hasSidebar = useHasPageSidebar();
+
+  // Close the mobile overlay on navigation
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [parentOwnerStatus, setParentOwnerStatus] = useState<{
     orgId: string | null;
@@ -290,59 +145,57 @@ export function AppSidebar() {
     return pathname === url || pathname.startsWith(`${url}/`);
   };
 
-  const navContent = (mobile: boolean) => {
-    const close = mobile ? () => setMobileOpen(false) : undefined;
+  const navContent = () => {
     return (
       <>
-        <div className="flex-1 overflow-y-auto overflow-x-hidden py-1">
-          <div className="flex flex-col gap-0.5">
+        <div className="flex-1 overflow-y-auto overflow-x-hidden">
+          <div className="flex flex-col">
             {orgId ? (
               navItems.map((item) => (
-                <NavRow
+                <SidebarNavItem
                   key={item.title}
+                  variant="app"
                   {...item}
                   isActive={isActiveItem(item.url)}
-                  onClick={close}
                 />
               ))
             ) : (
               <>
-                <NavRow
+                <SidebarNavItem
+                  variant="app"
                   title="Workspace"
                   url="/"
                   icon={LayoutDashboard}
                   isActive={pathname === "/"}
-                  onClick={close}
                 />
-                <NavCollapsibleRow icon={Building2} label="Organizations" defaultOpen>
-                  <SubRow icon={ListCheckIcon} label="List" disabled />
-                  <SubRow
-                    icon={PlusCircle}
-                    label="Create"
-                    href="/orgs/new"
-                    isActive={isActiveItem("/orgs/new")}
-                    onClick={close}
-                  />
-                  <SubRow icon={Mail} label="Invitations" disabled />
-                </NavCollapsibleRow>
-                <NavCollapsibleRow icon={HelpCircle} label="Help">
-                  <SubRow icon={BookOpen} label="Instructions" disabled />
-                  <SubRow icon={Info} label="About" disabled />
-                  <SubRow icon={Phone} label="Contact" disabled />
-                </NavCollapsibleRow>
+                <SidebarNavItem
+                  variant="app"
+                  title="Organizations"
+                  url="/orgs/new"
+                  icon={Building2}
+                  isActive={isActiveItem("/orgs")}
+                />
+                <SidebarNavItem
+                  variant="app"
+                  title="Help"
+                  url="/help"
+                  icon={HelpCircle}
+                  isActive={false}
+                  disabled
+                />
               </>
             )}
           </div>
         </div>
         {footerItems.length > 0 && (
-          <div className="border-t border-sidebar-border py-1">
-            <div className="flex flex-col gap-0.5">
+          <div className="border-t border-sidebar-border">
+            <div className="flex flex-col">
               {footerItems.map((item) => (
-                <NavRow
+                <SidebarNavItem
                   key={item.title}
+                  variant="app"
                   {...item}
                   isActive={isActiveItem(item.url)}
-                  onClick={close}
                 />
               ))}
             </div>
@@ -354,37 +207,34 @@ export function AppSidebar() {
 
   return (
     <>
-      {/* ── Desktop: spacer + absolute overlay panel ── */}
+      {/* ── Desktop: spacer + absolute hover-expand panel ── */}
       <div className="hidden md:block relative w-12 shrink-0">
         <div className="absolute inset-y-0 left-0 z-30 flex flex-col w-12 hover:w-52 transition-[width] duration-200 bg-sidebar border-r border-sidebar-border overflow-hidden">
-          {navContent(false)}
+          {navContent()}
         </div>
       </div>
 
-      {/* ── Mobile: full-screen overlay ── */}
-      {mobileOpen && (
-        <div className="md:hidden fixed inset-0 z-50 flex">
-          <div className="w-64 bg-sidebar flex flex-col overflow-hidden">
-            <div className="flex items-center justify-between h-14 px-4 border-b border-sidebar-border shrink-0">
-              <Link
-                href="/"
-                onClick={() => setMobileOpen(false)}
-              >
-                <Logo className="text-sidebar-foreground" />
-              </Link>
-              <button
-                onClick={() => setMobileOpen(false)}
-                aria-label="Close menu"
-                className="rounded-md p-1.5 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-            {navContent(true)}
+      {/* ── Mobile: overlay, shown when hamburger is open ── */}
+      {open && (
+        <>
+          <div className="md:hidden fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div className={cn(
+            "md:hidden fixed inset-y-0 left-0 z-50 bg-sidebar border-r border-sidebar-border flex flex-col overflow-hidden",
+            !hasSidebar ? "w-52" : "w-12",
+          )}>
+            <Link
+              href="/"
+              onClick={() => setOpen(false)}
+              className="flex items-center h-14 shrink-0 text-foreground px-2"
+            >
+              {!hasSidebar
+                ? <Logo className="text-foreground" />
+                : <span className="flex items-center justify-center w-full rounded-full border-2 border-current p-1.5"><HeartHandshake className="h-4 w-4" strokeWidth={1.75} /></span>
+              }
+            </Link>
+            {navContent()}
           </div>
-          {/* Backdrop */}
-          <div className="flex-1 bg-black/40" onClick={() => setMobileOpen(false)} />
-        </div>
+        </>
       )}
     </>
   );

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -30,7 +30,8 @@ export function MobileSidebarTrigger() {
   return (
     <button
       onClick={() => setOpen(!open)}
-      aria-label="Open menu"
+      aria-label={open ? "Close menu" : "Open menu"}
+      aria-expanded={open}
       className="md:hidden rounded-md p-1.5 text-foreground/70 hover:text-foreground hover:bg-accent transition-colors"
     >
       <Menu className="h-5 w-5" />

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -225,7 +225,7 @@ export function AppSidebar() {
             <Link
               href="/"
               onClick={() => setOpen(false)}
-              className="flex items-center h-14 shrink-0 text-foreground px-2"
+              className="flex items-center h-12 shrink-0 text-foreground px-2"
             >
               {!hasSidebar
                 ? <Logo className="text-foreground" />

--- a/components/layout/toolbar.tsx
+++ b/components/layout/toolbar.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 
 export function Toolbar({ children }: { children: ReactNode }) {
   return (
-    <div className="-mx-4 -mt-4 mb-4 border-b bg-card px-4 py-2 flex flex-wrap items-center gap-2 sm:-mx-6 sm:-mt-6 sm:mb-6 sm:px-6 sm:py-2">
+    <div className="-mx-4 -mt-4 mb-4 border-b bg-card px-4 h-12 shrink-0 flex flex-wrap items-center gap-2 sm:-mx-6 sm:-mt-6 sm:mb-6 sm:px-6">
       {children}
     </div>
   );

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -288,7 +288,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
+        "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:inset-s-1/2 after:w-0.5 hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",

--- a/components/ui/timezone-select.tsx
+++ b/components/ui/timezone-select.tsx
@@ -8,11 +8,13 @@ export function TimezoneSelect({
   onChange,
   timezones,
   className,
+  id,
 }: {
   value: string;
   onChange: (value: string) => void;
   timezones: TimezoneOption[];
   className?: string;
+  id?: string;
 }) {
   const [search, setSearch] = useState("");
   const [open, setOpen] = useState(false);
@@ -44,6 +46,7 @@ export function TimezoneSelect({
       className={`relative ${className ?? "max-w-xs w-full"}`}
     >
       <input
+        id={id}
         className="h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm"
         value={open ? search : (selected?.label ?? value)}
         onChange={(e) => setSearch(e.target.value)}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "seed:donut-a": "tsx scripts/seed-donut-shop-a.ts",
     "seed:donut-a:reset": "tsx scripts/seed-donut-shop-a.ts --reset",
     "test": "vitest run",
+    "test:unit": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:services": "vitest run __tests__/unit/lib/services",


### PR DESCRIPTION
## What Changed

Reworks the entire sidebar system — shared nav item component, page-level sidebar context, unified heights across navbar/toolbar/sidebar, and new org management pages.

## Why

To create a consistent, aligned grid where navbar, toolbar rows, and sidebar nav items all share the same `h-12` height so they line up perfectly edge-to-edge.

Closes #

## Type

- [ ] 🐛 Bug fix
- [x] ✨ Enhancement / Feature
- [x] 🔧 Refactor
- [ ] 📝 Documentation
- [x] 🎨 UI / Styling

## How to Test

1. Navigate to any org page — sidebar nav items should align with toolbar rows
2. Open Settings — page sidebar should appear with `h-12` title row and toggle buttons
3. Go to `/orgs/new` — Create Org page only; click "Join a Franchise instead" → `/orgs/join`
4. Collapse/expand page sidebar — toggle buttons hug corners at `w-12 h-12`
5. Check navbar height matches toolbar height on any page with a `<Toolbar>`

## Screenshots / Recordings

<!-- Before & after if UI changed -->

## Checklist

- [ ] Tested on desktop (Chrome)
- [ ] Tested on mobile (iPhone Safari)
- [ ] No lint errors (`pnpm lint`)
- [ ] Build passes (`pnpm build`)
- [ ] Smoke test updated (if applicable)

## Smoke Test Issues Resolved

- [ ] #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization management UI: create, join (invite token), invite, and list flows; “Invitations” and “Organizations” placeholder pages.
  * Settings navigation sidebar for org settings.

* **Refactor**
  * Redesigned app layout and sidebars for combined global/app/page sidebars and improved mobile behavior.
  * Updated top navigation and toolbar sizing.

* **Bug Fixes**
  * Removed breadcrumb navigation behavior.

* **Tests**
  * Added unit test script (vitest).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->