### PR TITLE
feat: tasks/members sidebar redesign with ActionSidebar panels and active nav indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,20 +255,32 @@ app/
       [orgId]/
         page.tsx          # Org overview
         franchisee/       # Franchise management (parent org owners only)
-        memberships/      # Members list, search, role filter, invite new member
+        memberships/      # Members list, role filter, list/card toggle, invite/add actions
+          layout.tsx            # Registers MembersSidebarShell for all memberships routes
           [memberId]/     # Member detail view (view-only, roles, working days, status)
             page.tsx
             edit/         # Edit member form (working days, roles)
             _components/
               member-toolbar-actions.tsx  # Restrict/Unrestrict + Delete confirm dialogs
           _components/
-            members-view.tsx        # Client component: toolbar, search/filter, list↔card toggle
-            member-form.tsx         # Shared create/edit form (email, working days, RolePicker)
-            role-picker.tsx         # Searchable role input — selecting auto-adds, no + button
+            members-sidebar-shell.tsx   # Persistent sidebar shell (panel title + List nav tab + sub-content slot)
+            members-sidebar-content.tsx # Filters (role dropdown, list/card toggle) + MembersActions
+            members-actions.tsx         # Invite Member + Add Bot buttons; ActionSidebar on desktop, Dialog on mobile
+            invite-member-panel.tsx     # InviteMemberPanel (ActionSidebar form) + InviteMemberDialog (mobile popup)
+            add-bot-panel.tsx           # AddBotPanel (ActionSidebar form) + AddBotDialog (mobile popup)
+            members-view.tsx            # Client component: toolbar (search only), list/card views
+            member-form.tsx             # Shared create/edit form (email, working days, RolePicker)
+            role-picker.tsx             # Searchable role input — selecting auto-adds, no + button
         tasks/            # Task definition list + create form
+          layout.tsx            # Registers TasksSidebarShell for all tasks routes
           [taskId]/       # Task detail view (links from timetable)
             edit/         # Edit task form (includes color picker)
           task-form.tsx   # Shared create/edit form — title, color picker, fields, eligibility
+          _components/
+            tasks-config.ts             # Shared sort constants (SortOption, SORT_OPTIONS) — plain module, no "use client"
+            tasks-sidebar-shell.tsx     # Persistent sidebar shell (panel title + List nav tab + sub-content slot)
+            tasks-sidebar-content.tsx   # Filters (sort dropdown, role filter, view toggle) + Create Task action
+            task-table.tsx              # Client component: toolbar (search only), list/card views
         timetable/        # Weekly timetable, template selector, template editor
           layout.tsx            # Registers TimetableSidebarShell for all timetable routes
           page.tsx              # Server page: fetches week entries, permissions, roles
@@ -327,7 +339,7 @@ components/
     sidebar.tsx                 # Global app sidebar: desktop hover-expand (w-12→w-52), mobile overlay
     sidebar-nav-item.tsx        # Shared nav link — variant="app" (icon-well) or variant="page" (inline)
     mobile-sidebar-context.tsx  # Boolean context for mobile sidebar overlay open/close state
-    page-sidebar-context.tsx    # Slot-based page sidebar: RegisterPageSidebar + PageSidebarSlot + sub-content slot
+    page-sidebar-context.tsx    # Slot-based page sidebar: RegisterPageSidebar + PageSidebarSlot + RegisterPageSidebarSubContent sub-content slot
     action-sidebar-context.tsx  # Transient action panel (ActionSidebarSlot) beside page sidebar; open/close via hook
     org-switcher.tsx            # Org selector dropdown
     toolbar.tsx                 # h-12 sticky sub-header; cancels main padding with negative margins; left-pads when sidebar collapsed
@@ -457,12 +469,12 @@ Server Actions call `revalidatePath` to invalidate the Next.js cache so server-r
 | `/orgs/join`                                     | Signed in                                  | Join an existing org as a franchisee using a one-time token                                         |
 | `/orgs/[orgId]`                                  | `requireOrgMemberPage`                     | Org overview                                                                                        |
 | `/orgs/[orgId]/franchisee`                       | `requireParentOrgOwnerPage`                | Franchise management — invite tokens + franchisee list                                              |
-| `/orgs/[orgId]/tasks`                            | `requireOrgMemberPage`                     | Task definition list — searchable/sortable table with role filter and per-row actions               |
+| `/orgs/[orgId]/tasks`                            | `requireOrgMemberPage`                     | Task definition list — sort, role filter, list/card toggle in sidebar; search in toolbar; Create Task action in sidebar (managers only) |
 | `/orgs/[orgId]/tasks/new`                        | `requireOrgPermissionPage MANAGE_TASKS`    | Create task — includes color picker                                                                 |
 | `/orgs/[orgId]/tasks/[taskId]`                   | `requireOrgMemberPage`                     | Task detail view; clicking a task name in the timetable navigates here                              |
 | `/orgs/[orgId]/tasks/[taskId]/edit`              | `requireOrgPermissionPage MANAGE_TASKS`    | Edit task — color picker pre-filled with current color                                              |
-| `/orgs/[orgId]/memberships`                      | `requireOrgMemberPage`                     | Member list                                                                                         |
-| `/orgs/[orgId]/memberships/new`                  | `requireOrgPermissionPage MANAGE_MEMBERS`  | Invite a new member by email                                                                        |
+| `/orgs/[orgId]/memberships`                      | `requireOrgMemberPage`                     | Member list — role filter, list/card toggle in sidebar; search in toolbar; Invite Member + Add Bot in sidebar (ActionSidebar on desktop, Dialog on mobile) |
+| `/orgs/[orgId]/memberships/new`                  | `requireOrgPermissionPage MANAGE_MEMBERS`  | Invite a new member by email (standalone page, also accessible from sidebar action)                 |
 | `/orgs/[orgId]/memberships/[memberId]`           | `requireOrgMemberPage`                     | Member detail view — avatar, roles (multi-badge), working days, status, join date                   |
 | `/orgs/[orgId]/memberships/[memberId]/edit`      | `requireOrgPermissionPage MANAGE_MEMBERS`  | Edit member — working days, roles (owner role excluded from picker)                                 |
 | `/orgs/[orgId]/timetable`                        | `requireOrgMemberPage`                     | Timetable — calendar or simple mode, week navigation                                                |
@@ -505,7 +517,9 @@ A parent org can spawn franchisee orgs using a one-time invite token flow:
 - **Sidebar architecture** — Three context layers work together:
   - `MobileSidebarContext` — boolean open/close state for the global app sidebar overlay on mobile.
   - `AppSidebar` — desktop hover-expand strip (`w-12` → `w-52`); mobile fixed overlay. Uses `SidebarNavItem variant="app"`.
-  - `PageSidebarContext` — slot-based system for page-level sidebars. Pages call `<RegisterPageSidebar>` to inject content into the `<PageSidebarSlot>` rendered by the app layout. Open/closed state persisted in `localStorage`.
+- **PageSidebarContext** — slot-based system for page-level sidebars. `layout.tsx` calls `<RegisterPageSidebar>` to mount a persistent shell; pages call `<RegisterPageSidebarSubContent>` to swap only the inner filters/actions without unmounting the shell (eliminates sidebar flicker on navigation). Open/closed state persisted in `localStorage`.
+- **Shell + sub-content pattern** — Tasks and Members each have a `*-sidebar-shell.tsx` (client, registered in `layout.tsx`) that renders the panel title, nav tabs, and a `usePageSidebarSubContent()` slot. The per-page sidebar content (`*-sidebar-content.tsx`) is registered via `RegisterPageSidebarSubContent` in `page.tsx` and fills that slot.
+- **ActionSidebar for member actions** — "Invite Member" and "Add Bot" in the members sidebar open an `ActionSidebarSlot` panel on desktop (button highlights blue while active) and a `Dialog` popup on mobile. The dialog is mounted in the same component tree as the button so it is not unmounted when the mobile sidebar overlay closes.
 - **Unified height system** — `h-12` (48px) is used consistently across: navbar inner row, toolbar, sidebar nav items, page sidebar title rows, and open/close buttons. This ensures every horizontal element lines up on a shared baseline.
 - **Sidebar nav** — The Progress nav item is disabled (`opacity-40 cursor-not-allowed pointer-events-none`). Active state uses prefix matching; Overview uses exact matching.
 - **Colors required** — Both `Role.color` and `Task.color` are non-nullable in the schema and enforced by Zod validators (`/^#[0-9a-fA-F]{6}$/`). Create and edit forms render a native `<input type="color">` with a hex label. The color is submitted as a hidden `<input name="color">` so it flows through `FormData`.
@@ -670,7 +684,7 @@ SENTRY_AUTH_TOKEN=   # Required whenever source maps are uploaded at build time 
 
 ## Status
 
-Work in progress. Fully implemented: service layer (all 10 services with 93 integration tests), REST API, auth, member management (list, view, edit, restrict, delete), task management (list, view, create, edit with color), timetable view (calendar + simple, task links), timetable templates (create, rename, duplicate, delete, calendar/simple editor, cycle-length controls, apply to timetable), org settings, role management (list, create, edit, delete, task eligibility, color), franchise management, required colors on tasks and roles, async breadcrumbs with name resolution, fixed-toolbar scroll containment on members and tasks pages, audit log (DB table + Zod-validated service layer, all significant mutations instrumented — UI pending).
+Work in progress. Fully implemented: service layer (all 10 services with 93 integration tests), REST API, auth, member management (list, view, edit, restrict, delete), task management (list, view, create, edit with color), timetable view (calendar + simple, task links), timetable templates (create, rename, duplicate, delete, calendar/simple editor, cycle-length controls, apply to timetable), org settings, role management (list, create, edit, delete, task eligibility, color), franchise management, required colors on tasks and roles, async breadcrumbs with name resolution, fixed-toolbar scroll containment on members and tasks pages, audit log (DB table + Zod-validated service layer, all significant mutations instrumented — UI pending), tasks/members page sidebar redesign (shell + sub-content pattern matching timetable architecture, URL-param-driven filters, ActionSidebar panels for Invite Member + Add Bot with mobile Dialog fallback).
 
 Not yet started: schedule generation (automatic cycle-based rotation), worker "Today" checklist, completion stats, timetable/notification settings pages, real-time notification refresh, audit log UI (activity feed page).
 

--- a/__tests__/unit/app/actions/memberships.test.ts
+++ b/__tests__/unit/app/actions/memberships.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { PermissionAction } from "@prisma/client";
 
 // ─── Mock modules ─────────────────────────────────────────────────────────────
 

--- a/__tests__/unit/app/actions/timetable-entries.test.ts
+++ b/__tests__/unit/app/actions/timetable-entries.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { EntryStatus, PermissionAction } from "@prisma/client";
+import { EntryStatus } from "@prisma/client";
 
 // ─── Mock modules ─────────────────────────────────────────────────────────────
 

--- a/__tests__/unit/lib/validators/task.test.ts
+++ b/__tests__/unit/lib/validators/task.test.ts
@@ -184,7 +184,7 @@ describe("createTaskSchema", () => {
 
   describe("wait-day cross-field validation", () => {
     it("rejects when both minWaitDays and maxWaitDays are missing", () => {
-      const { minWaitDays, maxWaitDays, ...rest } = validCreate;
+      const { minWaitDays: _minWaitDays, maxWaitDays: _maxWaitDays, ...rest } = validCreate;
       const result = createTaskSchema.safeParse(rest);
       expect(result.success).toBe(false);
       expect(issueMessages(result)).toContain(
@@ -279,7 +279,7 @@ describe("updateTaskSchema", () => {
   });
 
   it("rejects missing required color", () => {
-    const { color, ...rest } = validUpdate;
+    const { color: _color, ...rest } = validUpdate;
     expect(updateTaskSchema.safeParse(rest).success).toBe(false);
   });
 
@@ -293,7 +293,7 @@ describe("updateTaskSchema", () => {
   });
 
   it("applies same wait-day cross-field rule as create", () => {
-    const { minWaitDays, maxWaitDays, ...rest } = validUpdate;
+    const { minWaitDays: _minWaitDays, maxWaitDays: _maxWaitDays, ...rest } = validUpdate;
     const result = updateTaskSchema.safeParse(rest);
     expect(result.success).toBe(false);
   });

--- a/app/(app)/orgs/[orgId]/memberships/_components/add-bot-panel.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/add-bot-panel.tsx
@@ -41,29 +41,35 @@ export function AddBotPanel({
     );
   }
 
-  function handleSubmit() {
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
     if (!botName.trim()) {
       setErrors({ botName: "Name is required" });
       return;
     }
     setErrors({});
     startTransition(async () => {
-      const result = await createBotAction(orgId, {
-        botName: botName.trim(),
-        roleIds,
-        workingDays,
-      });
-      if (!result.ok) {
-        setErrors({ _: result.error });
-        return;
+      try {
+        const result = await createBotAction(orgId, {
+          botName: botName.trim(),
+          roleIds,
+          workingDays,
+        });
+        if (!result.ok) {
+          setErrors({ _: result.error });
+          return;
+        }
+        toast.success(`Bot "${botName.trim()}" added.`);
+        onClose();
+      } catch (error: any) {
+        setErrors({ _: error.message || String(error) });
+        toast.error("Failed to add bot");
       }
-      toast.success(`Bot "${botName.trim()}" added.`);
-      onClose();
     });
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       {errors._ && <p className="text-sm text-destructive">{errors._}</p>}
 
       <div className="flex flex-col gap-1.5">
@@ -89,6 +95,7 @@ export function AddBotPanel({
               key={key}
               type="button"
               onClick={() => toggleDay(key)}
+              aria-pressed={workingDays.includes(key)}
               className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
                 workingDays.includes(key)
                   ? "bg-primary text-primary-foreground border-primary"
@@ -106,10 +113,10 @@ export function AddBotPanel({
         <RolePicker allRoles={roles} selectedIds={roleIds} onChange={setRoleIds} />
       </div>
 
-      <Button onClick={handleSubmit} disabled={isPending} className="w-full">
+      <Button type="submit" disabled={isPending} className="w-full">
         {isPending ? "Adding…" : "Add Bot"}
       </Button>
-    </div>
+    </form>
   );
 }
 

--- a/app/(app)/orgs/[orgId]/memberships/_components/add-bot-panel.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/add-bot-panel.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+/**
+ * AddBotPanel — inline bot-creation form for the ActionSidebar (desktop) or
+ * AddBotDialog (mobile sheet).
+ */
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { RolePicker } from "./role-picker";
+import { DAYS } from "../_constants";
+import { createBotAction } from "@/app/actions/bots";
+
+type Role = { id: string; name: string };
+
+export function AddBotPanel({
+  orgId,
+  roles,
+  onClose,
+}: {
+  orgId: string;
+  roles: Role[];
+  onClose: () => void;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const [botName, setBotName] = useState("");
+  const [roleIds, setRoleIds] = useState<string[]>([]);
+  const [workingDays, setWorkingDays] = useState<string[]>([]);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  function toggleDay(day: string) {
+    setWorkingDays((prev) =>
+      prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day],
+    );
+  }
+
+  function handleSubmit() {
+    if (!botName.trim()) {
+      setErrors({ botName: "Name is required" });
+      return;
+    }
+    setErrors({});
+    startTransition(async () => {
+      const result = await createBotAction(orgId, {
+        botName: botName.trim(),
+        roleIds,
+        workingDays,
+      });
+      if (!result.ok) {
+        setErrors({ _: result.error });
+        return;
+      }
+      toast.success(`Bot "${botName.trim()}" added.`);
+      onClose();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {errors._ && <p className="text-sm text-destructive">{errors._}</p>}
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-sm font-medium">
+          Bot Name <span className="text-destructive">*</span>
+        </label>
+        <Input
+          type="text"
+          placeholder="e.g. Open Slot"
+          value={botName}
+          onChange={(e) => setBotName(e.target.value)}
+        />
+        {errors.botName && (
+          <p className="text-xs text-destructive">{errors.botName}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium">Working Days</label>
+        <div className="flex flex-wrap gap-2">
+          {DAYS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => toggleDay(key)}
+              className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                workingDays.includes(key)
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "border-border text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium">Roles</label>
+        <RolePicker allRoles={roles} selectedIds={roleIds} onChange={setRoleIds} />
+      </div>
+
+      <Button onClick={handleSubmit} disabled={isPending} className="w-full">
+        {isPending ? "Adding…" : "Add Bot"}
+      </Button>
+    </div>
+  );
+}
+
+export function AddBotDialog({
+  open,
+  onOpenChange,
+  orgId,
+  roles,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  orgId: string;
+  roles: Role[];
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Bot</DialogTitle>
+        </DialogHeader>
+        <AddBotPanel
+          orgId={orgId}
+          roles={roles}
+          onClose={() => onOpenChange(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/(app)/orgs/[orgId]/memberships/_components/add-bot-panel.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/add-bot-panel.tsx
@@ -61,8 +61,8 @@ export function AddBotPanel({
         }
         toast.success(`Bot "${botName.trim()}" added.`);
         onClose();
-      } catch (error: any) {
-        setErrors({ _: error.message || String(error) });
+      } catch (error: unknown) {
+        setErrors({ _: error instanceof Error ? error.message : String(error) });
         toast.error("Failed to add bot");
       }
     });

--- a/app/(app)/orgs/[orgId]/memberships/_components/invite-member-panel.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/invite-member-panel.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+/**
+ * InviteMemberPanel — inline invite form for the ActionSidebar (desktop) or
+ * InviteMemberDialog (mobile sheet).
+ */
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { RolePicker } from "./role-picker";
+import { DAYS } from "../_constants";
+import { sendMemberInviteAction } from "@/app/actions/memberships";
+
+type Role = { id: string; name: string };
+
+export function InviteMemberPanel({
+  orgId,
+  roles,
+  onClose,
+}: {
+  orgId: string;
+  roles: Role[];
+  onClose: () => void;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const [email, setEmail] = useState("");
+  const [roleIds, setRoleIds] = useState<string[]>([]);
+  const [workingDays, setWorkingDays] = useState<string[]>([]);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  function toggleDay(day: string) {
+    setWorkingDays((prev) =>
+      prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day],
+    );
+  }
+
+  function handleSubmit() {
+    setErrors({});
+    startTransition(async () => {
+      const result = await sendMemberInviteAction(orgId, {
+        email,
+        roleIds,
+        workingDays,
+      });
+      if (!result.ok) {
+        setErrors(
+          result.field
+            ? { [result.field]: result.error }
+            : { _: result.error },
+        );
+        return;
+      }
+      toast.success("Invite sent!");
+      onClose();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {errors._ && <p className="text-sm text-destructive">{errors._}</p>}
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-sm font-medium">
+          Email <span className="text-destructive">*</span>
+        </label>
+        <Input
+          type="email"
+          placeholder="member@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        {errors.email && (
+          <p className="text-xs text-destructive">{errors.email}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium">Working Days</label>
+        <div className="flex flex-wrap gap-2">
+          {DAYS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => toggleDay(key)}
+              className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                workingDays.includes(key)
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "border-border text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium">Roles</label>
+        <RolePicker allRoles={roles} selectedIds={roleIds} onChange={setRoleIds} />
+      </div>
+
+      <Button onClick={handleSubmit} disabled={isPending} className="w-full">
+        {isPending ? "Sending…" : "Send Invite"}
+      </Button>
+    </div>
+  );
+}
+
+export function InviteMemberDialog({
+  open,
+  onOpenChange,
+  orgId,
+  roles,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  orgId: string;
+  roles: Role[];
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Invite Member</DialogTitle>
+        </DialogHeader>
+        <InviteMemberPanel
+          orgId={orgId}
+          roles={roles}
+          onClose={() => onOpenChange(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/(app)/orgs/[orgId]/memberships/_components/invite-member-panel.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/invite-member-panel.tsx
@@ -57,6 +57,9 @@ export function InviteMemberPanel({
         );
         return;
       }
+      setEmail("");
+      setRoleIds([]);
+      setWorkingDays([]);
       toast.success("Invite sent!");
       onClose();
     });
@@ -67,10 +70,11 @@ export function InviteMemberPanel({
       {errors._ && <p className="text-sm text-destructive">{errors._}</p>}
 
       <div className="flex flex-col gap-1.5">
-        <label className="text-sm font-medium">
+        <label htmlFor="invite-email" className="text-sm font-medium">
           Email <span className="text-destructive">*</span>
         </label>
         <Input
+          id="invite-email"
           type="email"
           placeholder="member@example.com"
           value={email}
@@ -81,8 +85,8 @@ export function InviteMemberPanel({
         )}
       </div>
 
-      <div className="flex flex-col gap-2">
-        <label className="text-sm font-medium">Working Days</label>
+      <fieldset className="flex flex-col gap-2">
+        <legend className="text-sm font-medium">Working Days</legend>
         <div className="flex flex-wrap gap-2">
           {DAYS.map(({ key, label }) => (
             <button
@@ -99,11 +103,11 @@ export function InviteMemberPanel({
             </button>
           ))}
         </div>
-      </div>
+      </fieldset>
 
       <div className="flex flex-col gap-2">
-        <label className="text-sm font-medium">Roles</label>
-        <RolePicker allRoles={roles} selectedIds={roleIds} onChange={setRoleIds} />
+        <label id="invite-roles-label" className="text-sm font-medium">Roles</label>
+        <RolePicker allRoles={roles} selectedIds={roleIds} onChange={setRoleIds} aria-labelledby="invite-roles-label" />
       </div>
 
       <Button onClick={handleSubmit} disabled={isPending} className="w-full">

--- a/app/(app)/orgs/[orgId]/memberships/_components/members-actions.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/members-actions.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+/**
+ * MembersActions — action buttons rendered in the members sidebar.
+ *
+ * Desktop:
+ *   - "Invite Member" opens InviteMemberPanel inside ActionSidebarSlot.
+ *   - "Add Bot" opens AddBotPanel inside ActionSidebarSlot.
+ *   The active button highlights (variant="default") when its panel is open.
+ *
+ * Mobile:
+ *   - Both buttons close the mobile page-sidebar overlay and open a Dialog.
+ *
+ * Only rendered when canManage is true (enforced by MembersSidebarContent).
+ */
+import { useRef, useState } from "react";
+import { UserPlus, Bot } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useActionSidebar } from "@/components/layout/action-sidebar-context";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { InviteMemberPanel, InviteMemberDialog } from "./invite-member-panel";
+import { AddBotPanel, AddBotDialog } from "./add-bot-panel";
+
+type Role = { id: string; name: string };
+
+export function MembersActions({
+  orgId,
+  roles,
+}: {
+  orgId: string;
+  roles: Role[];
+}) {
+  const { open, close, activeTitle } = useActionSidebar();
+  const isMobile = useIsMobile();
+  const inviteKeyRef = useRef(0);
+  const botKeyRef = useRef(0);
+  const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
+  const [inviteDialogKey, setInviteDialogKey] = useState(0);
+  const [botDialogOpen, setBotDialogOpen] = useState(false);
+  const [botDialogKey, setBotDialogKey] = useState(0);
+
+  function openInviteMember() {
+    if (isMobile) {
+      setInviteDialogKey((k) => k + 1);
+      setInviteDialogOpen(true);
+    } else {
+      const k = ++inviteKeyRef.current;
+      open(
+        "Invite Member",
+        <InviteMemberPanel
+          key={k}
+          orgId={orgId}
+          roles={roles}
+          onClose={close}
+        />,
+      );
+    }
+  }
+
+  function openAddBot() {
+    if (isMobile) {
+      setBotDialogKey((k) => k + 1);
+      setBotDialogOpen(true);
+    } else {
+      const k = ++botKeyRef.current;
+      open(
+        "Add Bot",
+        <AddBotPanel key={k} orgId={orgId} roles={roles} onClose={close} />,
+      );
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant={activeTitle === "Invite Member" ? "default" : "outline"}
+        size="sm"
+        onClick={openInviteMember}
+        className="w-full justify-start gap-2"
+      >
+        <UserPlus className="h-4 w-4 shrink-0" />
+        Invite Member
+      </Button>
+      <Button
+        variant={activeTitle === "Add Bot" ? "default" : "outline"}
+        size="sm"
+        onClick={openAddBot}
+        className="w-full justify-start gap-2"
+      >
+        <Bot className="h-4 w-4 shrink-0" />
+        Add Bot
+      </Button>
+
+      <InviteMemberDialog
+        key={`invite-${inviteDialogKey}`}
+        open={inviteDialogOpen}
+        onOpenChange={setInviteDialogOpen}
+        orgId={orgId}
+        roles={roles}
+      />
+      <AddBotDialog
+        key={`bot-${botDialogKey}`}
+        open={botDialogOpen}
+        onOpenChange={setBotDialogOpen}
+        orgId={orgId}
+        roles={roles}
+      />
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/memberships/_components/members-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/members-sidebar-content.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+/**
+ * MembersSidebarContent — page sidebar for the members list page.
+ *
+ * Sections:
+ *  - Filters — role filter, list/card view toggle
+ *  - Actions — Invite Member, Add Bot (canManage only)
+ *
+ * All filter/view state is URL-driven: each control pushes a new URL so the
+ * server page re-renders with the updated params.
+ */
+import { useRouter } from "next/navigation";
+import { ChevronDown, LayoutGrid, List } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { MembersActions } from "./members-actions";
+
+type Role = { id: string; name: string };
+
+interface MembersSidebarContentProps {
+  orgId: string;
+  roles: Role[];
+  canManage: boolean;
+  roleId: string | null;
+  view: "list" | "card";
+}
+
+export function MembersSidebarContent({
+  orgId,
+  roles,
+  canManage,
+  roleId,
+  view,
+}: MembersSidebarContentProps) {
+  const router = useRouter();
+
+  function buildHref(overrides: {
+    roleId?: string | null;
+    view?: "list" | "card";
+  }) {
+    const params = new URLSearchParams();
+    const next = { roleId, view, ...overrides };
+    if (next.roleId) params.set("roleId", next.roleId);
+    if (next.view && next.view !== "card") params.set("view", next.view);
+    const qs = params.toString();
+    return `/orgs/${orgId}/memberships${qs ? `?${qs}` : ""}`;
+  }
+
+  const activeRole = roles.find((r) => r.id === roleId);
+
+  return (
+    <>
+      {/* Filters section */}
+      <div className="px-3 pt-3 pb-2">
+        <p className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider px-1 mb-2">
+          Filters
+        </p>
+        <div className="flex flex-col gap-2">
+
+        {/* Role filter */}
+        {roles.length > 0 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant={roleId ? "secondary" : "outline"}
+                size="sm"
+                className="w-full justify-between gap-2"
+              >
+                {activeRole ? activeRole.name : "All roles"}
+                <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="w-40">
+              {roleId && (
+                <DropdownMenuItem
+                  onClick={() => router.push(buildHref({ roleId: null }))}
+                >
+                  All roles
+                </DropdownMenuItem>
+              )}
+              {roles.map((r) => (
+                <DropdownMenuItem
+                  key={r.id}
+                  onClick={() => router.push(buildHref({ roleId: r.id }))}
+                >
+                  {r.name}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
+        {/* View toggle */}
+        <SegmentedControl
+          size="sm"
+          className="w-fit"
+          value={view}
+          onChange={(v) =>
+            router.push(buildHref({ view: v as "list" | "card" }))
+          }
+          options={[
+            { value: "list", label: <List className="h-4 w-4" /> },
+            { value: "card", label: <LayoutGrid className="h-4 w-4" /> },
+          ]}
+        />
+        </div>
+      </div>
+
+      {canManage && (
+        <div className="px-3 pt-2 pb-3 border-t border-border">
+          <p className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider px-1 mb-2">
+            Actions
+          </p>
+          <div className="flex flex-col gap-2">
+            <MembersActions orgId={orgId} roles={roles} />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/memberships/_components/members-sidebar-shell.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/members-sidebar-shell.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, usePathname } from "next/navigation";
+import { Users } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { usePageSidebarSubContent } from "@/components/layout/page-sidebar-context";
+
+export function MembersSidebarShell() {
+  const { orgId } = useParams<{ orgId: string }>();
+  const pathname = usePathname();
+  const subContent = usePageSidebarSubContent();
+
+  const membershipsHref = `/orgs/${orgId}/memberships`;
+
+  return (
+    <aside className="flex flex-col flex-1 overflow-y-auto">
+      {/* Panel title */}
+      <div className="h-12 flex items-center px-4 border-b border-border shrink-0">
+        <span className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider">
+          Members
+        </span>
+      </div>
+
+      {/* Nav tab */}
+      <nav className="shrink-0 border-b border-border">
+        <Link
+          href={membershipsHref}
+          className={cn(
+            "relative flex items-center gap-2.5 h-12 px-4 text-sm transition-colors",
+            pathname === membershipsHref
+              ? "bg-sidebar-primary text-sidebar-primary-foreground font-medium before:absolute before:top-2 before:left-2 before:w-2.5 before:h-2.5 before:border-t-2 before:border-l-2 before:border-primary after:absolute after:bottom-2 after:right-2 after:w-2.5 after:h-2.5 after:border-b-2 after:border-r-2 after:border-primary"
+              : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+          )}
+          aria-current={pathname === membershipsHref ? "page" : undefined}
+        >
+          <Users className="h-5 w-5 shrink-0" />
+          <span className="truncate">List</span>
+        </Link>
+      </nav>
+
+      {/* Page-specific sub-content (filters, actions, etc.) */}
+      {subContent}
+    </aside>
+  );
+}

--- a/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
@@ -1,8 +1,8 @@
 /**
  * MembersView — client component for the org members list page.
  *
- * Renders a toolbar (search, role filter, view toggle, "+ Add Member" button)
- * and the member roster in one of two layouts chosen by the user:
+ * Renders a toolbar (search) and the member roster in one of two layouts chosen
+ * via the page sidebar:
  *
  *   - List view  (`MemberList`)  — compact rows, ideal for many members.
  *   - Card view  (`CardGrid`)    — photo-forward grid, one card per member.
@@ -23,20 +23,11 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { usePersistedState } from "@/hooks/use-persisted-state";
 import Image from "next/image";
 import Link from "next/link";
-import { ChevronDown, LayoutGrid, List, Search } from "lucide-react";
+import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardTitle } from "@/components/ui/card";
-import { SegmentedControl } from "@/components/ui/segmented-control";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { Toolbar } from "@/components/layout/toolbar";
 import { MemberActions } from "./member-actions";
@@ -138,31 +129,16 @@ export function MembersView({
   members,
   orgId,
   canManage,
+  roleId,
+  view,
 }: {
   members: Member[];
   orgId: string;
   canManage: boolean;
+  roleId: string | null;
+  view: "list" | "card";
 }) {
-  const [view, setView] = usePersistedState<"card" | "list">(
-    "members:view",
-    "card",
-  );
   const [search, setSearch] = useState("");
-  const [roleFilter, setRoleFilter] = useState<string | null>(null);
-
-  const allRoles = useMemo(() => {
-    const seen = new Set<string>();
-    const roles: { id: string; name: string }[] = [];
-    for (const m of members) {
-      for (const { role } of m.memberRoles) {
-        if (!seen.has(role.id)) {
-          seen.add(role.id);
-          roles.push(role);
-        }
-      }
-    }
-    return roles.sort((a, b) => a.name.localeCompare(b.name));
-  }, [members]);
 
   const filtered = useMemo(() => {
     const q = search.toLowerCase().trim();
@@ -170,74 +146,31 @@ export function MembersView({
       if (q && !(m.user?.name ?? m.botName ?? "").toLowerCase().includes(q))
         return false;
       if (
-        roleFilter &&
-        !m.memberRoles.some(({ role }) => role.id === roleFilter)
+        roleId &&
+        !m.memberRoles.some(({ role }) => role.id === roleId)
       )
         return false;
       return true;
     });
-  }, [members, search, roleFilter]);
+  }, [members, search, roleId]);
 
   return (
     <div className="flex flex-col h-full">
       {/* Toolbar */}
       <Toolbar>
-        <div className="relative flex-1 min-w-[200px]">
+        <div className="relative flex-1 min-w-50">
           <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
           <Input
             placeholder="Search members…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="pl-7 h-8 w-full"
+            className="pl-7 h-7 w-full"
             aria-label="Search members by name"
           />
         </div>
-        <SegmentedControl
-          size="sm"
-          value={view}
-          onChange={setView}
-          options={[
-            { value: "list", label: <List className="h-4 w-4" /> },
-            { value: "card", label: <LayoutGrid className="h-4 w-4" /> },
-          ]}
-        />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm" className="gap-1.5 shrink-0">
-              {roleFilter
-                ? (allRoles.find((r) => r.id === roleFilter)?.name ?? "Role")
-                : "All roles"}
-              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start">
-            <DropdownMenuItem onSelect={() => setRoleFilter(null)}>
-              All roles
-            </DropdownMenuItem>
-            {allRoles.map((role) => (
-              <DropdownMenuItem
-                key={role.id}
-                onSelect={() => setRoleFilter(role.id)}
-              >
-                {role.name}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        {canManage && (
-          <div className="flex items-center gap-2 ml-auto shrink-0">
-            <Button asChild size="sm">
-              <Link href={`/orgs/${orgId}/memberships/new`}>+ Member</Link>
-            </Button>
-            <Button asChild size="sm">
-              <Link href={`/orgs/${orgId}/memberships/new?bot=1`}>+ Bot</Link>
-            </Button>
-          </div>
-        )}
       </Toolbar>
 
-      <div className="flex-1 overflow-auto -mx-4 sm:-mx-6 px-4 sm:px-6 pb-4 sm:pb-6">
+      <div className="flex-1 overflow-auto -mx-4 sm:-mx-6 px-4 sm:px-6 pt-4 sm:pt-6 pb-4 sm:pb-6">
         {filtered.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             {members.length === 0

--- a/app/(app)/orgs/[orgId]/memberships/layout.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { RegisterPageSidebar } from "@/components/layout/page-sidebar-context";
+import { MembersSidebarShell } from "./_components/members-sidebar-shell";
+
+export default function MembershipsLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <RegisterPageSidebar content={<MembersSidebarShell />} />
+      {children}
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/memberships/page.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/page.tsx
@@ -1,8 +1,11 @@
 import { getMemberships } from "@/lib/services/memberships";
+import { getRoles } from "@/lib/services/roles";
 import { requireOrgMemberPage } from "@/lib/authz";
 import { memberHasPermission, getOrgMembership } from "@/lib/authz/_shared";
 import { PermissionAction } from "@prisma/client";
+import { RegisterPageSidebarSubContent } from "@/components/layout/page-sidebar-context";
 import { MembersView } from "./_components/members-view";
+import { MembersSidebarContent } from "./_components/members-sidebar-content";
 
 /**
  * Members list page — server component.
@@ -12,22 +15,25 @@ import { MembersView } from "./_components/members-view";
  * holds the `MANAGE_MEMBERS` permission. Both fetches are parallelised with
  * `Promise.all` to avoid a waterfall.
  *
- * The `canManage` flag is forwarded to `MembersView` so it can conditionally
- * show the "+ Add Member" button without performing another auth check on
- * the client.
+ * Role filter and view (list/card) are URL-param driven so the sidebar
+ * controls and the members list stay in sync without client state sharing.
  */
 const MembersPage = async ({
   params,
+  searchParams,
 }: {
   params: Promise<{ orgId: string }>;
+  searchParams: Promise<{ roleId?: string; view?: string }>;
 }) => {
   const { orgId } = await params;
+  const sp = await searchParams;
 
   const { userId } = await requireOrgMemberPage(orgId);
 
-  const [memberships, membership] = await Promise.all([
+  const [memberships, membership, roles] = await Promise.all([
     getMemberships(orgId),
     getOrgMembership(orgId, userId),
+    getRoles(orgId),
   ]);
 
   const canManage = membership
@@ -38,19 +44,40 @@ const MembersPage = async ({
       )
     : false;
 
+  const roleId =
+    typeof sp.roleId === "string" && roles.some((r) => r.id === sp.roleId)
+      ? sp.roleId
+      : null;
+  const view: "list" | "card" = sp.view === "list" ? "list" : "card";
+
   return (
-    <MembersView
-      members={memberships.map((m) => ({
-        id: m.id,
-        userId: m.userId,
-        botName: m.botName,
-        status: m.status,
-        user: m.user,
-        memberRoles: m.memberRoles,
-      }))}
-      orgId={orgId}
-      canManage={canManage}
-    />
+    <>
+      <RegisterPageSidebarSubContent
+        content={
+          <MembersSidebarContent
+            orgId={orgId}
+            roles={roles}
+            canManage={canManage}
+            roleId={roleId}
+            view={view}
+          />
+        }
+      />
+      <MembersView
+        members={memberships.map((m) => ({
+          id: m.id,
+          userId: m.userId,
+          botName: m.botName,
+          status: m.status,
+          user: m.user,
+          memberRoles: m.memberRoles,
+        }))}
+        orgId={orgId}
+        canManage={canManage}
+        roleId={roleId}
+        view={view}
+      />
+    </>
   );
 };
 

--- a/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
@@ -9,9 +9,9 @@
  *
  * Toolbar:
  *  - Search input — filters rows by title (case-insensitive).
- *  - Sort dropdown — Name A–Z/Z–A, Duration ↑↓, People ↑↓.
- *  - Filter by role — hidden when no roles exist; highlights when active.
- *  - Actions dropdown — single "Create" link to the new-task form.
+ *
+ * Sort, role filter, and view (list/card) are URL-driven and come from the
+ * page sidebar (TasksSidebarContent) via server-rendered props.
  *
  * Row actions ([...] menu per row):
  *  - Edit — navigates to `/orgs/[orgId]/tasks/[taskId]/edit`.
@@ -23,17 +23,10 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import {
-  ChevronDown,
-  LayoutGrid,
-  List,
-  MoreHorizontal,
-  ListTodo,
-} from "lucide-react";
+import { MoreHorizontal, ListTodo } from "lucide-react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { SegmentedControl } from "@/components/ui/segmented-control";
 import { Toolbar } from "@/components/layout/toolbar";
 import {
   DropdownMenu,
@@ -52,7 +45,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { deleteTaskAction } from "@/app/actions/tasks";
-import { usePersistedState } from "@/hooks/use-persisted-state";
+import type { SortOption } from "./tasks-config";
 
 // Strip markdown syntax for plain-text previews
 function stripMd(text: string): string {
@@ -78,70 +71,29 @@ type Task = {
   eligibility: { role: { id: string; name: string; color: string | null } }[];
 };
 
-type Role = { id: string; name: string };
-
-type SortOption =
-  | "name-asc"
-  | "name-desc"
-  | "duration-asc"
-  | "duration-desc"
-  | "people-asc"
-  | "people-desc";
-
-const SORT_OPTIONS: { value: SortOption; label: string }[] = [
-  { value: "name-asc", label: "Name A–Z" },
-  { value: "name-desc", label: "Name Z–A" },
-  { value: "duration-asc", label: "Duration ↑" },
-  { value: "duration-desc", label: "Duration ↓" },
-  { value: "people-asc", label: "People ↑" },
-  { value: "people-desc", label: "People ↓" },
-];
-
 // ─── Component ────────────────────────────────────────────────────────────────
 
 interface TaskTableProps {
   orgId: string;
   tasks: Task[];
-  roles: Role[];
   canManageTasks: boolean;
+  sort: SortOption;
+  filterRoleId: string | null;
+  view: "list" | "card";
 }
 
 export function TaskTable({
   orgId,
   tasks,
-  roles,
   canManageTasks,
+  sort,
+  filterRoleId,
+  view,
 }: TaskTableProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [search, setSearch] = useState("");
-  const [sortRaw, setSortRaw] = usePersistedState<SortOption>(
-    "tasks:sort",
-    "name-asc",
-  );
-  // Validate persisted sort value against SORT_OPTIONS
-  const sort = SORT_OPTIONS.find((o) => o.value === sortRaw)
-    ? sortRaw
-    : "name-asc";
-  const setSort = (value: SortOption) => {
-    // Sanitize updates to only accept values present in SORT_OPTIONS
-    if (SORT_OPTIONS.find((o) => o.value === value)) {
-      setSortRaw(value);
-    }
-  };
-  const [filterRoleId, setFilterRoleId] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Task | null>(null);
-  const [viewRaw, setViewRaw] = usePersistedState<"list" | "card">(
-    "tasks:view",
-    "list",
-  );
-  // Validate persisted view value
-  const view = viewRaw === "list" || viewRaw === "card" ? viewRaw : "list";
-  const setView = (value: "list" | "card") => {
-    if (value === "list" || value === "card") {
-      setViewRaw(value);
-    }
-  };
 
   // Filter by search and role
   let visible = tasks.filter((t) =>
@@ -171,9 +123,6 @@ export function TaskTable({
     }
   });
 
-  const activeSort = SORT_OPTIONS.find((o) => o.value === sort)!;
-  const activeRole = roles.find((r) => r.id === filterRoleId);
-
   function handleDelete() {
     if (!deleteTarget) return;
     const taskId = deleteTarget.id;
@@ -197,73 +146,8 @@ export function TaskTable({
           placeholder="Search by title..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="flex-1 h-8 min-w-[200px]"
+          className="flex-1 h-7 min-w-50"
         />
-        <SegmentedControl
-          size="sm"
-          value={view}
-          onChange={setView}
-          options={[
-            { value: "list", label: <List className="h-4 w-4" /> },
-            { value: "card", label: <LayoutGrid className="h-4 w-4" /> },
-          ]}
-        />
-        {/* Sort */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm" className="gap-1.5 shrink-0">
-              {activeSort.label}
-              <ChevronDown className="h-3.5 w-3.5" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start">
-            {SORT_OPTIONS.map((o) => (
-              <DropdownMenuItem
-                key={o.value}
-                onClick={() => setSort(o.value)}
-              >
-                {o.label}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        {/* Filter by role */}
-        {roles.length > 0 && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant={filterRoleId ? "secondary" : "outline"}
-                size="sm"
-                className="gap-1.5 shrink-0"
-              >
-                {activeRole ? activeRole.name : "Filter by role"}
-                <ChevronDown className="h-3.5 w-3.5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start">
-              {filterRoleId && (
-                <DropdownMenuItem onClick={() => setFilterRoleId(null)}>
-                  All roles
-                </DropdownMenuItem>
-              )}
-              {roles.map((r) => (
-                <DropdownMenuItem
-                  key={r.id}
-                  onClick={() => setFilterRoleId(r.id)}
-                >
-                  {r.name}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
-
-        {canManageTasks && (
-          <Button asChild size="sm" className="ml-auto shrink-0">
-            <a href={`/orgs/${orgId}/tasks/new`}>+ Create Task</a>
-          </Button>
-        )}
       </Toolbar>
 
       <div className="flex-1 overflow-auto -mx-4 sm:-mx-6 px-4 sm:px-6 pb-4 sm:pb-6">

--- a/app/(app)/orgs/[orgId]/tasks/_components/tasks-config.ts
+++ b/app/(app)/orgs/[orgId]/tasks/_components/tasks-config.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared sort config for the tasks list page.
+ *
+ * Kept in a plain (non-"use client") module so it can be imported safely
+ * by both the server page component and the client sidebar component.
+ */
+
+export type SortOption =
+  | "name-asc"
+  | "name-desc"
+  | "duration-asc"
+  | "duration-desc"
+  | "people-asc"
+  | "people-desc";
+
+export const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: "name-asc", label: "Name A–Z" },
+  { value: "name-desc", label: "Name Z–A" },
+  { value: "duration-asc", label: "Duration ↑" },
+  { value: "duration-desc", label: "Duration ↓" },
+  { value: "people-asc", label: "People ↑" },
+  { value: "people-desc", label: "People ↓" },
+];

--- a/app/(app)/orgs/[orgId]/tasks/_components/tasks-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/_components/tasks-sidebar-content.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+/**
+ * TasksSidebarContent — page sidebar for the tasks list page.
+ *
+ * Sections:
+ *  - Filters — sort order, role filter, list/card view toggle
+ *  - Actions — Create Task link (canManageTasks only)
+ *
+ * All filter/sort/view state is URL-driven: each control pushes a new URL so
+ * the server page re-renders with the updated params. This keeps the sidebar
+ * and the task table in sync without a shared client context.
+ */
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ChevronDown, LayoutGrid, List, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { SORT_OPTIONS, type SortOption } from "./tasks-config";
+
+type Role = { id: string; name: string };
+
+interface TasksSidebarContentProps {
+  orgId: string;
+  roles: Role[];
+  canManageTasks: boolean;
+  sort: SortOption;
+  roleId: string | null;
+  view: "list" | "card";
+}
+
+export function TasksSidebarContent({
+  orgId,
+  roles,
+  canManageTasks,
+  sort,
+  roleId,
+  view,
+}: TasksSidebarContentProps) {
+  const router = useRouter();
+
+  function buildHref(overrides: {
+    sort?: SortOption;
+    roleId?: string | null;
+    view?: "list" | "card";
+  }) {
+    const params = new URLSearchParams();
+    const next = { sort, roleId, view, ...overrides };
+    if (next.sort && next.sort !== "name-asc") params.set("sort", next.sort);
+    if (next.roleId) params.set("roleId", next.roleId);
+    if (next.view && next.view !== "list") params.set("view", next.view);
+    const qs = params.toString();
+    return `/orgs/${orgId}/tasks${qs ? `?${qs}` : ""}`;
+  }
+
+  const activeSort = SORT_OPTIONS.find((o) => o.value === sort)!;
+  const activeRole = roles.find((r) => r.id === roleId);
+
+  return (
+    <>
+      {/* Filters section */}
+      <div className="px-3 pt-3 pb-2">
+        <p className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider px-1 mb-2">
+          Filters
+        </p>
+        <div className="flex flex-col gap-2">
+
+        {/* Sort */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full justify-between gap-2"
+            >
+              {activeSort.label}
+              <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-40">
+            {SORT_OPTIONS.map((o) => (
+              <DropdownMenuItem
+                key={o.value}
+                onClick={() => router.push(buildHref({ sort: o.value }))}
+              >
+                {o.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Role filter */}
+        {roles.length > 0 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant={roleId ? "secondary" : "outline"}
+                size="sm"
+                className="w-full justify-between gap-2"
+              >
+                {activeRole ? activeRole.name : "All roles"}
+                <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="w-40">
+              {roleId && (
+                <DropdownMenuItem
+                  onClick={() => router.push(buildHref({ roleId: null }))}
+                >
+                  All roles
+                </DropdownMenuItem>
+              )}
+              {roles.map((r) => (
+                <DropdownMenuItem
+                  key={r.id}
+                  onClick={() => router.push(buildHref({ roleId: r.id }))}
+                >
+                  {r.name}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
+        {/* View toggle */}
+        <SegmentedControl
+          size="sm"
+          className="w-fit"
+          value={view}
+          onChange={(v) => router.push(buildHref({ view: v as "list" | "card" }))}
+          options={[
+            { value: "list", label: <List className="h-4 w-4" /> },
+            { value: "card", label: <LayoutGrid className="h-4 w-4" /> },
+          ]}
+        />
+        </div>
+      </div>
+
+      {canManageTasks && (
+        <div className="px-3 pt-2 pb-3 border-t border-border">
+          <p className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider px-1 mb-2">
+            Actions
+          </p>
+          <div className="flex flex-col gap-2">
+            <Button asChild size="sm" className="w-full justify-start gap-2">
+              <Link href={`/orgs/${orgId}/tasks/new`}>
+                <Plus className="h-4 w-4" />
+                Create Task
+              </Link>
+            </Button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tasks/_components/tasks-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/_components/tasks-sidebar-content.tsx
@@ -103,6 +103,7 @@ export function TasksSidebarContent({
                 variant={roleId ? "secondary" : "outline"}
                 size="sm"
                 className="w-full justify-between gap-2"
+                aria-label="Filter by role"
               >
                 {activeRole ? activeRole.name : "All roles"}
                 <ChevronDown className="h-3.5 w-3.5 shrink-0" />

--- a/app/(app)/orgs/[orgId]/tasks/_components/tasks-sidebar-shell.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/_components/tasks-sidebar-shell.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, usePathname } from "next/navigation";
+import { ListTodo } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { usePageSidebarSubContent } from "@/components/layout/page-sidebar-context";
+
+export function TasksSidebarShell() {
+  const { orgId } = useParams<{ orgId: string }>();
+  const pathname = usePathname();
+  const subContent = usePageSidebarSubContent();
+
+  const tasksHref = `/orgs/${orgId}/tasks`;
+
+  return (
+    <aside className="flex flex-col flex-1 overflow-y-auto">
+      {/* Panel title */}
+      <div className="h-12 flex items-center px-4 border-b border-border shrink-0">
+        <span className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider">
+          Tasks
+        </span>
+      </div>
+
+      {/* Nav tab */}
+      <nav className="shrink-0 border-b border-border">
+        <Link
+          href={tasksHref}
+          className={cn(
+            "relative flex items-center gap-2.5 h-12 px-4 text-sm transition-colors",
+            pathname === tasksHref
+              ? "bg-sidebar-primary text-sidebar-primary-foreground font-medium before:absolute before:top-2 before:left-2 before:w-2.5 before:h-2.5 before:border-t-2 before:border-l-2 before:border-primary after:absolute after:bottom-2 after:right-2 after:w-2.5 after:h-2.5 after:border-b-2 after:border-r-2 after:border-primary"
+              : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+          )}
+          aria-current={pathname === tasksHref ? "page" : undefined}
+        >
+          <ListTodo className="h-5 w-5 shrink-0" />
+          <span className="truncate">List</span>
+        </Link>
+      </nav>
+
+      {/* Page-specific sub-content (filters, actions, etc.) */}
+      {subContent}
+    </aside>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tasks/layout.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { RegisterPageSidebar } from "@/components/layout/page-sidebar-context";
+import { TasksSidebarShell } from "./_components/tasks-sidebar-shell";
+
+export default function TasksLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <RegisterPageSidebar content={<TasksSidebarShell />} />
+      {children}
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tasks/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/page.tsx
@@ -7,7 +7,13 @@ import {
   getAuthUserId,
 } from "@/lib/authz/_shared";
 import { PermissionAction } from "@prisma/client";
+import { RegisterPageSidebarSubContent } from "@/components/layout/page-sidebar-context";
 import { TaskTable } from "./_components/task-table";
+import { TasksSidebarContent } from "./_components/tasks-sidebar-content";
+import {
+  SORT_OPTIONS,
+  type SortOption,
+} from "./_components/tasks-config";
 
 /**
  * Tasks list page — server component.
@@ -15,13 +21,21 @@ import { TaskTable } from "./_components/task-table";
  * Guards access with `requireOrgMemberPage`; redirects to `/` if the caller is not
  * a member. Fetches tasks (with role eligibility) and all org roles, then renders
  * the interactive TaskTable client component with search, sort, and filter.
+ *
+ * Sort, role filter, and view (list/card) are URL-param driven so the sidebar
+ * controls and the table stay in sync without client state sharing.
  */
+const VALID_SORT_VALUES = SORT_OPTIONS.map((o) => o.value);
+
 const TasksPage = async ({
   params,
+  searchParams,
 }: {
   params: Promise<{ orgId: string }>;
+  searchParams: Promise<{ sort?: string; roleId?: string; view?: string }>;
 }) => {
   const { orgId } = await params;
+  const sp = await searchParams;
 
   await requireOrgMemberPage(orgId);
 
@@ -37,13 +51,38 @@ const TasksPage = async ({
 
   const [tasks, roles] = await Promise.all([getTasks(orgId), getRoles(orgId)]);
 
+  const sort: SortOption = VALID_SORT_VALUES.includes(sp.sort as SortOption)
+    ? (sp.sort as SortOption)
+    : "name-asc";
+  const roleId =
+    typeof sp.roleId === "string" && roles.some((r) => r.id === sp.roleId)
+      ? sp.roleId
+      : null;
+  const view: "list" | "card" = sp.view === "card" ? "card" : "list";
+
   return (
-    <TaskTable
-      orgId={orgId}
-      tasks={tasks}
-      roles={roles}
-      canManageTasks={canManageTasks}
-    />
+    <>
+      <RegisterPageSidebarSubContent
+        content={
+          <TasksSidebarContent
+            orgId={orgId}
+            roles={roles}
+            canManageTasks={canManageTasks}
+            sort={sort}
+            roleId={roleId}
+            view={view}
+          />
+        }
+      />
+      <TaskTable
+        orgId={orgId}
+        tasks={tasks}
+        canManageTasks={canManageTasks}
+        sort={sort}
+        filterRoleId={roleId}
+        view={view}
+      />
+    </>
   );
 };
 

--- a/app/(app)/orgs/[orgId]/timetable/_components/timetable-sidebar-shell.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/_components/timetable-sidebar-shell.tsx
@@ -43,9 +43,9 @@ export function TimetableSidebarShell() {
               key={label}
               href={url}
               className={cn(
-                "flex items-center gap-2.5 h-12 px-4 text-sm transition-colors",
+                "relative flex items-center gap-2.5 h-12 px-4 text-sm transition-colors",
                 isActive
-                  ? "bg-sidebar-primary text-sidebar-primary-foreground font-medium"
+                  ? "bg-sidebar-primary text-sidebar-primary-foreground font-medium before:absolute before:top-2 before:left-2 before:w-2.5 before:h-2.5 before:border-t-2 before:border-l-2 before:border-primary after:absolute after:bottom-2 after:right-2 after:w-2.5 after:h-2.5 after:border-b-2 after:border-r-2 after:border-primary"
                   : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
               )}
               aria-current={isActive ? "page" : undefined}

--- a/components/layout/sidebar-nav-item.tsx
+++ b/components/layout/sidebar-nav-item.tsx
@@ -38,11 +38,12 @@ export function SidebarNavItem({
   variant = "page",
   onClick,
 }: SidebarNavItemProps) {
-  const active = "bg-sidebar-primary text-sidebar-primary-foreground font-medium";
+  const appActive = "bg-sidebar-primary text-sidebar-primary-foreground font-bold after:absolute after:bottom-1.5 after:left-1/2 after:-translate-x-1/2 after:w-5 after:h-0.5 after:rounded-full after:bg-primary";
+  const pageActive = "bg-sidebar-primary text-sidebar-primary-foreground font-medium before:absolute before:top-2 before:left-2 before:w-2.5 before:h-2.5 before:border-t-2 before:border-l-2 before:border-primary after:absolute after:bottom-2 after:right-2 after:w-2.5 after:h-2.5 after:border-b-2 after:border-r-2 after:border-primary";
   const hover = "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground";
 
   if (variant === "app") {
-    const base = "flex items-center h-12 w-full overflow-hidden rounded-none transition-colors";
+    const base = "relative flex items-center h-12 w-full overflow-hidden rounded-none transition-colors";
     const inner = (
       <>
         <span className="w-12 flex items-center justify-center shrink-0">
@@ -55,14 +56,14 @@ export function SidebarNavItem({
     );
     if (disabled) return <div className={cn(base, "opacity-40 pointer-events-none text-sidebar-foreground")} role="link" aria-disabled="true">{inner}</div>;
     return (
-      <Link href={url} onClick={onClick} className={cn(base, isActive ? active : cn("text-sidebar-foreground", hover))} aria-current={isActive ? "page" : undefined}>
+      <Link href={url} onClick={onClick} className={cn(base, isActive ? appActive : cn("text-sidebar-foreground", hover))} aria-current={isActive ? "page" : undefined}>
         {inner}
       </Link>
     );
   }
 
   // page variant
-  const base = "flex items-center gap-2.5 h-12 px-4 text-sm transition-colors";
+  const base = "relative flex items-center gap-2.5 h-12 px-4 text-sm transition-colors";
   const inner = (
     <>
       <Icon className="h-5 w-5 shrink-0" />
@@ -80,7 +81,7 @@ export function SidebarNavItem({
     <Link
       href={url}
       onClick={onClick}
-      className={cn(base, isActive ? active : cn("text-sidebar-foreground", hover))}
+      className={cn(base, isActive ? pageActive : cn("text-sidebar-foreground", hover))}
       aria-current={isActive ? "page" : undefined}
     >
       {inner}

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -65,7 +65,7 @@ type NavItem = {
 
 function getOrgItems(orgId: string): NavItem[] {
   return [
-    { title: "Overview", url: `/orgs/${orgId}`, icon: Building2, disabled: true },
+    { title: "Overview", url: `/orgs/${orgId}`, icon: Building2 },
     { title: "Timetable", url: `/orgs/${orgId}/timetable`, icon: Calendar },
     { title: "Tasks", url: `/orgs/${orgId}/tasks`, icon: ListTodo },
     { title: "Tools", url: `/orgs/${orgId}/tools`, icon: Wrench, disabled: true },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,15 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  // Allow _-prefixed function parameters to be unused (common TS convention).
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  },
   // Relax strict TypeScript rules for test files — mocking requires `as any`
   // and unused destructuring variables (_) are idiomatic in tests.
   {
@@ -13,7 +22,7 @@ const eslintConfig = defineConfig([
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-unused-vars": [
         "warn",
-        { varsIgnorePattern: "^_" },
+        { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
       ],
     },
   },


### PR DESCRIPTION
## What Changed

Redesigns the tasks and members pages to use a shell+sub-content sidebar pattern. Adds inline ActionSidebar panels for member management actions. Applies consistent active nav tab indicators across all sidebars.

## Why

Closes #

## Type

- [ ] 🐛 Bug fix
- [x] ✨ Enhancement / Feature
- [ ] 🔧 Refactor
- [ ] 📝 Documentation
- [x] 🎨 UI / Styling

## How to Test

1. Navigate to any org's Tasks page — sidebar should show filters in the sub-content area with no flicker on navigation
2. Navigate to Members page — sidebar should show role/search filters
3. On Members (desktop): click **Invite Member** — right-side ActionSidebar panel should open and button should turn blue; same for **Add Bot**
4. On Members (mobile): tap **Invite Member** / **Add Bot** — Dialog should appear correctly
5. Check active nav items in the app sidebar — should show a short bold underline
6. Check active nav items in page-level sidebars (tasks, members, timetable) — should show corner bracket indicators (top-left `┌` and bottom-right `┘`)

## Screenshots / Recordings

<!-- Before & after if UI changed -->

## Checklist

- [ ] Tested on desktop (Chrome)
- [ ] Tested on mobile (iPhone Safari)
- [ ] No lint errors (`pnpm lint`)
- [ ] Build passes (`pnpm build`)
- [ ] Smoke test updated (if applicable)

## Changes

**New files**
- `memberships/_components/invite-member-panel.tsx` — Invite Member form (ActionSidebar + Dialog)
- `memberships/_components/add-bot-panel.tsx` — Add Bot form (ActionSidebar + Dialog)
- `memberships/_components/members-actions.tsx` — action buttons with desktop/mobile routing
- `memberships/_components/members-sidebar-content.tsx` — filters + actions sub-content
- `memberships/_components/members-sidebar-shell.tsx` — persistent sidebar shell
- `memberships/layout.tsx` — registers members sidebar shell
- `tasks/_components/tasks-config.ts` — sort option types/constants
- `tasks/_components/tasks-sidebar-content.tsx` — filters + Create Task sub-content
- `tasks/_components/tasks-sidebar-shell.tsx` — persistent sidebar shell
- `tasks/layout.tsx` — registers tasks sidebar shell

**Updated files**
- `tasks/page.tsx`, `memberships/page.tsx` — register sub-content, read searchParams
- `tasks/_components/task-table.tsx` — scroll container top padding to fix shadow clipping
- `timetable/_components/timetable-sidebar-shell.tsx` — corner bracket active indicator
- `components/layout/sidebar-nav-item.tsx` — split active styles: underline for app variant, corner brackets for page variant

## Smoke Test Issues Resolved

- [ ] #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invite members and add bots via new panels/dialogs
  * Sidebar controls on Members and Tasks pages: role filters, sort options, and list/card view toggles (URL-driven)
  * Responsive action flows: desktop side panels and mobile dialog fallbacks
  * Page layouts now surface dedicated Members and Tasks sidebars

* **Documentation**
  * README updated with expanded front-end routes, sidebar architecture, and current UI work-in-progress status
<!-- end of auto-generated comment: release notes by coderabbit.ai -->