### PR TITLE
fix: toolbar mobile responsiveness

### DIFF
--- a/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
@@ -182,65 +182,58 @@ export function MembersView({
     <div className="flex flex-col h-full">
       {/* Toolbar */}
       <Toolbar>
-        {/* Row 1: search + view toggle */}
-        <div className="flex items-center gap-2 w-full">
-          <div className="relative flex-1">
-            <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
-            <Input
-              placeholder="Search members…"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="pl-7 h-8 w-full"
-            />
-          </div>
-          <SegmentedControl
-            size="sm"
-            value={view}
-            onChange={setView}
-            options={[
-              { value: "list", label: <List className="h-4 w-4" /> },
-              { value: "card", label: <LayoutGrid className="h-4 w-4" /> },
-            ]}
+        <div className="relative flex-1 min-w-[200px]">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+          <Input
+            placeholder="Search members…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-7 h-8 w-full"
           />
         </div>
-
-        {/* Row 2: role filter + add member */}
-        <div className="flex items-center gap-2 w-full">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" className="gap-1.5 shrink-0">
-                {roleFilter
-                  ? (allRoles.find((r) => r.id === roleFilter)?.name ?? "Role")
-                  : "All roles"}
-                <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start">
-              <DropdownMenuItem onSelect={() => setRoleFilter(null)}>
-                All roles
+        <SegmentedControl
+          size="sm"
+          value={view}
+          onChange={setView}
+          options={[
+            { value: "list", label: <List className="h-4 w-4" /> },
+            { value: "card", label: <LayoutGrid className="h-4 w-4" /> },
+          ]}
+        />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm" className="gap-1.5 shrink-0">
+              {roleFilter
+                ? (allRoles.find((r) => r.id === roleFilter)?.name ?? "Role")
+                : "All roles"}
+              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            <DropdownMenuItem onSelect={() => setRoleFilter(null)}>
+              All roles
+            </DropdownMenuItem>
+            {allRoles.map((role) => (
+              <DropdownMenuItem
+                key={role.id}
+                onSelect={() => setRoleFilter(role.id)}
+              >
+                {role.name}
               </DropdownMenuItem>
-              {allRoles.map((role) => (
-                <DropdownMenuItem
-                  key={role.id}
-                  onSelect={() => setRoleFilter(role.id)}
-                >
-                  {role.name}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
 
-          {canManage && (
-            <div className="flex items-center gap-2 ml-auto shrink-0">
-              <Button asChild size="sm">
-                <Link href={`/orgs/${orgId}/memberships/new`}>+ Member</Link>
-              </Button>
-              <Button asChild size="sm">
-                <Link href={`/orgs/${orgId}/memberships/new?bot=1`}>+ Bot</Link>
-              </Button>
-            </div>
-          )}
-        </div>
+        {canManage && (
+          <div className="flex items-center gap-2 ml-auto shrink-0">
+            <Button asChild size="sm">
+              <Link href={`/orgs/${orgId}/memberships/new`}>+ Member</Link>
+            </Button>
+            <Button asChild size="sm">
+              <Link href={`/orgs/${orgId}/memberships/new?bot=1`}>+ Bot</Link>
+            </Button>
+          </div>
+        )}
       </Toolbar>
 
       <div className="flex-1 overflow-auto -mx-4 sm:-mx-6 px-4 sm:px-6 pt-4 sm:pt-6 pb-4 sm:pb-6">

--- a/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
@@ -189,6 +189,7 @@ export function MembersView({
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="pl-7 h-8 w-full"
+            aria-label="Search members by name or email"
           />
         </div>
         <SegmentedControl

--- a/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
@@ -192,85 +192,78 @@ export function TaskTable({
   return (
     <div className="flex flex-col h-full">
       <Toolbar>
-        {/* Row 1: search + view toggle */}
-        <div className="flex items-center gap-2 w-full">
-          <Input
-            aria-label="Search tasks by title"
-            placeholder="Search by title..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="flex-1 h-8"
-          />
-          <SegmentedControl
-            size="sm"
-            value={view}
-            onChange={setView}
-            options={[
-              { value: "list", label: <List className="h-4 w-4" /> },
-              { value: "card", label: <LayoutGrid className="h-4 w-4" /> },
-            ]}
-          />
-        </div>
+        <Input
+          aria-label="Search tasks by title"
+          placeholder="Search by title..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="flex-1 h-8 min-w-[200px]"
+        />
+        <SegmentedControl
+          size="sm"
+          value={view}
+          onChange={setView}
+          options={[
+            { value: "list", label: <List className="h-4 w-4" /> },
+            { value: "card", label: <LayoutGrid className="h-4 w-4" /> },
+          ]}
+        />
+        {/* Sort */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm" className="gap-1.5 shrink-0">
+              {activeSort.label}
+              <ChevronDown className="h-3.5 w-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            {SORT_OPTIONS.map((o) => (
+              <DropdownMenuItem
+                key={o.value}
+                onClick={() => setSort(o.value)}
+              >
+                {o.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
 
-        {/* Row 2: sort + role filter + create */}
-        <div className="flex items-center gap-2 flex-wrap w-full">
-          {/* Sort */}
+        {/* Filter by role */}
+        {roles.length > 0 && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" className="gap-1.5 shrink-0">
-                {activeSort.label}
+              <Button
+                variant={filterRoleId ? "secondary" : "outline"}
+                size="sm"
+                className="gap-1.5 shrink-0"
+              >
+                {activeRole ? activeRole.name : "Filter by role"}
                 <ChevronDown className="h-3.5 w-3.5" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start">
-              {SORT_OPTIONS.map((o) => (
+              {filterRoleId && (
+                <DropdownMenuItem onClick={() => setFilterRoleId(null)}>
+                  All roles
+                </DropdownMenuItem>
+              )}
+              {roles.map((r) => (
                 <DropdownMenuItem
-                  key={o.value}
-                  onClick={() => setSort(o.value)}
+                  key={r.id}
+                  onClick={() => setFilterRoleId(r.id)}
                 >
-                  {o.label}
+                  {r.name}
                 </DropdownMenuItem>
               ))}
             </DropdownMenuContent>
           </DropdownMenu>
+        )}
 
-          {/* Filter by role */}
-          {roles.length > 0 && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant={filterRoleId ? "secondary" : "outline"}
-                  size="sm"
-                  className="gap-1.5 shrink-0"
-                >
-                  {activeRole ? activeRole.name : "Filter by role"}
-                  <ChevronDown className="h-3.5 w-3.5" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start">
-                {filterRoleId && (
-                  <DropdownMenuItem onClick={() => setFilterRoleId(null)}>
-                    All roles
-                  </DropdownMenuItem>
-                )}
-                {roles.map((r) => (
-                  <DropdownMenuItem
-                    key={r.id}
-                    onClick={() => setFilterRoleId(r.id)}
-                  >
-                    {r.name}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-
-          {canManageTasks && (
-            <Button asChild size="sm" className="ml-auto shrink-0">
-              <a href={`/orgs/${orgId}/tasks/new`}>+ Create Task</a>
-            </Button>
-          )}
-        </div>
+        {canManageTasks && (
+          <Button asChild size="sm" className="ml-auto shrink-0">
+            <a href={`/orgs/${orgId}/tasks/new`}>+ Create Task</a>
+          </Button>
+        )}
       </Toolbar>
 
       <div className="flex-1 overflow-auto -mx-4 sm:-mx-6 px-4 sm:px-6 pt-4 sm:pt-6 pb-4 sm:pb-6">

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client/index.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client/index.tsx
@@ -36,6 +36,7 @@ import { useState, useTransition, useEffect, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Toolbar } from "@/components/layout/toolbar";
 import { addDays, getDayName, getMonthName } from "../_shared/grid-utils";
 import { getMondayOf, formatDayRange } from "./helpers";
 import { CalendarView } from "./calendar-view";
@@ -162,9 +163,7 @@ export function TimetableClient({
   return (
     <div className={`flex flex-col${fillHeight ? " flex-1 min-h-0" : ""}`}>
       {/* Combined toolbar */}
-      {/* Note: Uses sm:mb-4 (smaller than Toolbar component's sm:mb-6) to reduce
-           spacing between the navigation controls and the calendar grid below. */}
-      <div className="-mx-4 -mt-4 mb-4 border-b bg-card px-4 min-h-12 py-2 shrink-0 flex flex-wrap items-center gap-2 sm:-mx-6 sm:-mt-6 sm:mb-4 sm:px-6">
+      <Toolbar>
         {/* Row 1 (always): prev / date label / next + Today */}
         <div className="flex items-center gap-2 w-full sm:w-auto">
           <div className="flex items-center gap-0.5">
@@ -210,7 +209,7 @@ export function TimetableClient({
             {children}
           </div>
         )}
-      </div>
+      </Toolbar>
 
       <div
         className={`bg-background rounded-xl transition-opacity duration-150${isNavPending ? " opacity-40 pointer-events-none" : ""}${fillHeight ? " flex-1 min-h-0 flex flex-col" : ""}`}

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client/index.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client/index.tsx
@@ -162,9 +162,9 @@ export function TimetableClient({
   return (
     <div className={`flex flex-col${fillHeight ? " flex-1 min-h-0" : ""}`}>
       {/* Combined toolbar */}
-      <div className="-mx-4 -mt-4 mb-4 border-b bg-card px-4 min-h-12 py-3 shrink-0 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:-mx-6 sm:-mt-6 sm:mb-4 sm:px-6">
+      <div className="-mx-4 -mt-4 mb-4 border-b bg-card px-4 min-h-12 py-2 shrink-0 flex flex-wrap items-center gap-2 sm:-mx-6 sm:-mt-6 sm:mb-4 sm:px-6">
         {/* Row 1 (always): prev / date label / next + Today */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 w-full sm:w-auto">
           <div className="flex items-center gap-0.5">
             <Button
               variant="outline"
@@ -176,7 +176,7 @@ export function TimetableClient({
               <ChevronLeft className="h-4 w-4" />
             </Button>
             <span
-              className={`text-sm font-medium min-w-40 text-center px-1 transition-opacity duration-150${isNavPending ? " opacity-50" : ""}`}
+              className={`text-sm font-medium text-center px-1 transition-opacity duration-150${isNavPending ? " opacity-50" : ""}`}
             >
               {navLabel}
             </span>
@@ -202,9 +202,9 @@ export function TimetableClient({
           </Button>
         </div>
 
-        {/* Row 2 (mobile) / same row (sm+): toolbar slot */}
+        {/* Toolbar slot */}
         {children && (
-          <div className="flex flex-wrap items-center gap-2 sm:flex-1 sm:justify-end">
+          <div className="flex flex-wrap items-center gap-2 w-full sm:w-auto sm:ml-auto">
             {children}
           </div>
         )}

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client/index.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client/index.tsx
@@ -162,6 +162,8 @@ export function TimetableClient({
   return (
     <div className={`flex flex-col${fillHeight ? " flex-1 min-h-0" : ""}`}>
       {/* Combined toolbar */}
+      {/* Note: Uses sm:mb-4 (smaller than Toolbar component's sm:mb-6) to reduce
+           spacing between the navigation controls and the calendar grid below. */}
       <div className="-mx-4 -mt-4 mb-4 border-b bg-card px-4 min-h-12 py-2 shrink-0 flex flex-wrap items-center gap-2 sm:-mx-6 sm:-mt-6 sm:mb-4 sm:px-6">
         {/* Row 1 (always): prev / date label / next + Today */}
         <div className="flex items-center gap-2 w-full sm:w-auto">

--- a/components/layout/toolbar.tsx
+++ b/components/layout/toolbar.tsx
@@ -2,15 +2,17 @@
  * Toolbar — sticky sub-header rendered at the top of page content areas.
  *
  * Sits flush against the page edges by cancelling `<main>`'s padding with
- * negative margins (`-mx-4 -mt-4` / `sm:-mx-6 sm:-mt-6`). Always `h-12`
- * (48px) to align with the navbar, sidebar buttons, and section title rows.
- * Use `flex-1` spacers or `ml-auto` on children to push items to the right.
+ * negative margins (`-mx-4 -mt-4` / `sm:-mx-6 sm:-mt-6`). Minimum height is
+ * 48px (matching the navbar); grows in row increments when children wrap.
+ * Use `flex-1` on an input to fill available space, or `ml-auto` on trailing
+ * items to push them right. Avoid large `py-*` on direct children — the
+ * toolbar's own `py-2` provides the vertical rhythm.
  */
 import { ReactNode } from "react";
 
 export function Toolbar({ children }: { children: ReactNode }) {
   return (
-    <div className="-mx-4 -mt-4 mb-4 border-b bg-card px-4 h-12 shrink-0 flex flex-wrap items-center gap-2 sm:-mx-6 sm:-mt-6 sm:mb-6 sm:px-6">
+    <div className="-mx-4 -mt-4 mb-4 border-b bg-card px-4 min-h-12 py-2 shrink-0 flex flex-wrap items-center gap-2 sm:-mx-6 sm:-mt-6 sm:mb-6 sm:px-6">
       {children}
     </div>
   );


### PR DESCRIPTION
## What Changed

Reworked all toolbars to be properly responsive on mobile — no more overflow or horizontal scrolling.

## Why

Toolbars were either fixed `h-12` (causing content to cut off the screen) or using forced two-row `w-full` div wrappers (always double height). On mobile, items were running off-screen.

Closes #

## Type

- [ ] 🐛 Bug fix
- [x] ✨ Enhancement / Feature
- [ ] 🔧 Refactor
- [ ] 📝 Documentation
- [x] 🎨 UI / Styling

## How to Test

1. Open Tasks page on mobile (375px) — search bar should take up nearly the full first row, other controls wrap to row 2
2. Open Members page on mobile — same behaviour as tasks
3. Open Timetable on mobile — nav row (◀ date ▶ Today) on row 1, filter/view pickers wrap to row 2+, nothing overflows

## Screenshots / Recordings

<!-- Before & after if UI changed -->

## Checklist

- [ ] Tested on desktop (Chrome)
- [ ] Tested on mobile (iPhone Safari)
- [ ] No lint errors (`pnpm lint`)
- [ ] Build passes (`pnpm build`)
- [ ] Smoke test updated (if applicable)

## Smoke Test Issues Resolved

- [ ] #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated toolbar controls (search, filters, view toggles, and create/member actions) into single inline toolbars for members, tasks, and timetable views to improve layout consistency.
  * Toolbar now uses a flexible minimum height so it can grow when controls wrap, improving responsiveness on smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->