### PR TITLE
feat(tags): add task panel to tag create/edit forms

### DIFF
--- a/app/(app)/orgs/[orgId]/settings/tags/_components/tag-form.tsx
+++ b/app/(app)/orgs/[orgId]/settings/tags/_components/tag-form.tsx
@@ -3,9 +3,13 @@
 import { useState, useActionState, useTransition, useEffect } from "react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import { createTagAction, updateTagAction } from "@/app/actions/tags";
+import { createTagAction, updateTagAction, addTagToTaskAction, removeTagFromTaskAction } from "@/app/actions/tags";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  SearchableCombobox,
+  type ComboboxItem,
+} from "@/components/ui/searchable-combobox";
 
 // ─── Color presets ────────────────────────────────────────────────────────────
 
@@ -48,13 +52,110 @@ function ColorPicker({ value, onChange }: { value: string; onChange: (c: string)
 
 type ActionResult = { ok: true } | { ok: false; error: string };
 
+type Task = { id: string; name: string; color: string };
+
+// ─── Task panel ───────────────────────────────────────────────────────────────
+//
+// create mode: tasks held in local state, emitted as hidden <input name="taskIds">
+// edit mode:   add/remove fire server actions immediately
+
+type TaskPanelProps =
+  | { mode: "create"; allTasks: Task[] }
+  | { mode: "edit"; orgId: string; tagId: string; allTasks: Task[]; tagTasks: Task[] };
+
+function TaskPanel(props: TaskPanelProps) {
+  const isEdit = props.mode === "edit";
+  const [tasks, setTasks] = useState<Task[]>(isEdit ? props.tagTasks : []);
+  const [isPending, startTransition] = useTransition();
+
+  const taskIds = new Set(tasks.map((t) => t.id));
+  const availableItems: ComboboxItem[] = props.allTasks
+    .filter((t) => !taskIds.has(t.id))
+    .map((t) => ({ id: t.id, name: t.name, color: t.color }));
+
+  const add = (item: ComboboxItem) => {
+    const task = props.allTasks.find((t) => t.id === item.id);
+    if (!task) return;
+    if (isEdit) {
+      startTransition(async () => {
+        const res = await addTagToTaskAction(props.orgId, task.id, props.tagId);
+        if (res.ok) setTasks((prev) => [...prev, task]);
+        else toast.error(res.error);
+      });
+    } else {
+      setTasks((prev) => [...prev, task]);
+    }
+  };
+
+  const remove = (taskId: string) => {
+    if (isEdit) {
+      startTransition(async () => {
+        const res = await removeTagFromTaskAction(props.orgId, taskId, props.tagId);
+        if (res.ok) setTasks((prev) => prev.filter((t) => t.id !== taskId));
+        else toast.error(res.error);
+      });
+    } else {
+      setTasks((prev) => prev.filter((t) => t.id !== taskId));
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <span className="text-sm font-medium">Tasks</span>
+
+      {/* Hidden inputs for create mode */}
+      {!isEdit &&
+        tasks.map((task) => (
+          <input key={task.id} type="hidden" name="taskIds" value={task.id} />
+        ))}
+
+      <SearchableCombobox
+        items={availableItems}
+        onSelect={add}
+        triggerLabel="Add task"
+        placeholder="Search tasks…"
+        emptyText="No tasks found"
+        disabled={isPending}
+      />
+
+      {tasks.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {tasks.map((task) => (
+            <span
+              key={task.id}
+              className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs"
+            >
+              <span
+                className="inline-block w-2 h-2 rounded-full shrink-0"
+                style={{ backgroundColor: task.color }}
+              />
+              {task.name}
+              <button
+                type="button"
+                className="ml-0.5 hover:text-destructive transition-colors leading-none"
+                onClick={() => remove(task.id)}
+                disabled={isPending}
+                aria-label={`Remove ${task.name}`}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ─── Create Tag Form ──────────────────────────────────────────────────────────
 
 export function CreateTagForm({
   orgId,
+  allTasks,
   onSuccess,
 }: {
   orgId: string;
+  allTasks: Task[];
   onSuccess?: () => void;
 }) {
   const [name, setName] = useState("");
@@ -118,6 +219,8 @@ export function CreateTagForm({
         <ColorPicker value={color} onChange={setColor} />
       </div>
 
+      <TaskPanel mode="create" allTasks={allTasks} />
+
       <Button
         type="submit"
         size="sm"
@@ -138,6 +241,8 @@ export function EditTagForm({
   defaultName,
   defaultColor,
   isDefault,
+  allTasks,
+  tagTasks,
   onSuccess,
 }: {
   orgId: string;
@@ -145,6 +250,8 @@ export function EditTagForm({
   defaultName: string;
   defaultColor: string;
   isDefault: boolean;
+  allTasks: Task[];
+  tagTasks: Task[];
   onSuccess?: () => void;
 }) {
   const [name, setName] = useState(defaultName);
@@ -211,6 +318,14 @@ export function EditTagForm({
         </div>
         <ColorPicker value={color} onChange={setColor} />
       </div>
+
+      <TaskPanel
+        mode="edit"
+        orgId={orgId}
+        tagId={tagId}
+        allTasks={allTasks}
+        tagTasks={tagTasks}
+      />
 
       <Button
         type="submit"

--- a/app/(app)/orgs/[orgId]/settings/tags/_components/tag-form.tsx
+++ b/app/(app)/orgs/[orgId]/settings/tags/_components/tag-form.tsx
@@ -160,6 +160,7 @@ export function CreateTagForm({
 }) {
   const [name, setName] = useState("");
   const [color, setColor] = useState("#3B82F6");
+  const [resetKey, setResetKey] = useState(0);
 
   const boundAction = createTagAction.bind(null, orgId);
   const [state, dispatch, pending] = useActionState<ActionResult | null, FormData>(
@@ -175,6 +176,7 @@ export function CreateTagForm({
       startTransition(() => {
         setName("");
         setColor("#3B82F6");
+        setResetKey((prev) => prev + 1);
       });
       onSuccess?.();
     } else {
@@ -219,7 +221,7 @@ export function CreateTagForm({
         <ColorPicker value={color} onChange={setColor} />
       </div>
 
-      <TaskPanel mode="create" allTasks={allTasks} />
+      <TaskPanel key={resetKey} mode="create" allTasks={allTasks} />
 
       <Button
         type="submit"

--- a/app/(app)/orgs/[orgId]/settings/tags/_components/tags-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/settings/tags/_components/tags-sidebar-content.tsx
@@ -8,7 +8,13 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useMobileSidebar } from "@/components/layout/mobile-sidebar-context";
 import { CreateTagForm } from "./tag-form";
 
-export function TagsSidebarContent({ orgId }: { orgId: string }) {
+export function TagsSidebarContent({
+  orgId,
+  allTasks,
+}: {
+  orgId: string;
+  allTasks: { id: string; name: string; color: string }[];
+}) {
   const { open, activeTitle } = useActionSidebar();
   const isMobile = useIsMobile();
   const { setOpen: setMobileSidebarOpen } = useMobileSidebar();
@@ -16,7 +22,7 @@ export function TagsSidebarContent({ orgId }: { orgId: string }) {
 
   function handleCreate() {
     const k = ++formKeyRef.current;
-    open("New Tag", <CreateTagForm key={k} orgId={orgId} />);
+    open("New Tag", <CreateTagForm key={k} orgId={orgId} allTasks={allTasks} />);
     if (isMobile) {
       setMobileSidebarOpen(false);
     }

--- a/app/(app)/orgs/[orgId]/settings/tags/page.tsx
+++ b/app/(app)/orgs/[orgId]/settings/tags/page.tsx
@@ -1,6 +1,7 @@
 import { PermissionAction } from "@prisma/client";
 import { requireOrgPermissionPage } from "@/lib/authz";
 import { getOrgTags } from "@/lib/services/tags";
+import { getTasksSimple } from "@/lib/services/tasks";
 import { RegisterPageSidebar } from "@/components/layout/page-sidebar-context";
 import { TagsSidebarContent } from "./_components/tags-sidebar-content";
 import { TagsClient } from "./tags-client";
@@ -13,12 +14,15 @@ export default async function TagsPage({
   const { orgId } = await params;
   await requireOrgPermissionPage(orgId, PermissionAction.MANAGE_SETTINGS);
 
-  const tags = await getOrgTags(orgId);
+  const [tags, allTasks] = await Promise.all([
+    getOrgTags(orgId),
+    getTasksSimple(orgId),
+  ]);
 
   return (
     <>
-      <RegisterPageSidebar content={<TagsSidebarContent orgId={orgId} />} />
-      <TagsClient orgId={orgId} tags={tags} />
+      <RegisterPageSidebar content={<TagsSidebarContent orgId={orgId} allTasks={allTasks} />} />
+      <TagsClient orgId={orgId} tags={tags} allTasks={allTasks} />
     </>
   );
 }

--- a/app/(app)/orgs/[orgId]/settings/tags/tags-client.tsx
+++ b/app/(app)/orgs/[orgId]/settings/tags/tags-client.tsx
@@ -23,17 +23,28 @@ import { EditTagForm } from "./_components/tag-form";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
+type Task = { id: string; name: string; color: string };
+
 type Tag = {
   id: string;
   name: string;
   color: string;
   isDefault: boolean;
   _count: { tasks: number };
+  tasks: { task: Task }[];
 };
 
 // ─── Tag row ──────────────────────────────────────────────────────────────────
 
-function TagRow({ orgId, tag }: { orgId: string; tag: Tag }) {
+function TagRow({
+  orgId,
+  tag,
+  allTasks,
+}: {
+  orgId: string;
+  tag: Tag;
+  allTasks: Task[];
+}) {
   const { open, close } = useActionSidebar();
   const [isPending, startTransition] = useTransition();
   const editKeyRef = useRef(0);
@@ -49,6 +60,8 @@ function TagRow({ orgId, tag }: { orgId: string; tag: Tag }) {
         defaultName={tag.name}
         defaultColor={tag.color}
         isDefault={tag.isDefault}
+        allTasks={allTasks}
+        tagTasks={tag.tasks.map((tt) => tt.task)}
         onSuccess={close}
       />,
     );
@@ -146,9 +159,10 @@ function TagRow({ orgId, tag }: { orgId: string; tag: Tag }) {
 interface Props {
   orgId: string;
   tags: Tag[];
+  allTasks: Task[];
 }
 
-export function TagsClient({ orgId, tags }: Props) {
+export function TagsClient({ orgId, tags, allTasks }: Props) {
   const [query, setQuery] = useState("");
   const trimmedQuery = query.trim().toLowerCase();
   const filtered = trimmedQuery
@@ -189,7 +203,7 @@ export function TagsClient({ orgId, tags }: Props) {
             </div>
             {filtered.map((tag, i) => (
               <div key={tag.id} className={i < filtered.length - 1 ? "border-b" : ""}>
-                <TagRow orgId={orgId} tag={tag} />
+                <TagRow orgId={orgId} tag={tag} allTasks={allTasks} />
               </div>
             ))}
           </div>

--- a/app/actions/tags.ts
+++ b/app/actions/tags.ts
@@ -45,7 +45,7 @@ export async function createTagAction(
   if (taskIds.length > 0) {
     try {
       await setTagTasks(orgId, result.data.id, taskIds);
-    } catch (error) {
+    } catch {
       revalidatePath(`/orgs/${orgId}/settings/tags`);
       return { ok: false, error: "Tag created, but failed to associate tasks." };
     }

--- a/app/actions/tags.ts
+++ b/app/actions/tags.ts
@@ -17,6 +17,7 @@ import {
   deleteTag,
   addTagToTask,
   removeTagFromTask,
+  setTagTasks,
 } from "@/lib/services/tags";
 import { revalidatePath } from "next/cache";
 
@@ -39,6 +40,11 @@ export async function createTagAction(
 
   const result = await createTag(orgId, { name, color }, authz.userId, authz.userEmail);
   if (!result.ok) return { ok: false, error: result.error };
+
+  const taskIds = (formData.getAll("taskIds") as string[]).filter(Boolean);
+  if (taskIds.length > 0) {
+    await setTagTasks(orgId, result.data.id, taskIds);
+  }
 
   revalidatePath(`/orgs/${orgId}/settings/tags`);
   return { ok: true };

--- a/app/actions/tags.ts
+++ b/app/actions/tags.ts
@@ -43,7 +43,12 @@ export async function createTagAction(
 
   const taskIds = (formData.getAll("taskIds") as string[]).filter(Boolean);
   if (taskIds.length > 0) {
-    await setTagTasks(orgId, result.data.id, taskIds);
+    try {
+      await setTagTasks(orgId, result.data.id, taskIds);
+    } catch (error) {
+      revalidatePath(`/orgs/${orgId}/settings/tags`);
+      return { ok: false, error: "Tag created, but failed to associate tasks." };
+    }
   }
 
   revalidatePath(`/orgs/${orgId}/settings/tags`);

--- a/lib/services/tags.ts
+++ b/lib/services/tags.ts
@@ -13,7 +13,12 @@ export async function getOrgTags(orgId: string) {
   return prisma.tag.findMany({
     where: { orgId },
     orderBy: [{ isDefault: "desc" }, { name: "asc" }],
-    include: { _count: { select: { tasks: true } } },
+    include: {
+      _count: { select: { tasks: true } },
+      tasks: {
+        select: { task: { select: { id: true, name: true, color: true } } },
+      },
+    },
   });
 }
 
@@ -217,4 +222,24 @@ export async function setTaskTags(
       skipDuplicates: true,
     }),
   ]);
+}
+
+/**
+ * Bulk-attaches tasks to a tag (used on tag creation when tasks are pre-selected).
+ * Task ids that don't belong to `orgId` are silently ignored.
+ */
+export async function setTagTasks(
+  orgId: string,
+  tagId: string,
+  taskIds: string[],
+): Promise<void> {
+  const validTasks = await prisma.task.findMany({
+    where: { id: { in: taskIds }, orgId },
+    select: { id: true },
+  });
+  const validIds = validTasks.map((t) => t.id);
+  await prisma.taskTag.createMany({
+    data: validIds.map((taskId) => ({ taskId, tagId })),
+    skipDuplicates: true,
+  });
 }

--- a/lib/services/tags.ts
+++ b/lib/services/tags.ts
@@ -233,6 +233,8 @@ export async function setTagTasks(
   tagId: string,
   taskIds: string[],
 ): Promise<void> {
+  if (taskIds.length === 0) return;
+
   const validTasks = await prisma.task.findMany({
     where: { id: { in: taskIds }, orgId },
     select: { id: true },

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -230,3 +230,15 @@ export async function setTaskEligibilities(
     skipDuplicates: true,
   });
 }
+
+/**
+ * Returns a minimal list of all tasks for an org (id, name, color).
+ * Used for lightweight dropdowns and selectors.
+ */
+export async function getTasksSimple(orgId: string) {
+  return prisma.task.findMany({
+    where: { orgId },
+    select: { id: true, name: true, color: true },
+    orderBy: { name: "asc" },
+  });
+}


### PR DESCRIPTION
## What Changed

<!-- Brief description of what this PR does -->

## Why

<!-- What issue does this fix/close? -->

Closes #

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ Enhancement / Feature
- [ ] 🔧 Refactor
- [ ] 📝 Documentation
- [ ] 🎨 UI / Styling

## How to Test

1. ...
2. ...
3. ...

## Screenshots / Recordings

<!-- Before & after if UI changed -->

## Checklist

- [ ] Tested on desktop (Chrome)
- [ ] Tested on mobile (iPhone Safari)
- [ ] No lint errors (`pnpm lint`)
- [ ] Build passes (`pnpm build`)
- [ ] Smoke test updated (if applicable)

## Smoke Test Issues Resolved

<!-- List any smoke test issues this PR fixes -->

- [ ] #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assign tasks to tags during tag creation.
  * Manage task associations (add/remove) from the tag edit interface with immediate updates.
  * Tag settings now surface a simplified task list across the sidebar and tag list for easier selection.
  * Tag creation form reliably resets between opens to ensure a fresh task-selection UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->