### PR TITLE
feat(roster): roster templates + apply-to-roster workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,13 @@ Provider: PostgreSQL (Supabase), managed via Prisma ORM.
 | `TimetableEntry`           | A scheduled task occurrence with date, start/end times, status, and assignees.                                                                                                                                                                                                                                                                                  |
 | `TimetableEntryAssignee`   | Links a `Membership` to a `TimetableEntry` (many-to-many).                                                                                                                                                                                                                                                                                                      |
 | `TimetableSettings`        | Per-org timetable display preferences (view type, start day, slot duration).                                                                                                                                                                                                                                                                                    |
-| `Template`                 | A reusable schedule template with a `cycleLengthDays`. Contains `TemplateEntry` rows.                                                                                                                                                                                                                                                                           |
-| `TemplateEntry`            | One time slot in a `Template` — which task, which day index, start/end times.                                                                                                                                                                                                                                                                                   |
-| `TemplateEntryAssignee`    | Pre-assigns a `Membership` to a `TemplateEntry`.                                                                                                                                                                                                                                                                                                                |
+| `TimetableTemplate`        | A reusable schedule template with a `cycleLengthDays`. Contains `TimetableTemplateEntry` rows.                                                                                                                                                                                                                                                                  |
+| `TimetableTemplateEntry`   | One time slot in a `TimetableTemplate` — which task, which day index, start/end times.                                                                                                                                                                                                                                                                          |
+| `TimetableTemplateEntryAssignee` | Pre-assigns a `Membership` to a `TimetableTemplateEntry`.                                                                                                                                                                                                                                                                                               |
+| `RosterEntry`              | One shift assignment: a membership assigned to a specific `weekStart` + `dayIndex` combination, with optional `shiftStartMin`/`shiftEndMin`.                                                                                                                                                                                                                     |
+| `RosterDayConfig`          | Per-org day configuration for the roster grid: `recommendedSize` (target headcount), optional `openTimeMin`/`closeTimeMin` for the default shift time range.                                                                                                                                                                                                     |
+| `RosterTemplate`           | A reusable roster staffing pattern with a `cycleWeeks` (1–12). Contains `RosterTemplateEntry` rows that can be stamped onto the live roster.                                                                                                                                                                                                                     |
+| `RosterTemplateEntry`      | One shift slot in a `RosterTemplate` — which member, which `weekIndex` (0-based within the cycle), which `dayIndex` (0 = Mon … 6 = Sun), optional `shiftStartMin`/`shiftEndMin`.                                                                                                                                                                                |
 | `FranchiseToken`           | One-time invite token issued by a parent org for a franchisee to join.                                                                                                                                                                                                                                                                                          |
 | `Invite`                   | A member or franchise invite sent to a `User`. Carries a status (`PENDING`/`ACCEPTED`/`DECLINED`), snapshot fields for the org name and inviter name, and a JSON `metadata` blob with the roleIds/workingDays pre-filled for the accept step. Visible in the notification panel.                                                                                |
 | `AuditLog`                 | Append-only record of significant org mutations. Stores `action` (e.g. `task.create`), `entityType`, `entityId`, optional `before`/`after` JSON snapshots, the `actorId` who triggered the change, and a `createdAt` timestamp. Scoped per org. Actor is nullable (set to `NULL` on user deletion via `onDelete: SetNull`). Org deletion cascades all its logs. |
@@ -142,6 +146,12 @@ pnpm seed
 | `20260414045652_add_invite_snapshots`  | Add snapshot fields (`orgName`, `inviterName`) to `Invite` so cards render without joins                                                                                                                         |
 | `20260415021658_invite_pending_unique` | Partial unique index on `Invite(orgId, recipientId, type)` where `status = 'PENDING'` — DB-level guard against duplicate pending invites                                                                         |
 | _(schema push)_                        | `AuditLog` model added (`orgId`, `actorId`, `action`, `entityType`, `entityId`, `before`, `after`, `createdAt`). Applied via `pnpm prisma db push` (dev DB had migration drift — no timestamped migration file). |
+| `20260513023554_rename_template_to_timetable_template_add_roster` | Rename `Template`/`TemplateEntry`/`TemplateEntryAssignee` → `TimetableTemplate`/`TimetableTemplateEntry`/`TimetableTemplateEntryAssignee` using `ALTER TABLE ... RENAME TO` (data-safe). Add `RosterEntry` and `RosterDayConfig` tables with shift-time and day-config columns. |
+| `20260513030121_add_shift_times_to_roster_entry` | Add `shiftStartMin`/`shiftEndMin` (nullable `Int`) to `RosterEntry`.                                                                                                                          |
+| `20260513031027_add_open_close_time_to_roster_day_config` | Add `openTimeMin`/`closeTimeMin` (nullable `Int`) to `RosterDayConfig`.                                                                                                             |
+| `20260513122627_add_roster_template`   | Add `RosterTemplate` and `RosterTemplateEntry` tables with cascade deletes and a composite unique index on `(templateId, membershipId, weekIndex, dayIndex)`.                                                     |
+| `20260513123326_roster_template_cycle_weeks` | Add `cycleWeeks Int @default(1)` to `RosterTemplate`.                                                                                                                                        |
+| `20260514000000_add_check_constraints` | DB-level CHECK constraints enforcing field bounds: time fields 0–1440, `dayIndex` 0–6, `cycleWeeks` 1–12.                                                                                                        |
 
 ## Authentication
 
@@ -284,10 +294,30 @@ app/
                 add-item-form.tsx         # Create ToolItem (org-scoped, shared across sets)
                 add-rate-form.tsx         # Create/delete ConversionRate; unit abbreviation helper (≤4 chars kept, longer → first+last letter)
                 add-template-form.tsx     # Create/delete/switch ConversionTemplate; URL-driven active state via ?template=<id>
-          roster/         # Roster tool (stub)
-            page.tsx      # Server page; registers RosterSidebarContent as page sidebar
+          roster/         # Roster tool — weekly shift grid + templates
+            page.tsx      # Server page; fetches week range, members, day configs; registers RosterSidebarContent
             _components/
-              roster-sidebar-content.tsx  # Title row + Back link
+              roster-sidebar-content.tsx  # Title row + Back + Templates link + Edit Day Config action
+              roster-board-constants.ts   # Grid dimension constants (cell width, day labels) shared by board and template board
+              roster-board.tsx            # Scrollable 7-row × N-week grid; each cell opens EditCellDialog
+              roster-client.tsx           # Week navigation state + board rendering
+              roster-page-client.tsx      # Combines RosterClient with sticky toolbar (week range label)
+              edit-cell-dialog.tsx        # Dialog: assign members + shift start/end for one (week, day) cell
+              edit-day-config-dialog.tsx  # Dialog: set recommendedSize + open/close times for a day column
+              apply-template-panel.tsx    # ActionSidebar panel: pick template, start date, repeat count, force checkbox
+            _utils/
+              time-utils.ts              # Shared: formatMinutes, timeToMinutes, hoursWorked
+            templates/
+              page.tsx                   # Server page; lists all roster templates; registers RosterTemplatesSidebarContent
+              _components/
+                roster-templates-client.tsx         # Template list (card view); Create/Rename/Delete actions
+                roster-templates-sidebar-content.tsx # Sidebar: Back link + Create Template action
+              [templateId]/
+                page.tsx                 # Server page; fetches template + entries + members
+                _components/
+                  roster-template-editor-client.tsx  # Cycle stepper (+ / − weeks), column-paged board; ResizeObserver for visible column count
+                  roster-template-board.tsx          # Template grid: weekIndex columns × 7 day rows; each cell opens EditTemplateCellPanel in ActionSidebar
+                  edit-template-cell-panel.tsx       # ActionSidebar panel: assign members + shift times for one (weekIndex, day) cell
         franchisee/       # Franchise management (parent org owners only)
         memberships/      # Members list, role filter, list/card toggle, invite/add actions
           layout.tsx            # Registers MembersSidebarShell for all memberships routes
@@ -561,6 +591,71 @@ All write actions require `MANAGE_TASKS` permission.
 | `upsertTemplateEntryAction` | Save a calculator item slot (add/update) |
 | `removeTemplateEntryAction` | Remove a calculator item slot |
 
+## Roster Tool
+
+The Roster tool (`/orgs/[orgId]/tools/roster`) is a shift-scheduling grid for managing weekly staff assignments. It supports live editing, reusable multi-week templates, and a one-click apply-to-roster workflow.
+
+### Data model
+
+```
+RosterDayConfig        — per-org day settings (recommendedSize, openTimeMin, closeTimeMin)
+RosterEntry            — one shift: membership + weekStart + dayIndex + optional shift times
+RosterTemplate         — reusable pattern with cycleWeeks (1–12)
+  └─ RosterTemplateEntry — one slot: membership + weekIndex + dayIndex + optional shift times
+```
+
+### Service layer (`lib/services/roster.ts`)
+
+| Function | Description |
+| --- | --- |
+| `getOrgSchedule(orgId)` | Returns org default `openTimeMin`, `closeTimeMin`, `timezone` |
+| `hasRosterActivity(orgId)` | Returns true if the org has any roster entries, day configs, or templates |
+| `getRosterEntries(orgId, weekStarts)` | Fetches entries for a list of week-start dates |
+| `getRosterDayConfigs(orgId)` | Returns all day configs ordered by `dayIndex` |
+| `getOrgMembersForRoster(orgId)` | Active members for the cell member picker |
+| `setRosterCellMembers(orgId, weekStart, dayIndex, members)` | Replaces the member list for one (weekStart, dayIndex) cell in a transaction |
+| `upsertRosterDayConfig(orgId, dayIndex, data)` | Upserts `recommendedSize`, `openTimeMin`, `closeTimeMin` for a day |
+| `getRosterTemplates(orgId)` | Lists all templates with entry count |
+| `getRosterTemplate(orgId, templateId)` | Fetches a single template with expanded entries |
+| `createRosterTemplate(orgId, name, cycleWeeks)` | Creates a template; name must be unique within the org |
+| `deleteRosterTemplate(orgId, templateId)` | Deletes a template and all its entries |
+| `renameRosterTemplate(orgId, templateId, name)` | Renames with uniqueness check |
+| `setRosterTemplateCellMembers(orgId, templateId, weekIndex, dayIndex, members)` | Replaces entries for one template cell in a transaction |
+| `updateRosterTemplateCycleWeeks(orgId, templateId, cycleWeeks)` | Resizes the cycle; blocked if entries exist in the removed range |
+| `clearRosterTemplateWeek(orgId, templateId, weekIndex)` | Deletes all entries in one week column of a template |
+| `applyRosterTemplate(orgId, templateId, startMonday, cycleRepeats, force)` | Stamps the template onto the live roster starting from `startMonday`, repeating `cycleRepeats` times |
+
+### Server actions (`app/actions/roster.ts`)
+
+All write actions require `MANAGE_TIMETABLE` permission.
+
+| Action | Description |
+| --- | --- |
+| `setRosterCellMembersAction` | Replace members for a live roster cell |
+| `upsertRosterDayConfigAction` | Save day config (recommended size + open/close times) |
+| `createRosterTemplateAction` | Create a template; returns `templateId` on success |
+| `deleteRosterTemplateAction` | Delete a template |
+| `renameRosterTemplateAction` | Rename a template |
+| `setRosterTemplateCellMembersAction` | Replace members for a template cell |
+| `updateRosterTemplateCycleWeeksAction` | Resize the cycle (blocked if out-of-range entries exist) |
+| `clearRosterTemplateWeekAction` | Clear all entries in one week column |
+| `applyRosterTemplateAction` | Apply a template to the live roster; accepts ISO date string + repeat count + force flag |
+
+### Apply workflow
+
+1. From the live roster page, click **Apply Template** in the sidebar.
+2. The `ApplyTemplatePanel` shows a template picker, a start-date input (any day in the target week), and a repeat count.
+3. On submit, `applyRosterTemplateAction` normalizes the date to the nearest Monday, runs a conflict check, and on conflict returns `{ conflict: true }` — the panel shows a confirmation asking to overwrite.
+4. Confirming re-submits with `force: true`, which deletes then re-creates all entries in the affected weeks atomically.
+
+### Shared time utilities (`_utils/time-utils.ts`)
+
+| Export | Description |
+| --- | --- |
+| `formatMinutes(min)` | Integer minutes → `"HH:MM"` string (e.g. 90 → `"01:30"`) |
+| `timeToMinutes(time)` | `"HH:MM"` string → integer minutes, or `null` for invalid input |
+| `hoursWorked(start, end)` | Duration string (e.g. `"7h 30m"`) from two nullable minute offsets |
+
 ## Server Actions vs API Routes
 
 | Path               | Used by                              | Location       |
@@ -585,7 +680,9 @@ Server Actions call `revalidatePath` to invalidate the Next.js cache so server-r
 | `/orgs/[orgId]/tools/item-list`                  | `requireOrgMemberPage`                     | Item List tool stub — own page sidebar with Back link                                                                                                      |
 | `/orgs/[orgId]/tools/conversion`                 | `requireOrgMemberPage`                     | Conversion tool — lists all ConversionSets for the org; sidebar: Back + "Add Set" action                                                                   |
 | `/orgs/[orgId]/tools/conversion/[setId]`         | `requireOrgMemberPage`                     | Conversion calculator — two-column From/To grid with live calculations; template switcher dropdown in toolbar; template state persisted in DB via `ConversionTemplateEntry`; sidebar: Items · Rates · Templates actions |
-| `/orgs/[orgId]/tools/roster`                     | `requireOrgMemberPage`                     | Roster tool stub — own page sidebar with Back link                                                                                                         |
+| `/orgs/[orgId]/tools/roster`                     | `requireOrgMemberPage`                     | Roster tool — scrollable weekly shift grid (Mon–Sun rows × multi-week columns); week navigation; Edit Day Config + Apply Template actions in sidebar        |
+| `/orgs/[orgId]/tools/roster/templates`           | `requireOrgMemberPage`                     | Roster template list — card view; MANAGE_TIMETABLE holders can create, rename, and delete templates                                                         |
+| `/orgs/[orgId]/tools/roster/templates/[templateId]` | `requireOrgMemberPage`                  | Roster template editor — cycle-week stepper, column-paged board (7 day rows × cycleWeeks columns); clicking a cell opens the member/shift-time panel        |
 | `/orgs/[orgId]/franchisee`                       | `requireParentOrgOwnerPage`                | Franchise management — invite tokens + franchisee list                                                                                                     |
 | `/orgs/[orgId]/tasks`                            | `requireOrgMemberPage`                     | Task definition list — sort, role filter, list/card toggle in sidebar; search in toolbar; Create Task action in sidebar (managers only)                    |
 | `/orgs/[orgId]/tasks/new`                        | `requireOrgPermissionPage MANAGE_TASKS`    | Create task — includes color picker                                                                                                                        |
@@ -648,6 +745,8 @@ A parent org can spawn franchisee orgs using a one-time invite token flow:
 - **Timetable** — Calendar and Simple mode toggle, week navigation via `?week=` and `?mode=` params. Calendar view uses absolute positioning for task blocks; overlapping tasks get side-by-side columns. Status colours: gray = TODO, amber = IN_PROGRESS, green = DONE, red = SKIPPED.
 - **Fixed toolbar / scroll containment** — `h-dvh` on `SidebarProvider` + `overflow-hidden` on `SidebarInset` keep the body from scrolling so toolbars can stay visually fixed. The `<main>` element is the actual scroll container. Child pages that need a pinned toolbar use `flex flex-col h-full` on their root, a static `<Toolbar>` at the top, and a `flex-1 overflow-auto` div below it for the scrollable list. Negative horizontal margins on the scrollable div cancel `<main>`'s padding so the list extends edge-to-edge.
 - **Template editor** — Two view modes (Calendar / Simple) toggled via a segmented control and persisted in `localStorage`. **Calendar** mode shows a drag-and-drop time grid; tasks are dragged from a sidebar panel (desktop) or a bottom sheet (mobile); adaptive column count based on container width via `ResizeObserver`. **Simple** mode shows a day-by-day table sorted by start time; clicking a row opens an inline popup to adjust time and assignees. Both modes share day/week navigation and +/− cycle-length controls.
+- **Roster tool** — A scrollable week-by-week shift assignment grid. Days (Mon–Sun) are rows; each week column represents one calendar week identified by its Monday `weekStart` date. Clicking a cell opens a dialog to assign org members and optional shift start/end times. Day columns carry a configurable `recommendedSize` badge and optional open/close time range. Week navigation shifts the visible window by one week.
+- **Roster templates** — Reusable multi-week staffing patterns. A template has a `cycleWeeks` (1–12); the editor shows a 7-row × cycleWeeks-column grid. Clicking a cell opens an `ActionSidebar` panel to assign members and shift times. The +/− stepper adds/removes week columns — removing a column is blocked when entries exist in the last week. Applying a template (via the Apply Template panel on the live roster page) stamps the pattern starting from a selected Monday, repeating it `N` times; a conflict check prevents overwriting existing entries unless the force checkbox is ticked.
 - **Template list management** — MANAGE_TASKS holders see a ··· dropdown on each template (card and list view) with Rename (inline Dialog), Duplicate ("Copy of …" with collision suffix), and Delete (AlertDialog confirmation). Mutations call `revalidatePath` so the list refreshes without a full reload.
 - **Task descriptions** — Task descriptions are stored as GFM markdown and rendered via `react-markdown` + `remark-gfm` on the task detail page. The task list (card and table views) strips markdown via a lightweight `stripMd()` helper for plain-text previews.
 - **Task table** — `TaskTable` client component: search, sort (name/duration/people), role filter, row `···` menu (Edit / Duplicate / Delete with confirm). Clicking the row navigates to the task detail page.

--- a/__tests__/integration/helpers.ts
+++ b/__tests__/integration/helpers.ts
@@ -104,7 +104,7 @@ export async function cleanupTempUser(userId: string) {
     await prisma.timetableEntryAssignee.deleteMany({
       where: { membershipId: { in: membershipIds } },
     });
-    await prisma.templateEntryAssignee.deleteMany({
+    await prisma.timetableTemplateEntryAssignee.deleteMany({
       where: { membershipId: { in: membershipIds } },
     });
     await prisma.memberRole.deleteMany({

--- a/__tests__/integration/lib/services/templates.test.ts
+++ b/__tests__/integration/lib/services/templates.test.ts
@@ -49,7 +49,7 @@ describe("createTemplate", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 
-    const template = await prisma.template.findUnique({
+    const template = await prisma.timetableTemplate.findUnique({
       where: { id: result.data.id },
     });
     expect(template).not.toBeNull();
@@ -81,7 +81,7 @@ describe("addTemplateInstance", () => {
 
     expect(result.ok).toBe(true);
 
-    const entry = await prisma.templateEntry.findFirst({
+    const entry = await prisma.timetableTemplateEntry.findFirst({
       where: { templateId, taskId: task.id, dayIndex: 0 },
     });
     expect(entry).not.toBeNull();
@@ -138,14 +138,14 @@ describe("removeTemplateInstance", () => {
     const { id: templateId } = await makeTemplate(org.id, 7);
 
     await addTemplateInstance(org.id, templateId, task.id, 0, 360);
-    const entry = await prisma.templateEntry.findFirstOrThrow({
+    const entry = await prisma.timetableTemplateEntry.findFirstOrThrow({
       where: { templateId, taskId: task.id },
     });
 
     const result = await removeTemplateInstance(org.id, entry.id);
 
     expect(result.ok).toBe(true);
-    const gone = await prisma.templateEntry.findUnique({
+    const gone = await prisma.timetableTemplateEntry.findUnique({
       where: { id: entry.id },
     });
     expect(gone).toBeNull();
@@ -175,7 +175,7 @@ describe("updateTemplateInstance", () => {
     const { id: templateId } = await makeTemplate(org.id, 7);
 
     await addTemplateInstance(org.id, templateId, task.id, 0, 360);
-    const entry = await prisma.templateEntry.findFirstOrThrow({
+    const entry = await prisma.timetableTemplateEntry.findFirstOrThrow({
       where: { templateId, taskId: task.id },
     });
 
@@ -185,7 +185,7 @@ describe("updateTemplateInstance", () => {
 
     expect(result.ok).toBe(true);
 
-    const updated = await prisma.templateEntry.findUnique({
+    const updated = await prisma.timetableTemplateEntry.findUnique({
       where: { id: entry.id },
     });
     expect(updated?.dayIndex).toBe(3);
@@ -199,7 +199,7 @@ describe("updateTemplateInstance", () => {
     const { id: templateId } = await makeTemplate(org.id, 7);
 
     await addTemplateInstance(org.id, templateId, task.id, 0, 360);
-    const entry = await prisma.templateEntry.findFirstOrThrow({
+    const entry = await prisma.timetableTemplateEntry.findFirstOrThrow({
       where: { templateId, taskId: task.id },
     });
 
@@ -226,7 +226,7 @@ describe("updateTemplateDays", () => {
 
     expect(result.ok).toBe(true);
 
-    const updated = await prisma.template.findUnique({
+    const updated = await prisma.timetableTemplate.findUnique({
       where: { id: templateId },
     });
     expect(updated?.cycleLengthDays).toBe(14);
@@ -266,7 +266,7 @@ describe("addTemplateInstanceAssignee / removeTemplateInstanceAssignee", () => {
     const { id: templateId } = await makeTemplate(org.id, 7);
 
     await addTemplateInstance(org.id, templateId, task.id, 0, 360);
-    const entry = await prisma.templateEntry.findFirstOrThrow({
+    const entry = await prisma.timetableTemplateEntry.findFirstOrThrow({
       where: { templateId, taskId: task.id },
     });
 
@@ -278,7 +278,7 @@ describe("addTemplateInstanceAssignee / removeTemplateInstanceAssignee", () => {
     );
     expect(addResult.ok).toBe(true);
 
-    const link = await prisma.templateEntryAssignee.findFirst({
+    const link = await prisma.timetableTemplateEntryAssignee.findFirst({
       where: { templateEntryId: entry.id, membershipId: member.id },
     });
     expect(link).not.toBeNull();
@@ -291,7 +291,7 @@ describe("addTemplateInstanceAssignee / removeTemplateInstanceAssignee", () => {
     );
     expect(removeResult.ok).toBe(true);
 
-    const gone = await prisma.templateEntryAssignee.findFirst({
+    const gone = await prisma.timetableTemplateEntryAssignee.findFirst({
       where: { templateEntryId: entry.id, membershipId: member.id },
     });
     expect(gone).toBeNull();
@@ -311,7 +311,7 @@ describe("addTemplateInstanceAssignee / removeTemplateInstanceAssignee", () => {
     const { id: templateId } = await makeTemplate(org.id, 7);
 
     await addTemplateInstance(org.id, templateId, task.id, 0, 360);
-    const entry = await prisma.templateEntry.findFirstOrThrow({
+    const entry = await prisma.timetableTemplateEntry.findFirstOrThrow({
       where: { templateId, taskId: task.id },
     });
 
@@ -341,7 +341,7 @@ describe("renameTemplate", () => {
 
     expect(result.ok).toBe(true);
 
-    const updated = await prisma.template.findUnique({
+    const updated = await prisma.timetableTemplate.findUnique({
       where: { id: templateId },
     });
     expect(updated?.name).toBe(newName);
@@ -377,7 +377,7 @@ describe("duplicateTemplate", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 
-    const copy = await prisma.template.findUnique({
+    const copy = await prisma.timetableTemplate.findUnique({
       where: { id: result.data.id },
       include: { entries: true },
     });
@@ -417,12 +417,12 @@ describe("deleteTemplate", () => {
 
     expect(result.ok).toBe(true);
 
-    const gone = await prisma.template.findUnique({
+    const gone = await prisma.timetableTemplate.findUnique({
       where: { id: templateId },
     });
     expect(gone).toBeNull();
 
-    const entries = await prisma.templateEntry.findMany({
+    const entries = await prisma.timetableTemplateEntry.findMany({
       where: { templateId },
     });
     expect(entries).toHaveLength(0);

--- a/app/(app)/orgs/(organizations)/join/join-franchise-client.tsx
+++ b/app/(app)/orgs/(organizations)/join/join-franchise-client.tsx
@@ -22,11 +22,7 @@ import { TimezoneSelect } from "@/components/ui/timezone-select";
 import type { TimezoneOption } from "@/lib/timezones";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { joinFranchise } from "@/app/actions/orgs";
-
-function timeToMinutes(time: string) {
-  const [h, m] = time.split(":").map(Number);
-  return h * 60 + m;
-}
+import { timeToMinutes } from "@/app/(app)/orgs/[orgId]/tools/roster/_utils/time-utils";
 
 const ALL_DAYS = [
   { key: "mon", label: "Mon" },
@@ -158,8 +154,8 @@ function useScheduleState() {
 }
 
 function buildSchedulePayload(s: ReturnType<typeof useScheduleState>) {
-  const openMin = s.openTime ? timeToMinutes(s.openTime) : undefined;
-  const closeMin = s.closeTime ? timeToMinutes(s.closeTime) : undefined;
+  const openMin = s.openTime ? (timeToMinutes(s.openTime) ?? undefined) : undefined;
+  const closeMin = s.closeTime ? (timeToMinutes(s.closeTime) ?? undefined) : undefined;
   if (openMin !== undefined && closeMin !== undefined && closeMin <= openMin) {
     throw new Error("Close time must be after open time");
   }

--- a/app/(app)/orgs/(organizations)/new/new-org-client.tsx
+++ b/app/(app)/orgs/(organizations)/new/new-org-client.tsx
@@ -10,11 +10,7 @@ import { TimezoneSelect } from "@/components/ui/timezone-select";
 import type { TimezoneOption } from "@/lib/timezones";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { createOrg } from "@/app/actions/orgs";
-
-function timeToMinutes(time: string) {
-  const [h, m] = time.split(":").map(Number);
-  return h * 60 + m;
-}
+import { timeToMinutes } from "@/app/(app)/orgs/[orgId]/tools/roster/_utils/time-utils";
 
 const ALL_DAYS = [
   { key: "mon", label: "Mon" },
@@ -148,8 +144,8 @@ function useScheduleState() {
 }
 
 function buildSchedulePayload(s: ReturnType<typeof useScheduleState>) {
-  const openMin = s.openTime ? timeToMinutes(s.openTime) : undefined;
-  const closeMin = s.closeTime ? timeToMinutes(s.closeTime) : undefined;
+  const openMin = s.openTime ? (timeToMinutes(s.openTime) ?? undefined) : undefined;
+  const closeMin = s.closeTime ? (timeToMinutes(s.closeTime) ?? undefined) : undefined;
   if (openMin !== undefined && closeMin !== undefined && closeMin <= openMin) {
     throw new Error("Close time must be after open time");
   }

--- a/app/(app)/orgs/[orgId]/memberships/_components/page-sidebar/members-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/page-sidebar/members-sidebar-content.tsx
@@ -11,7 +11,7 @@
  * server page re-renders with the updated params.
  */
 import { useRouter } from "next/navigation";
-import { ChevronDown, LayoutGrid, List } from "lucide-react";
+import { ChevronDown, LayoutGrid, List, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import {
@@ -21,6 +21,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { MembersActions } from "../action-sidebar/members-panel-triggers";
+import Link from "next/link";
 
 type Role = { id: string; name: string; color: string };
 
@@ -119,6 +120,17 @@ export function MembersSidebarContent({
           </p>
           <div className="flex flex-col gap-2">
             <MembersActions orgId={orgId} roles={roles} />
+            <Button
+              variant="outline"
+              size="sm"
+              asChild
+              className="w-full justify-start gap-2"
+            >
+              <Link href={`/orgs/${orgId}/tools/roster`}>
+                <Users className="h-4 w-4 shrink-0" />
+                Roster
+              </Link>
+            </Button>
           </div>
         </div>
       )}

--- a/app/(app)/orgs/[orgId]/page.tsx
+++ b/app/(app)/orgs/[orgId]/page.tsx
@@ -133,12 +133,27 @@ const Page = async ({ params }: { params: Promise<{ orgId: string }> }) => {
           ))}
         </div>
 
+        {/* Roster feature card — always visible */}
+        <Link
+          href={`/orgs/${orgId}/tools/roster`}
+          className="group flex items-center gap-4 rounded-xl border bg-card px-5 py-4 shadow-sm hover:border-primary/40 hover:shadow-md transition-all mb-8"
+        >
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary group-hover:bg-primary/15 transition-colors">
+            <Users className="h-5 w-5" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold leading-snug">Roster</p>
+            <p className="text-xs text-muted-foreground mt-0.5">Manage your weekly staff roster</p>
+          </div>
+          <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground opacity-0 group-hover:opacity-100 group-hover:translate-x-0.5 transition-all" />
+        </Link>
+
         {/* Recent Tools */}
         {recentSets.length > 0 && (
           <div className="mb-8">
             <div className="flex items-center justify-between mb-3">
               <h2 className="text-sm font-semibold">Recent Tools</h2>
-              <Link href={`/orgs/${orgId}/tools/conversion`} className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+              <Link href={`/orgs/${orgId}/tools`} className="text-xs text-muted-foreground hover:text-foreground transition-colors">
                 All tools →
               </Link>
             </div>

--- a/app/(app)/orgs/[orgId]/timetable/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/page.tsx
@@ -97,11 +97,11 @@ export default async function TimetablePage({
     : false;
 
   // Build membership→roles map for client rendering
-  const clientMemberships = memberships.map((m) => ({
+  const clientMemberships = memberships.map((m: typeof memberships[number]) => ({
     id: m.id,
     user: m.user ? { id: m.user.id, name: m.user.name } : null,
     botName: m.botName ?? null,
-    roles: m.memberRoles.map((mr) => ({
+    roles: m.memberRoles.map((mr: typeof m.memberRoles[number]) => ({
       id: mr.role.id,
       name: mr.role.name,
       color: mr.role.color,
@@ -110,7 +110,7 @@ export default async function TimetablePage({
 
   // Roles for filter dropdown — all org roles
   const filterRoles = orgRoles
-    .map((r) => ({ id: r.id, name: r.name, color: r.color }))
+    .map((r: typeof orgRoles[number]) => ({ id: r.id, name: r.name, color: r.color }))
     .sort((a, b) => a.name.localeCompare(b.name));
 
   // Filter instances by task eligibility for the selected role

--- a/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/_components/add-template-task-panel.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/_components/add-template-task-panel.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState, useTransition, useEffect } from "react";
+import { ArrowLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { TaskPanel } from "../../../_shared/task-panel";
+import { addTemplateInstanceAction } from "@/app/actions/templates";
+import type { SharedTask } from "../../../_shared/types";
+
+interface AddTemplateTaskPanelProps {
+  tasks: SharedTask[];
+  orgId: string;
+  templateId: string;
+  templateDays: number;
+}
+
+/**
+ * Two-mode panel for adding tasks to a template.
+ *
+ * - "list" mode  — searchable task list; clicking a task opens the form;
+ *                  dragging still works for drag-to-grid.
+ * - "schedule" mode — day index + time pickers; submits via addTemplateInstanceAction.
+ *
+ * Dispatches custom window events so TemplateEditorClient can suppress the
+ * empty-state overlay while the schedule form is active.
+ */
+export function AddTemplateTaskPanel({
+  tasks,
+  orgId,
+  templateId,
+  templateDays,
+}: AddTemplateTaskPanelProps) {
+  const router = useRouter();
+  const [mode, setMode] = useState<"list" | "schedule">("list");
+  const [selectedTask, setSelectedTask] = useState<SharedTask | null>(null);
+  const [dayIndex, setDayIndex] = useState(0); // 0-based
+  const [timeStr, setTimeStr] = useState("09:00");
+  const [isPending, startTransition] = useTransition();
+
+  // Notify TemplateEditorClient when entering/leaving schedule mode so it can
+  // suppress the empty-state overlay.
+  useEffect(() => {
+    const evt = mode === "schedule"
+      ? "template:schedule-mode-enter"
+      : "template:schedule-mode-exit";
+    window.dispatchEvent(new CustomEvent(evt));
+  }, [mode]);
+
+  // Always fire exit when the panel is removed from the DOM (sidebar closed / key change).
+  useEffect(() => {
+    return () => {
+      window.dispatchEvent(new CustomEvent("template:schedule-mode-exit"));
+    };
+  }, []);
+
+  function handleTaskClick(task: SharedTask) {
+    setSelectedTask(task);
+    setMode("schedule");
+  }
+
+  function handleBack() {
+    setMode("list");
+    setSelectedTask(null);
+  }
+
+  function handleSubmit() {
+    if (!selectedTask) return;
+    const [hours, minutes] = timeStr.split(":").map(Number);
+    if (
+      isNaN(hours) ||
+      isNaN(minutes) ||
+      hours < 0 ||
+      hours > 23 ||
+      minutes < 0 ||
+      minutes > 59
+    ) {
+      toast.error("Invalid time format. Please enter a valid time.");
+      return;
+    }
+    const startTimeMin = hours * 60 + minutes;
+    startTransition(async () => {
+      try {
+        const result = await addTemplateInstanceAction(
+          orgId,
+          templateId,
+          selectedTask.id,
+          dayIndex,
+          startTimeMin,
+        );
+        if (!result.ok) {
+          toast.error(result.error ?? "Something went wrong");
+          return;
+        }
+        router.refresh();
+        handleBack();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Something went wrong");
+      }
+    });
+  }
+
+  // ── Schedule form ────────────────────────────────────────────────────────
+  if (mode === "schedule" && selectedTask) {
+    return (
+      <div className="flex flex-col gap-4 p-4">
+        <button
+          onClick={handleBack}
+          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors -mx-1 px-1 py-0.5 rounded w-fit"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to tasks
+        </button>
+
+        {/* Selected task card */}
+        <div className="rounded-lg border bg-card px-3 py-2.5">
+          <div className="flex items-start gap-2.5">
+            <span
+              className="w-1 self-stretch rounded-full shrink-0 mt-0.5"
+              style={{
+                backgroundColor:
+                  selectedTask.roleColor ?? selectedTask.color ?? "#9ca3af",
+              }}
+            />
+            <div>
+              <p className="text-sm font-semibold leading-snug">
+                {selectedTask.name}
+              </p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {selectedTask.roleName ? `${selectedTask.roleName} · ` : ""}
+                {selectedTask.durationMin} min
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Day + time inputs */}
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="template-day-input"
+              className="text-xs font-medium text-muted-foreground uppercase tracking-wider"
+            >
+              Day
+            </label>
+            <select
+              id="template-day-input"
+              value={dayIndex}
+              onChange={(e) => setDayIndex(Number(e.target.value))}
+              className="h-8 w-full rounded-md border border-input bg-background px-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {Array.from({ length: templateDays }, (_, i) => (
+                <option key={i} value={i}>
+                  Day {i + 1}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="template-time-input"
+              className="text-xs font-medium text-muted-foreground uppercase tracking-wider"
+            >
+              Start time
+            </label>
+            <Input
+              id="template-time-input"
+              type="time"
+              value={timeStr}
+              onChange={(e) => setTimeStr(e.target.value)}
+              className="h-8 text-sm"
+            />
+          </div>
+        </div>
+
+        <Button onClick={handleSubmit} disabled={isPending} size="sm">
+          {isPending ? "Adding…" : "Add to template"}
+        </Button>
+      </div>
+    );
+  }
+
+  // ── Task list ────────────────────────────────────────────────────────────
+  return (
+    <TaskPanel
+      tasks={tasks}
+      onDragStart={(taskId, e) => {
+        e.dataTransfer.setData("timetable/taskId", taskId);
+        e.dataTransfer.effectAllowed = "copy";
+      }}
+      onDragEnd={() => {}}
+      onTaskClick={handleTaskClick}
+    />
+  );
+}

--- a/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/_components/template-editor-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/_components/template-editor-sidebar-content.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { ListPlus, Minus, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { TimetableViewPicker } from "../../../_components/timetable-view-picker";
-import { TaskPanel } from "../../../_shared/task-panel";
+import { AddTemplateTaskPanel } from "./add-template-task-panel";
 import { updateTemplateDaysAction } from "@/app/actions/templates";
 import { useActionSidebar } from "@/components/layout/action-sidebar-context";
 import type { SharedTask } from "../../../_shared/types";
@@ -44,14 +44,12 @@ export function TemplateEditorSidebarContent({
     const k = ++taskPanelKeyRef.current;
     open(
       "Add Task",
-      <TaskPanel
+      <AddTemplateTaskPanel
         key={k}
         tasks={availableTasks}
-        onDragStart={(taskId, e) => {
-          e.dataTransfer.setData("timetable/taskId", taskId);
-          e.dataTransfer.effectAllowed = "copy";
-        }}
-        onDragEnd={() => {}}
+        orgId={orgId}
+        templateId={templateId}
+        templateDays={templateDays}
       />,
     );
   }

--- a/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/template-editor-client.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/templates/[templateId]/template-editor-client.tsx
@@ -33,6 +33,7 @@ import { useRouter } from "next/navigation";
 import {
   ChevronLeft,
   ChevronRight,
+  LayoutList,
   MoreHorizontal,
   Plus,
   X,
@@ -388,6 +389,20 @@ export function TemplateEditorClient({
       window.removeEventListener("template:open-task-panel", handler);
   }, []);
 
+  // Track when the sidebar's schedule form is open so we can suppress the
+  // empty-state overlay (otherwise the overlay blocks the grid).
+  const [isScheduling, setIsScheduling] = useState(false);
+  useEffect(() => {
+    const onEnter = () => setIsScheduling(true);
+    const onExit = () => setIsScheduling(false);
+    window.addEventListener("template:schedule-mode-enter", onEnter);
+    window.addEventListener("template:schedule-mode-exit", onExit);
+    return () => {
+      window.removeEventListener("template:schedule-mode-enter", onEnter);
+      window.removeEventListener("template:schedule-mode-exit", onExit);
+    };
+  }, []);
+
   // ── Filter visible instances ──────────────────────────────────────────
   const visibleInstances = instances.filter((inst) =>
     visibleDays.includes(inst.dayIndex),
@@ -619,8 +634,8 @@ export function TemplateEditorClient({
             ref={containerRef}
             className={`relative flex-1 min-w-0${fillHeight ? " min-h-0 flex flex-col" : ""}`}
           >
-            {/* Empty state — hidden during tap-to-place and drag */}
-            {!visibleInstances.length && !isDragging && !selectedTaskId && (
+            {/* Empty state — hidden during tap-to-place, drag, or schedule form */}
+            {!visibleInstances.length && !isDragging && !selectedTaskId && !isScheduling && (
               <div className="absolute inset-0 z-20 flex items-center justify-center border bg-background/90">
                 <div className="flex flex-col items-center gap-3 text-center">
                   <p className="text-2xl font-semibold text-foreground">
@@ -707,10 +722,10 @@ export function TemplateEditorClient({
         </div>
       )}
 
-      {/* Mobile: cancel tap-to-place button + Sheet */}
+      {/* Mobile: floating Tasks / Cancel button + Sheet */}
       {isMobile && (
         <>
-          {selectedTaskId && (
+          {selectedTaskId ? (
             <button
               onClick={() => setSelectedTaskId(null)}
               className="fixed bottom-6 right-4 z-40 flex items-center gap-2 rounded-full bg-destructive text-destructive-foreground shadow-lg px-4 py-2.5 text-sm font-medium active:scale-95 transition-transform"
@@ -719,6 +734,16 @@ export function TemplateEditorClient({
             >
               <X className="h-4 w-4" />
               Cancel
+            </button>
+          ) : (
+            <button
+              onClick={() => setTaskPanelOpen(true)}
+              className="fixed bottom-6 right-4 z-40 flex items-center gap-2 rounded-full bg-primary text-primary-foreground shadow-lg px-4 py-2.5 text-sm font-medium active:scale-95 transition-transform"
+              style={{ marginBottom: "env(safe-area-inset-bottom, 0px)" }}
+              aria-label="Open task list"
+            >
+              <LayoutList className="h-4 w-4" />
+              Tasks
             </button>
           )}
 

--- a/app/(app)/orgs/[orgId]/tools/_components/tools-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/tools/_components/tools-sidebar-content.tsx
@@ -10,11 +10,10 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ArrowLeftRight, List, Users } from "lucide-react";
-import { cn } from "@/lib/utils";
 import { SearchInput } from "@/components/ui/search-input";
+import { SidebarNavItem } from "@/components/layout/sidebar-nav-item";
 
 // Placeholder tool list — replace with DB-driven data once the Tool model exists
 const PLACEHOLDER_TOOLS = [
@@ -61,19 +60,14 @@ export function ToolsSidebarContent({ orgId }: { orgId: string }) {
             const isActive = pathname === href;
             const Icon = tool.icon;
             return (
-              <Link
+              <SidebarNavItem
                 key={tool.id}
-                href={href}
-                className={cn(
-                  "relative flex items-center gap-2.5 h-12 px-4 text-sm border-b border-border transition-colors",
-                  isActive
-                    ? "bg-sidebar-accent text-sidebar-foreground font-medium"
-                    : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground",
-                )}
-              >
-                <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
-                <span className="truncate">{tool.name}</span>
-              </Link>
+                title={tool.name}
+                url={href}
+                icon={Icon}
+                isActive={isActive}
+                variant="page"
+              />
             );
           })
         )}

--- a/app/(app)/orgs/[orgId]/tools/conversion/[setId]/_components/add-template-form.tsx
+++ b/app/(app)/orgs/[orgId]/tools/conversion/[setId]/_components/add-template-form.tsx
@@ -14,7 +14,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { Trash2 } from "lucide-react";
+import { Copy, Trash2 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -23,6 +23,7 @@ import { cn } from "@/lib/utils";
 import {
   createConversionTemplateAction,
   deleteConversionTemplateAction,
+  duplicateConversionTemplateAction,
 } from "@/app/actions/tools";
 
 type Template = { id: string; name: string };
@@ -47,6 +48,7 @@ export function AddTemplateForm({
   const [search, setSearch] = useState("");
   const [isPending, startTransition] = useTransition();
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
 
   // Resolve the active template from the URL (matching server logic)
   const urlTemplateId = searchParams.get("template");
@@ -95,6 +97,22 @@ export function AddTemplateForm({
         toast.success("Template deleted.");
       }
       setDeletingId(null);
+    });
+  }
+
+  function handleDuplicate(template: Template) {
+    setDuplicatingId(template.id);
+    startTransition(async () => {
+      const newName = `${template.name} (Copy)`;
+      const result = await duplicateConversionTemplateAction(orgId, setId, template.id, newName);
+      if (!result.ok) {
+        toast.error("error" in result ? result.error : "Failed to duplicate template.");
+      } else {
+        setTemplateList((prev) => [...prev, result.template]);
+        selectTemplate(result.template.id);
+        toast.success(`"${result.template.name}" created.`);
+      }
+      setDuplicatingId(null);
     });
   }
 
@@ -171,6 +189,15 @@ export function AddTemplateForm({
                       {t.name}
                     </span>
                   </button>
+                  <button
+                      type="button"
+                      onClick={(e) => { e.stopPropagation(); handleDuplicate(t); }}
+                      disabled={isPending && duplicatingId === t.id}
+                      className="shrink-0 text-muted-foreground hover:text-foreground transition-colors p-2"
+                      aria-label="Duplicate template"
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </button>
                   {t.name !== "Default" && (
                     <button
                       type="button"

--- a/app/(app)/orgs/[orgId]/tools/conversion/[setId]/_components/set-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/tools/conversion/[setId]/_components/set-sidebar-content.tsx
@@ -13,9 +13,9 @@
 "use client";
 
 import { useRef } from "react";
-import Link from "next/link";
 import { ArrowLeft, ArrowLeftRight, LayoutTemplate, Package } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { SidebarNavItem } from "@/components/layout/sidebar-nav-item";
 import { useActionSidebar } from "@/components/layout/action-sidebar-context";
 import { AddItemForm } from "./add-item-form";
 import { AddRateForm } from "./add-rate-form";
@@ -103,13 +103,13 @@ export function SetSidebarContent({
       </div>
 
       {/* Back */}
-      <Link
-        href={`/orgs/${orgId}/tools/conversion`}
-        className="flex items-center gap-2 h-12 px-4 text-sm border-b border-border text-sidebar-foreground/70 hover:text-sidebar-foreground transition-colors shrink-0"
-      >
-        <ArrowLeft className="h-4 w-4 shrink-0" />
-        Back
-      </Link>
+      <SidebarNavItem
+        title="Back"
+        url={`/orgs/${orgId}/tools/conversion`}
+        icon={ArrowLeft}
+        isActive={false}
+        variant="page"
+      />
 
       {/* Actions */}
       <div className="px-3 py-3 flex flex-col gap-2">

--- a/app/(app)/orgs/[orgId]/tools/conversion/_components/conversion-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/tools/conversion/_components/conversion-sidebar-content.tsx
@@ -8,8 +8,8 @@
 "use client";
 
 import { useRef } from "react";
-import Link from "next/link";
 import { ArrowLeft, Plus } from "lucide-react";
+import { SidebarNavItem } from "@/components/layout/sidebar-nav-item";
 import { Button } from "@/components/ui/button";
 import { useActionSidebar } from "@/components/layout/action-sidebar-context";
 import { AddSetForm } from "./add-set-form";
@@ -38,13 +38,13 @@ export function ConversionSidebarContent({ orgId }: { orgId: string }) {
       </div>
 
       {/* Back */}
-      <Link
-        href={`/orgs/${orgId}/tools`}
-        className="flex items-center gap-2 h-12 px-4 text-sm border-b border-border text-sidebar-foreground/70 hover:text-sidebar-foreground transition-colors shrink-0"
-      >
-        <ArrowLeft className="h-4 w-4" />
-        Back
-      </Link>
+      <SidebarNavItem
+        title="Back"
+        url={`/orgs/${orgId}/tools`}
+        icon={ArrowLeft}
+        isActive={false}
+        variant="page"
+      />
 
       {/* Actions */}
       <div className="px-3 py-3 flex flex-col gap-2">

--- a/app/(app)/orgs/[orgId]/tools/item-list/_components/item-list-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/tools/item-list/_components/item-list-sidebar-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { SidebarNavItem } from "@/components/layout/sidebar-nav-item";
 
 export function ItemListSidebarContent({ orgId }: { orgId: string }) {
   return (
@@ -14,13 +14,13 @@ export function ItemListSidebarContent({ orgId }: { orgId: string }) {
       </div>
 
       {/* Back */}
-      <Link
-        href={`/orgs/${orgId}/tools`}
-        className="flex items-center gap-2 h-12 px-4 text-sm border-b border-border text-sidebar-foreground/70 hover:text-sidebar-foreground transition-colors shrink-0"
-      >
-        <ArrowLeft className="h-4 w-4" />
-        Back
-      </Link>
+      <SidebarNavItem
+        title="Back"
+        url={`/orgs/${orgId}/tools`}
+        icon={ArrowLeft}
+        isActive={false}
+        variant="page"
+      />
     </div>
   );
 }

--- a/app/(app)/orgs/[orgId]/tools/page.tsx
+++ b/app/(app)/orgs/[orgId]/tools/page.tsx
@@ -1,6 +1,7 @@
 import { requireOrgMemberPage } from "@/lib/authz";
 import { RegisterPageSidebar } from "@/components/layout/page-sidebar-context";
 import { getConversionSets } from "@/lib/services/tools";
+import { hasRosterActivity } from "@/lib/services/roster";
 import { ToolsSidebarContent } from "./_components/tools-sidebar-content";
 import { ToolsClient } from "./tools-client";
 
@@ -12,12 +13,15 @@ export default async function ToolsPage({
   const { orgId } = await params;
   await requireOrgMemberPage(orgId);
 
-  const recentSets = await getConversionSets(orgId);
+  const [recentSets, hasRoster] = await Promise.all([
+    getConversionSets(orgId),
+    hasRosterActivity(orgId),
+  ]);
 
   return (
     <>
       <RegisterPageSidebar content={<ToolsSidebarContent orgId={orgId} />} />
-      <ToolsClient orgId={orgId} recentSets={recentSets} />
+      <ToolsClient orgId={orgId} recentSets={recentSets} hasRoster={hasRoster} />
     </>
   );
 }

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/apply-template-panel.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/apply-template-panel.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Loader2, Minus, Plus, TriangleAlert } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { SearchableCombobox, type ComboboxItem } from "@/components/ui/searchable-combobox";
+import { useActionSidebar } from "@/components/layout/action-sidebar-context";
+import { applyRosterTemplateAction } from "@/app/actions/roster";
+
+type RosterTemplate = { id: string; name: string; cycleWeeks: number };
+
+function thisMondayStr(): string {
+  const d = new Date();
+  const day = d.getUTCDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setUTCDate(d.getUTCDate() + diff);
+  return d.toISOString().slice(0, 10);
+}
+
+interface ApplyTemplatePanelProps {
+  orgId: string;
+  templates: RosterTemplate[];
+}
+
+export function ApplyTemplatePanel({ orgId, templates }: ApplyTemplatePanelProps) {
+  const { close } = useActionSidebar();
+  const [templateId, setTemplateId] = useState("");
+  const [startDate, setStartDate] = useState(thisMondayStr);
+  const [repeats, setRepeats] = useState(1);
+  const [conflict, setConflict] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const selectedTemplate = templates.find((t) => t.id === templateId);
+  const totalWeeks = selectedTemplate ? selectedTemplate.cycleWeeks * repeats : null;
+
+  function handleApply(force: boolean) {
+    if (!templateId || !startDate) return;
+    startTransition(async () => {
+      setConflict(false);
+      const result = await applyRosterTemplateAction(orgId, templateId, startDate, repeats, force);
+      if (!result.ok) {
+        if (result.conflict) {
+          setConflict(true);
+        } else {
+          toast.error(result.error ?? "Failed to apply template");
+        }
+        return;
+      }
+      toast.success("Template applied");
+      close();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {/* Template picker */}
+      <div className="flex flex-col gap-1.5">
+        <span className="text-xs text-muted-foreground">Template</span>
+        <SearchableCombobox
+          items={templates.map((t) => ({ id: t.id, name: t.name }))}
+          onSelect={(item: ComboboxItem) => setTemplateId(item.id)}
+          triggerLabel={selectedTemplate?.name ?? "Choose template…"}
+          placeholder="Search templates…"
+        />
+      </div>
+
+      {/* Starting week */}
+      <div className="flex flex-col gap-1.5">
+        <span className="text-xs text-muted-foreground">Starting week</span>
+        <Input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          className="h-8 text-sm px-2"
+        />
+      </div>
+
+      {/* Repeat cycles */}
+      <div className="flex flex-col gap-1.5">
+        <span className="text-xs text-muted-foreground">
+          Repeat{totalWeeks ? ` — ${totalWeeks} week${totalWeeks === 1 ? "" : "s"} total` : ""}
+        </span>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-7 w-7 shrink-0"
+            disabled={repeats <= 1}
+            onClick={() => setRepeats((r) => Math.max(1, r - 1))}
+          >
+            <Minus className="h-3 w-3" />
+          </Button>
+          <span className="flex-1 text-center text-sm font-medium tabular-nums">{repeats}</span>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-7 w-7 shrink-0"
+            disabled={repeats >= 52}
+            onClick={() => setRepeats((r) => Math.min(52, r + 1))}
+          >
+            <Plus className="h-3 w-3" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Conflict warning */}
+      {conflict && (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5 flex gap-2 items-start">
+          <TriangleAlert className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+          <p className="text-xs text-amber-800 dark:text-amber-300">
+            Some of these weeks already have entries. Applying will replace them.
+          </p>
+        </div>
+      )}
+
+      {/* Action buttons */}
+      <div className="flex gap-2">
+        <Button variant="outline" size="sm" className="flex-1" onClick={close}>
+          Cancel
+        </Button>
+        {conflict ? (
+          <Button
+            size="sm"
+            className="flex-1 bg-amber-600 hover:bg-amber-700 text-white border-0"
+            disabled={isPending}
+            onClick={() => handleApply(true)}
+          >
+            {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Replace"}
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            className="flex-1"
+            disabled={isPending || !templateId || !startDate}
+            onClick={() => handleApply(false)}
+          >
+            {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Apply"}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/edit-cell-dialog.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/edit-cell-dialog.tsx
@@ -23,8 +23,12 @@ function minToTime(min: number | null): string {
 
 function timeToMin(time: string): number | null {
   if (!time) return null;
-  const [h, m] = time.split(":").map(Number);
+  const parts = time.split(":");
+  if (parts.length !== 2) return null;
+  const h = Number(parts[0]);
+  const m = Number(parts[1]);
   if (isNaN(h) || isNaN(m)) return null;
+  if (h < 0 || h > 23 || m < 0 || m > 59) return null;
   return h * 60 + m;
 }
 

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/edit-cell-dialog.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/edit-cell-dialog.tsx
@@ -9,6 +9,7 @@ import { SearchableCombobox } from "@/components/ui/searchable-combobox";
 import { setRosterCellMembersAction } from "@/app/actions/roster";
 import { useActionSidebar } from "@/components/layout/action-sidebar-context";
 import type { RosterEntryRow, OrgMember, DayConfigRow } from "./roster-board";
+import { formatMinutes, hoursWorked, timeToMinutes } from "../_utils/time-utils";
 
 function memberDisplayName(m: OrgMember): string {
   return m.botName ?? m.user?.name ?? "Unknown";
@@ -16,29 +17,11 @@ function memberDisplayName(m: OrgMember): string {
 
 function minToTime(min: number | null): string {
   if (min === null) return "";
-  const h = Math.floor(min / 60).toString().padStart(2, "0");
-  const m = (min % 60).toString().padStart(2, "0");
-  return `${h}:${m}`;
+  return formatMinutes(min);
 }
 
 function timeToMin(time: string): number | null {
-  if (!time) return null;
-  const parts = time.split(":");
-  if (parts.length !== 2) return null;
-  const h = Number(parts[0]);
-  const m = Number(parts[1]);
-  if (isNaN(h) || isNaN(m)) return null;
-  if (h < 0 || h > 23 || m < 0 || m > 59) return null;
-  return h * 60 + m;
-}
-
-function hoursWorked(startMin: number | null, endMin: number | null): string {
-  if (startMin === null || endMin === null) return "";
-  const diff = endMin - startMin;
-  if (diff <= 0) return "";
-  const h = Math.floor(diff / 60);
-  const m = diff % 60;
-  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  return timeToMinutes(time);
 }
 
 type MemberShift = {

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/edit-cell-dialog.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/edit-cell-dialog.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Minus } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { setRosterCellMembersAction } from "@/app/actions/roster";
+import type { RosterEntryRow, OrgMember } from "./roster-board";
+import { DAY_LABELS } from "./roster-board-constants";
+
+function formatWeekDate(weekStart: Date, dayIndex: number): string {
+  const d = new Date(weekStart);
+  d.setUTCDate(d.getUTCDate() + dayIndex);
+  return `${d.getUTCDate()}/${d.getUTCMonth() + 1}/${d.getUTCFullYear()}`;
+}
+
+function memberDisplayName(m: OrgMember): string {
+  return m.botName ?? m.user?.name ?? "Unknown";
+}
+
+interface EditCellDialogProps {
+  orgId: string;
+  weekStart: Date;
+  dayIndex: number;
+  members: OrgMember[];
+  currentEntries: RosterEntryRow[];
+  onClose: () => void;
+}
+
+export function EditCellDialog({
+  orgId,
+  weekStart,
+  dayIndex,
+  members,
+  currentEntries,
+  onClose,
+}: EditCellDialogProps) {
+  const [selected, setSelected] = useState<string[]>(
+    currentEntries.map((e) => e.membershipId),
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const dayLabel = DAY_LABELS[dayIndex];
+  const dateLabel = formatWeekDate(weekStart, dayIndex);
+  const title = `Edit ${dayLabel} — ${dateLabel}`;
+
+  const available = members.filter((m) => !selected.includes(m.id));
+
+  function addMember(id: string) {
+    setSelected((prev) => [...prev, id]);
+  }
+
+  function removeMember(id: string) {
+    setSelected((prev) => prev.filter((s) => s !== id));
+  }
+
+  function handleSave() {
+    startTransition(async () => {
+      const result = await setRosterCellMembersAction(
+        orgId,
+        weekStart,
+        dayIndex,
+        selected,
+      );
+      if (result.ok) {
+        onClose();
+      } else {
+        toast.error(result.error ?? "Failed to save");
+      }
+    });
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-sm">{title}</DialogTitle>
+        </DialogHeader>
+
+        {/* Member picker */}
+        {available.length > 0 && (
+          <select
+            className="w-full h-8 rounded-md border border-input bg-background px-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+            defaultValue=""
+            onChange={(e) => {
+              if (e.target.value) addMember(e.target.value);
+              e.target.value = "";
+            }}
+          >
+            <option value="" disabled>
+              Add member…
+            </option>
+            {available.map((m) => (
+              <option key={m.id} value={m.id}>
+                {memberDisplayName(m)}
+              </option>
+            ))}
+          </select>
+        )}
+
+        {/* Selected members list */}
+        <div className="flex flex-col gap-1 min-h-[60px]">
+          {selected.length === 0 ? (
+            <p className="text-xs text-muted-foreground py-2">
+              No members rostered.
+            </p>
+          ) : (
+            selected.map((id) => {
+              const member = members.find((m) => m.id === id);
+              if (!member) return null;
+              return (
+                <div
+                  key={id}
+                  className="flex items-center justify-between px-2 py-1 rounded bg-muted/50 text-sm"
+                >
+                  <span>{memberDisplayName(member)}</span>
+                  <button
+                    type="button"
+                    onClick={() => removeMember(id)}
+                    className="text-muted-foreground hover:text-destructive transition-colors"
+                  >
+                    <Minus className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleSave} disabled={isPending}>
+            {isPending ? "Saving…" : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/edit-cell-dialog.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/edit-cell-dialog.tsx
@@ -3,62 +3,99 @@
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Minus } from "lucide-react";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { setRosterCellMembersAction } from "@/app/actions/roster";
-import type { RosterEntryRow, OrgMember } from "./roster-board";
-import { DAY_LABELS } from "./roster-board-constants";
-
-function formatWeekDate(weekStart: Date, dayIndex: number): string {
-  const d = new Date(weekStart);
-  d.setUTCDate(d.getUTCDate() + dayIndex);
-  return `${d.getUTCDate()}/${d.getUTCMonth() + 1}/${d.getUTCFullYear()}`;
-}
+import { useActionSidebar } from "@/components/layout/action-sidebar-context";
+import type { RosterEntryRow, OrgMember, DayConfigRow } from "./roster-board";
 
 function memberDisplayName(m: OrgMember): string {
   return m.botName ?? m.user?.name ?? "Unknown";
 }
 
-interface EditCellDialogProps {
+function minToTime(min: number | null): string {
+  if (min === null) return "";
+  const h = Math.floor(min / 60).toString().padStart(2, "0");
+  const m = (min % 60).toString().padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+function timeToMin(time: string): number | null {
+  if (!time) return null;
+  const [h, m] = time.split(":").map(Number);
+  if (isNaN(h) || isNaN(m)) return null;
+  return h * 60 + m;
+}
+
+function hoursWorked(startMin: number | null, endMin: number | null): string {
+  if (startMin === null || endMin === null) return "";
+  const diff = endMin - startMin;
+  if (diff <= 0) return "";
+  const h = Math.floor(diff / 60);
+  const m = diff % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+type MemberShift = {
+  membershipId: string;
+  startTime: string; // "HH:MM"
+  endTime: string;
+};
+
+interface EditCellPanelProps {
   orgId: string;
   weekStart: Date;
   dayIndex: number;
   members: OrgMember[];
   currentEntries: RosterEntryRow[];
-  onClose: () => void;
+  dayConfig: DayConfigRow | null;
+  orgOpenTimeMin: number | null;
+  orgCloseTimeMin: number | null;
 }
 
-export function EditCellDialog({
+export function EditCellPanel({
   orgId,
   weekStart,
   dayIndex,
   members,
   currentEntries,
-  onClose,
-}: EditCellDialogProps) {
-  const [selected, setSelected] = useState<string[]>(
-    currentEntries.map((e) => e.membershipId),
+  dayConfig,
+  orgOpenTimeMin,
+  orgCloseTimeMin,
+}: EditCellPanelProps) {
+  const { close } = useActionSidebar();
+
+  // Default shift = day config times, falling back to org times
+  const defaultStart = minToTime(dayConfig?.openTimeMin ?? orgOpenTimeMin);
+  const defaultEnd = minToTime(dayConfig?.closeTimeMin ?? orgCloseTimeMin);
+
+  const [shifts, setShifts] = useState<MemberShift[]>(
+    currentEntries.map((e) => ({
+      membershipId: e.membershipId,
+      startTime: minToTime(e.shiftStartMin) || defaultStart,
+      endTime: minToTime(e.shiftEndMin) || defaultEnd,
+    })),
   );
   const [isPending, startTransition] = useTransition();
 
-  const dayLabel = DAY_LABELS[dayIndex];
-  const dateLabel = formatWeekDate(weekStart, dayIndex);
-  const title = `Edit ${dayLabel} — ${dateLabel}`;
-
-  const available = members.filter((m) => !selected.includes(m.id));
+  const selectedIds = shifts.map((s) => s.membershipId);
+  const available = members.filter((m) => !selectedIds.includes(m.id));
 
   function addMember(id: string) {
-    setSelected((prev) => [...prev, id]);
+    setShifts((prev) => [
+      ...prev,
+      { membershipId: id, startTime: defaultStart, endTime: defaultEnd },
+    ]);
   }
 
   function removeMember(id: string) {
-    setSelected((prev) => prev.filter((s) => s !== id));
+    setShifts((prev) => prev.filter((s) => s.membershipId !== id));
+  }
+
+  function updateShift(id: string, field: "startTime" | "endTime", value: string) {
+    setShifts((prev) =>
+      prev.map((s) => (s.membershipId === id ? { ...s, [field]: value } : s)),
+    );
   }
 
   function handleSave() {
@@ -67,10 +104,14 @@ export function EditCellDialog({
         orgId,
         weekStart,
         dayIndex,
-        selected,
+        shifts.map((s) => ({
+          membershipId: s.membershipId,
+          shiftStartMin: timeToMin(s.startTime),
+          shiftEndMin: timeToMin(s.endTime),
+        })),
       );
       if (result.ok) {
-        onClose();
+        close();
       } else {
         toast.error(result.error ?? "Failed to save");
       }
@@ -78,12 +119,9 @@ export function EditCellDialog({
   }
 
   return (
-    <Dialog open onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="sm:max-w-sm">
-        <DialogHeader>
-          <DialogTitle className="text-sm">{title}</DialogTitle>
-        </DialogHeader>
-
+    <div className="flex flex-col h-full">
+      {/* Scrollable body */}
+      <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-3 p-4">
         {/* Member picker */}
         {available.length > 0 && (
           <select
@@ -105,44 +143,66 @@ export function EditCellDialog({
           </select>
         )}
 
-        {/* Selected members list */}
-        <div className="flex flex-col gap-1 min-h-[60px]">
-          {selected.length === 0 ? (
-            <p className="text-xs text-muted-foreground py-2">
-              No members rostered.
-            </p>
-          ) : (
-            selected.map((id) => {
-              const member = members.find((m) => m.id === id);
-              if (!member) return null;
-              return (
-                <div
-                  key={id}
-                  className="flex items-center justify-between px-2 py-1 rounded bg-muted/50 text-sm"
-                >
-                  <span>{memberDisplayName(member)}</span>
+        {/* Rostered members with shift times */}
+        {shifts.length === 0 ? (
+          <p className="text-xs text-muted-foreground py-2">
+            No members rostered.
+          </p>
+        ) : (
+          shifts.map((s) => {
+            const member = members.find((m) => m.id === s.membershipId);
+            if (!member) return null;
+            const worked = hoursWorked(timeToMin(s.startTime), timeToMin(s.endTime));
+            return (
+              <div key={s.membershipId} className="flex flex-col gap-2 rounded-md border border-border p-2.5">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium truncate pr-2">{memberDisplayName(member)}</span>
                   <button
                     type="button"
-                    onClick={() => removeMember(id)}
-                    className="text-muted-foreground hover:text-destructive transition-colors"
+                    onClick={() => removeMember(s.membershipId)}
+                    className="shrink-0 text-muted-foreground hover:text-destructive transition-colors"
                   >
                     <Minus className="h-3.5 w-3.5" />
                   </button>
                 </div>
-              );
-            })
-          )}
-        </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="flex flex-col gap-0.5">
+                    <label className="text-[10px] text-muted-foreground uppercase tracking-wide">Start</label>
+                    <Input
+                      type="time"
+                      value={s.startTime}
+                      onChange={(e) => updateShift(s.membershipId, "startTime", e.target.value)}
+                      className="h-7 text-xs px-1.5"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-0.5">
+                    <label className="text-[10px] text-muted-foreground uppercase tracking-wide">End</label>
+                    <Input
+                      type="time"
+                      value={s.endTime}
+                      onChange={(e) => updateShift(s.membershipId, "endTime", e.target.value)}
+                      className="h-7 text-xs px-1.5"
+                    />
+                  </div>
+                </div>
+                {worked && (
+                  <p className="text-xs text-muted-foreground text-right">{worked}</p>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
 
-        <DialogFooter>
-          <Button variant="outline" size="sm" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button size="sm" onClick={handleSave} disabled={isPending}>
-            {isPending ? "Saving…" : "Save"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      {/* Sticky footer */}
+      <div className="shrink-0 flex gap-2 justify-end p-4 border-t border-border">
+        <Button variant="outline" size="sm" onClick={close}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={handleSave} disabled={isPending}>
+          {isPending ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/edit-day-config-dialog.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/edit-day-config-dialog.tsx
@@ -17,8 +17,12 @@ function minToTime(min: number | null): string {
 
 function timeToMin(time: string): number | null {
   if (!time) return null;
-  const [h, m] = time.split(":").map(Number);
+  const parts = time.split(":");
+  if (parts.length !== 2) return null;
+  const h = Number(parts[0]);
+  const m = Number(parts[1]);
   if (isNaN(h) || isNaN(m)) return null;
+  if (h < 0 || h > 23 || m < 0 || m > 59) return null;
   return h * 60 + m;
 }
 

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/edit-day-config-dialog.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/edit-day-config-dialog.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { upsertRosterDayConfigAction } from "@/app/actions/roster";
+import type { DayConfigRow } from "./roster-board";
+import { DAY_LABELS } from "./roster-board-constants";
+
+function minToTime(min: number | null): string {
+  if (min === null) return "";
+  const h = Math.floor(min / 60).toString().padStart(2, "0");
+  const m = (min % 60).toString().padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+function timeToMin(time: string): number | null {
+  if (!time) return null;
+  const [h, m] = time.split(":").map(Number);
+  if (isNaN(h) || isNaN(m)) return null;
+  return h * 60 + m;
+}
+
+interface EditDayConfigDialogProps {
+  orgId: string;
+  dayIndex: number;
+  config: DayConfigRow | null;
+  onClose: () => void;
+}
+
+export function EditDayConfigDialog({
+  orgId,
+  dayIndex,
+  config,
+  onClose,
+}: EditDayConfigDialogProps) {
+  const [recommendedSize, setRecommendedSize] = useState(
+    config?.recommendedSize ?? 1,
+  );
+  const [openTime, setOpenTime] = useState(
+    minToTime(config?.openTimeMin ?? null),
+  );
+  const [closeTime, setCloseTime] = useState(
+    minToTime(config?.closeTimeMin ?? null),
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const dayLabel = DAY_LABELS[dayIndex];
+
+  function handleSave() {
+    startTransition(async () => {
+      const result = await upsertRosterDayConfigAction(orgId, dayIndex, {
+        recommendedSize,
+        openTimeMin: timeToMin(openTime),
+        closeTimeMin: timeToMin(closeTime),
+      });
+      if (result.ok) {
+        onClose();
+      } else {
+        toast.error(result.error ?? "Failed to save");
+      }
+    });
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-xs">
+        <DialogHeader>
+          <DialogTitle className="text-sm">Edit {dayLabel} row</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-medium">Recommended Size</label>
+            <Input
+              type="number"
+              min={0}
+              max={100}
+              value={recommendedSize}
+              onChange={(e) =>
+                setRecommendedSize(Math.max(0, Number(e.target.value)))
+              }
+              className="h-8 text-sm"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-medium">Open Time</label>
+            <Input
+              type="time"
+              value={openTime}
+              onChange={(e) => setOpenTime(e.target.value)}
+              className="h-8 text-sm"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-medium">Close Time</label>
+            <Input
+              type="time"
+              value={closeTime}
+              onChange={(e) => setCloseTime(e.target.value)}
+              className="h-8 text-sm"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleSave} disabled={isPending}>
+            {isPending ? "Saving…" : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/edit-day-config-dialog.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/edit-day-config-dialog.tsx
@@ -2,18 +2,11 @@
 
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { upsertRosterDayConfigAction } from "@/app/actions/roster";
+import { useActionSidebar } from "@/components/layout/action-sidebar-context";
 import type { DayConfigRow } from "./roster-board";
-import { DAY_LABELS } from "./roster-board-constants";
 
 function minToTime(min: number | null): string {
   if (min === null) return "";
@@ -29,31 +22,32 @@ function timeToMin(time: string): number | null {
   return h * 60 + m;
 }
 
-interface EditDayConfigDialogProps {
+interface EditDayConfigPanelProps {
   orgId: string;
   dayIndex: number;
   config: DayConfigRow | null;
-  onClose: () => void;
+  orgOpenTimeMin: number | null;
+  orgCloseTimeMin: number | null;
 }
 
-export function EditDayConfigDialog({
+export function EditDayConfigPanel({
   orgId,
   dayIndex,
   config,
-  onClose,
-}: EditDayConfigDialogProps) {
+  orgOpenTimeMin,
+  orgCloseTimeMin,
+}: EditDayConfigPanelProps) {
+  const { close } = useActionSidebar();
   const [recommendedSize, setRecommendedSize] = useState(
     config?.recommendedSize ?? 1,
   );
   const [openTime, setOpenTime] = useState(
-    minToTime(config?.openTimeMin ?? null),
+    minToTime(config?.openTimeMin ?? orgOpenTimeMin),
   );
   const [closeTime, setCloseTime] = useState(
-    minToTime(config?.closeTimeMin ?? null),
+    minToTime(config?.closeTimeMin ?? orgCloseTimeMin),
   );
   const [isPending, startTransition] = useTransition();
-
-  const dayLabel = DAY_LABELS[dayIndex];
 
   function handleSave() {
     startTransition(async () => {
@@ -63,7 +57,7 @@ export function EditDayConfigDialog({
         closeTimeMin: timeToMin(closeTime),
       });
       if (result.ok) {
-        onClose();
+        close();
       } else {
         toast.error(result.error ?? "Failed to save");
       }
@@ -71,57 +65,49 @@ export function EditDayConfigDialog({
   }
 
   return (
-    <Dialog open onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="sm:max-w-xs">
-        <DialogHeader>
-          <DialogTitle className="text-sm">Edit {dayLabel} row</DialogTitle>
-        </DialogHeader>
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex flex-col gap-1.5">
+        <label className="text-xs font-medium">Recommended Size</label>
+        <Input
+          type="number"
+          min={0}
+          max={100}
+          value={recommendedSize}
+          onChange={(e) =>
+            setRecommendedSize(Math.max(0, Number(e.target.value)))
+          }
+          className="h-8 text-sm"
+        />
+      </div>
 
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-1.5">
-            <label className="text-xs font-medium">Recommended Size</label>
-            <Input
-              type="number"
-              min={0}
-              max={100}
-              value={recommendedSize}
-              onChange={(e) =>
-                setRecommendedSize(Math.max(0, Number(e.target.value)))
-              }
-              className="h-8 text-sm"
-            />
-          </div>
+      <div className="flex flex-col gap-1.5">
+        <label className="text-xs font-medium">Open Time</label>
+        <Input
+          type="time"
+          value={openTime}
+          onChange={(e) => setOpenTime(e.target.value)}
+          className="h-8 text-sm"
+        />
+      </div>
 
-          <div className="flex flex-col gap-1.5">
-            <label className="text-xs font-medium">Open Time</label>
-            <Input
-              type="time"
-              value={openTime}
-              onChange={(e) => setOpenTime(e.target.value)}
-              className="h-8 text-sm"
-            />
-          </div>
+      <div className="flex flex-col gap-1.5">
+        <label className="text-xs font-medium">Close Time</label>
+        <Input
+          type="time"
+          value={closeTime}
+          onChange={(e) => setCloseTime(e.target.value)}
+          className="h-8 text-sm"
+        />
+      </div>
 
-          <div className="flex flex-col gap-1.5">
-            <label className="text-xs font-medium">Close Time</label>
-            <Input
-              type="time"
-              value={closeTime}
-              onChange={(e) => setCloseTime(e.target.value)}
-              className="h-8 text-sm"
-            />
-          </div>
-        </div>
-
-        <DialogFooter>
-          <Button variant="outline" size="sm" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button size="sm" onClick={handleSave} disabled={isPending}>
-            {isPending ? "Saving…" : "Save"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      <div className="flex gap-2 justify-end">
+        <Button variant="outline" size="sm" onClick={close}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={handleSave} disabled={isPending}>
+          {isPending ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board-constants.ts
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board-constants.ts
@@ -1,0 +1,28 @@
+/**
+ * roster-board-constants.ts
+ * Cell size constants exported so the same grid can be reused for template mode.
+ */
+
+export const ROSTER_CELL_WIDTH = 160; // px — each week column
+export const ROSTER_DAY_LABEL_WIDTH = 120; // px — left day label column
+export const ROSTER_CELL_MIN_HEIGHT = 64; // px — minimum row height
+
+export const DAY_LABELS = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+] as const;
+
+export const DAY_KEYS = [
+  "mon",
+  "tue",
+  "wed",
+  "thu",
+  "fri",
+  "sat",
+  "sun",
+] as const;

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board.tsx
@@ -89,6 +89,15 @@ function formatMinutes(min: number): string {
   return `${h}:${m}`;
 }
 
+function hoursWorked(startMin: number | null, endMin: number | null): string {
+  if (startMin === null || endMin === null) return "";
+  const diff = endMin - startMin;
+  if (diff <= 0) return "";
+  const h = Math.floor(diff / 60);
+  const m = diff % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
 const DAY_ABBR = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"] as const;
 
 export function RosterBoard({
@@ -169,6 +178,7 @@ export function RosterBoard({
                 sidebar.open(
                   `Edit ${label} row`,
                   <EditDayConfigPanel
+                    key={dayIndex}
                     orgId={orgId}
                     dayIndex={dayIndex}
                     config={config ?? null}
@@ -223,7 +233,7 @@ export function RosterBoard({
                 <button
                   key={weekStart.getTime()}
                   className={cn(
-                    "group flex-1 flex flex-col items-start justify-start gap-1 px-2 py-2 border-r border-border text-left transition-colors hover:brightness-[0.97] dark:hover:brightness-110 min-w-0",
+                    "group flex-1 flex flex-col items-start justify-start gap-1 px-2 py-2 border-r border-border text-left transition-colors cursor-pointer hover:brightness-[0.93] dark:hover:brightness-125 min-w-0",
                     isToday && "border-l-2 border-l-primary/50",
                     bg,
                   )}
@@ -231,6 +241,7 @@ export function RosterBoard({
                     sidebar.open(
                       `${DAY_LABELS[dayIndex]}, ${formatWeekDate(weekStart, dayIndex)}`,
                       <EditCellPanel
+                        key={`${weekStart.getTime()}-${dayIndex}`}
                         orgId={orgId}
                         weekStart={weekStart}
                         dayIndex={dayIndex}
@@ -271,6 +282,8 @@ export function RosterBoard({
                               <span className="text-[10px] text-muted-foreground font-normal">
                                 {formatMinutes(e.shiftStartMin)}–
                                 {formatMinutes(e.shiftEndMin)}
+                                {" · "}
+                                {hoursWorked(e.shiftStartMin, e.shiftEndMin)}
                               </span>
                             )}
                         </span>

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board.tsx
@@ -22,6 +22,7 @@ import {
   ROSTER_DAY_LABEL_WIDTH,
   ROSTER_CELL_MIN_HEIGHT,
 } from "./roster-board-constants";
+import { formatMinutes, hoursWorked } from "../_utils/time-utils";
 
 export type RosterEntryRow = {
   id: string;
@@ -83,20 +84,6 @@ function formatWeekDate(weekStart: Date, dayIndex: number): string {
   return `${d.getUTCDate()} ${months[d.getUTCMonth()]}`;
 }
 
-function formatMinutes(min: number): string {
-  const h = Math.floor(min / 60).toString().padStart(2, "0");
-  const m = (min % 60).toString().padStart(2, "0");
-  return `${h}:${m}`;
-}
-
-function hoursWorked(startMin: number | null, endMin: number | null): string {
-  if (startMin === null || endMin === null) return "";
-  const diff = endMin - startMin;
-  if (diff <= 0) return "";
-  const h = Math.floor(diff / 60);
-  const m = diff % 60;
-  return m > 0 ? `${h}h ${m}m` : `${h}h`;
-}
 
 const DAY_ABBR = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"] as const;
 

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+/**
+ * RosterBoard — the reusable week × day grid.
+ *
+ * Exports ROSTER_CELL_WIDTH / ROSTER_DAY_LABEL_WIDTH constants so a future
+ * template-mode board can reuse the exact same grid structure.
+ *
+ * Row colors:
+ *   RED    — no members rostered
+ *   YELLOW — member count doesn't match recommendedSize
+ *   GREEN  — filtered member is rostered on this day
+ *   default (white/dark) — fully staffed
+ */
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { EditCellDialog } from "./edit-cell-dialog";
+import { EditDayConfigDialog } from "./edit-day-config-dialog";
+import {
+  DAY_LABELS,
+  ROSTER_CELL_WIDTH,
+  ROSTER_DAY_LABEL_WIDTH,
+  ROSTER_CELL_MIN_HEIGHT,
+} from "./roster-board-constants";
+
+export type RosterEntryRow = {
+  id: string;
+  membershipId: string;
+  weekStart: Date;
+  dayIndex: number;
+  shiftStartMin: number | null;
+  shiftEndMin: number | null;
+  membership: {
+    id: string;
+    botName: string | null;
+    user: { name: string | null } | null;
+  };
+};
+
+export type DayConfigRow = {
+  dayIndex: number;
+  recommendedSize: number;
+  openTimeMin: number | null;
+  closeTimeMin: number | null;
+};
+
+export type OrgMember = {
+  id: string;
+  botName: string | null;
+  user: { name: string | null } | null;
+};
+
+export type RosterBoardProps = {
+  orgId: string;
+  entries: RosterEntryRow[];
+  dayConfigs: DayConfigRow[];
+  members: OrgMember[];
+  weekStarts: Date[];
+  todayMonday: number; // .getTime() of today's Monday
+  filterMembershipId: string | null;
+  onFilterChange: (id: string | null) => void;
+};
+
+function memberName(m: OrgMember): string {
+  return m.botName ?? m.user?.name ?? "Unknown";
+}
+
+function formatMinutes(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return `${h}:${m.toString().padStart(2, "0")}`;
+}
+
+export function RosterBoard({
+  orgId,
+  entries,
+  dayConfigs,
+  members,
+  weekStarts,
+  todayMonday,
+  filterMembershipId,
+  onFilterChange,
+}: RosterBoardProps) {
+  const [editCell, setEditCell] = useState<{
+    weekStart: Date;
+    dayIndex: number;
+  } | null>(null);
+  const [editDayConfig, setEditDayConfig] = useState<number | null>(null); // dayIndex
+
+  // Build lookup: "weekStartMs-dayIndex" → RosterEntryRow[]
+  const cellMap = new Map<string, RosterEntryRow[]>();
+  for (const entry of entries) {
+    const key = `${entry.weekStart.getTime()}-${entry.dayIndex}`;
+    const existing = cellMap.get(key) ?? [];
+    existing.push(entry);
+    cellMap.set(key, existing);
+  }
+
+  // Day config lookup by dayIndex
+  const configMap = new Map<number, DayConfigRow>();
+  for (const cfg of dayConfigs) configMap.set(cfg.dayIndex, cfg);
+
+  return (
+    <>
+      <div
+        className="relative"
+        style={{
+          minWidth: ROSTER_DAY_LABEL_WIDTH + ROSTER_CELL_WIDTH * weekStarts.length,
+        }}
+      >
+        {/* Day rows */}
+        {DAY_LABELS.map((label, dayIndex) => {
+          const config = configMap.get(dayIndex);
+          const recommendedSize = config?.recommendedSize ?? 1;
+
+          return (
+            <div
+              key={dayIndex}
+              className="flex border-b border-border"
+              style={{ minHeight: ROSTER_CELL_MIN_HEIGHT }}
+            >
+              {/* Day label — clicking opens day config editor */}
+              <button
+                className="shrink-0 flex flex-col items-start justify-center px-3 py-2 border-r border-border hover:bg-muted/60 transition-colors text-left"
+                style={{ width: ROSTER_DAY_LABEL_WIDTH }}
+                onClick={() => setEditDayConfig(dayIndex)}
+              >
+                <span className="text-sm font-semibold">{label}</span>
+                <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
+                  rec. size: {recommendedSize}
+                </span>
+              </button>
+
+              {/* Week cells */}
+              {weekStarts.map((weekStart) => {
+                const key = `${weekStart.getTime()}-${dayIndex}`;
+                const cellEntries = cellMap.get(key) ?? [];
+                const isToday = weekStart.getTime() === todayMonday;
+
+                const isEmpty = cellEntries.length === 0;
+                const isMismatch =
+                  !isEmpty && cellEntries.length !== recommendedSize;
+                const isFiltered =
+                  filterMembershipId !== null &&
+                  cellEntries.some(
+                    (e) => e.membershipId === filterMembershipId,
+                  );
+
+                const bg = isFiltered
+                  ? "bg-green-200 dark:bg-green-900/40"
+                  : isEmpty
+                    ? "bg-red-100 dark:bg-red-900/30"
+                    : isMismatch
+                      ? "bg-yellow-100 dark:bg-yellow-900/30"
+                      : "";
+
+                return (
+                  <button
+                    key={weekStart.getTime()}
+                    className={cn(
+                      "shrink-0 flex flex-col items-start justify-start gap-0.5 px-2 py-1.5 border-r border-border text-left transition-colors hover:brightness-95",
+                      isToday && "ring-2 ring-inset ring-primary/40",
+                      bg,
+                    )}
+                    style={{ width: ROSTER_CELL_WIDTH }}
+                    onClick={() => setEditCell({ weekStart, dayIndex })}
+                  >
+                    {cellEntries.map((e) => {
+                      const name =
+                        e.membership.botName ??
+                        e.membership.user?.name ??
+                        "Unknown";
+                      const isHighlighted =
+                        filterMembershipId === e.membershipId;
+                      return (
+                        <span
+                          key={e.id}
+                          className={cn(
+                            "text-xs leading-snug",
+                            isHighlighted && "font-bold",
+                          )}
+                        >
+                          {name}
+                          {e.shiftStartMin !== null && e.shiftEndMin !== null && (
+                            <span className="ml-1 text-[10px] text-muted-foreground">
+                              {formatMinutes(e.shiftStartMin)}–
+                              {formatMinutes(e.shiftEndMin)}
+                            </span>
+                          )}
+                        </span>
+                      );
+                    })}
+                  </button>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Edit cell dialog */}
+      {editCell && (
+        <EditCellDialog
+          orgId={orgId}
+          weekStart={editCell.weekStart}
+          dayIndex={editCell.dayIndex}
+          members={members}
+          currentEntries={
+            cellMap.get(
+              `${editCell.weekStart.getTime()}-${editCell.dayIndex}`,
+            ) ?? []
+          }
+          onClose={() => setEditCell(null)}
+        />
+      )}
+
+      {/* Edit day config dialog */}
+      {editDayConfig !== null && (
+        <EditDayConfigDialog
+          orgId={orgId}
+          dayIndex={editDayConfig}
+          config={configMap.get(editDayConfig) ?? null}
+          onClose={() => setEditDayConfig(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 /**
- * RosterBoard — the reusable week × day grid.
  *
  * Exports ROSTER_CELL_WIDTH / ROSTER_DAY_LABEL_WIDTH constants so a future
  * template-mode board can reuse the exact same grid structure.
@@ -13,10 +12,10 @@
  *   default (white/dark) — fully staffed
  */
 
-import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { EditCellDialog } from "./edit-cell-dialog";
-import { EditDayConfigDialog } from "./edit-day-config-dialog";
+import { useActionSidebar } from "@/components/layout/action-sidebar-context";
+import { EditCellPanel } from "./edit-cell-dialog";
+import { EditDayConfigPanel } from "./edit-day-config-dialog";
 import {
   DAY_LABELS,
   ROSTER_CELL_WIDTH,
@@ -58,19 +57,39 @@ export type RosterBoardProps = {
   members: OrgMember[];
   weekStarts: Date[];
   todayMonday: number; // .getTime() of today's Monday
+  todayDayIndex: number; // 0=Mon … 6=Sun in org timezone
   filterMembershipId: string | null;
-  onFilterChange: (id: string | null) => void;
+  onFilterChange?: (id: string | null) => void;
+  orgOpenTimeMin: number | null;
+  orgCloseTimeMin: number | null;
 };
 
 function memberName(m: OrgMember): string {
   return m.botName ?? m.user?.name ?? "Unknown";
 }
 
-function formatMinutes(min: number): string {
-  const h = Math.floor(min / 60);
-  const m = min % 60;
-  return `${h}:${m.toString().padStart(2, "0")}`;
+function formatWeekRange(monday: Date): string {
+  const sunday = new Date(monday);
+  sunday.setUTCDate(monday.getUTCDate() + 6);
+  const months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+  const fmt = (d: Date) => `${d.getUTCDate()} ${months[d.getUTCMonth()]}`;
+  return `${fmt(monday)} – ${fmt(sunday)}`;
 }
+
+function formatWeekDate(weekStart: Date, dayIndex: number): string {
+  const d = new Date(weekStart);
+  d.setUTCDate(d.getUTCDate() + dayIndex);
+  const months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+  return `${d.getUTCDate()} ${months[d.getUTCMonth()]}`;
+}
+
+function formatMinutes(min: number): string {
+  const h = Math.floor(min / 60).toString().padStart(2, "0");
+  const m = (min % 60).toString().padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+const DAY_ABBR = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"] as const;
 
 export function RosterBoard({
   orgId,
@@ -79,14 +98,12 @@ export function RosterBoard({
   members,
   weekStarts,
   todayMonday,
+  todayDayIndex,
   filterMembershipId,
-  onFilterChange,
+  orgOpenTimeMin,
+  orgCloseTimeMin,
 }: RosterBoardProps) {
-  const [editCell, setEditCell] = useState<{
-    weekStart: Date;
-    dayIndex: number;
-  } | null>(null);
-  const [editDayConfig, setEditDayConfig] = useState<number | null>(null); // dayIndex
+  const sidebar = useActionSidebar();
 
   // Build lookup: "weekStartMs-dayIndex" → RosterEntryRow[]
   const cellMap = new Map<string, RosterEntryRow[]>();
@@ -102,128 +119,170 @@ export function RosterBoard({
   for (const cfg of dayConfigs) configMap.set(cfg.dayIndex, cfg);
 
   return (
-    <>
-      <div
-        className="relative"
-        style={{
-          minWidth: ROSTER_DAY_LABEL_WIDTH + ROSTER_CELL_WIDTH * weekStarts.length,
-        }}
-      >
-        {/* Day rows */}
-        {DAY_LABELS.map((label, dayIndex) => {
-          const config = configMap.get(dayIndex);
-          const recommendedSize = config?.recommendedSize ?? 1;
-
+    <div className="w-full">
+      {/* ── Header row: week date ranges ── */}
+      <div className="flex border-b border-border bg-muted/30 sticky top-0 z-10">
+        {/* Spacer aligned with the day-label column */}
+        <div
+          className="shrink-0 border-r border-border"
+          style={{ width: ROSTER_DAY_LABEL_WIDTH }}
+        />
+        {weekStarts.map((weekStart) => {
+          const isThisWeek = weekStart.getTime() === todayMonday;
           return (
             <div
-              key={dayIndex}
-              className="flex border-b border-border"
-              style={{ minHeight: ROSTER_CELL_MIN_HEIGHT }}
+              key={weekStart.getTime()}
+              className={cn(
+                "flex-1 text-center text-xs font-medium py-2.5 border-r border-border",
+                isThisWeek
+                  ? "bg-primary/10 text-primary font-semibold"
+                  : "text-muted-foreground",
+              )}
             >
-              {/* Day label — clicking opens day config editor */}
-              <button
-                className="shrink-0 flex flex-col items-start justify-center px-3 py-2 border-r border-border hover:bg-muted/60 transition-colors text-left"
-                style={{ width: ROSTER_DAY_LABEL_WIDTH }}
-                onClick={() => setEditDayConfig(dayIndex)}
-              >
-                <span className="text-sm font-semibold">{label}</span>
-                <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
-                  rec. size: {recommendedSize}
-                </span>
-              </button>
+              {formatWeekRange(weekStart)}
+            </div>
+          );
+        })}
+      </div>
 
-              {/* Week cells */}
-              {weekStarts.map((weekStart) => {
-                const key = `${weekStart.getTime()}-${dayIndex}`;
-                const cellEntries = cellMap.get(key) ?? [];
-                const isToday = weekStart.getTime() === todayMonday;
+      {/* ── Day rows ── */}
+      {DAY_LABELS.map((label, dayIndex) => {
+        const config = configMap.get(dayIndex);
+        const recommendedSize = config?.recommendedSize ?? 1;
+        const isLastDay = dayIndex === DAY_LABELS.length - 1;
+        const isTodayRow = dayIndex === todayDayIndex;
 
-                const isEmpty = cellEntries.length === 0;
-                const isMismatch =
-                  !isEmpty && cellEntries.length !== recommendedSize;
-                const isFiltered =
-                  filterMembershipId !== null &&
-                  cellEntries.some(
-                    (e) => e.membershipId === filterMembershipId,
-                  );
+        return (
+          <div
+            key={dayIndex}
+            className={cn("flex", isLastDay ? "" : "border-b border-border")}
+            style={{ minHeight: ROSTER_CELL_MIN_HEIGHT }}
+          >
+            {/* Day label — clicking opens day config editor */}
+            <button
+              className={cn(
+                "shrink-0 flex flex-col items-start justify-center gap-0.5 px-3 py-2 border-r border-border hover:bg-muted/50 transition-colors text-left",
+                isTodayRow && "bg-primary/8",
+              )}
+              style={{ width: ROSTER_DAY_LABEL_WIDTH }}
+              onClick={() =>
+                sidebar.open(
+                  `Edit ${label} row`,
+                  <EditDayConfigPanel
+                    orgId={orgId}
+                    dayIndex={dayIndex}
+                    config={config ?? null}
+                    orgOpenTimeMin={orgOpenTimeMin}
+                    orgCloseTimeMin={orgCloseTimeMin}
+                  />,
+                )
+              }
+            >
+              <span className={cn("text-sm font-semibold", isTodayRow && "text-primary")}>
+                {DAY_ABBR[dayIndex]}
+              </span>
+              <span className={cn("text-[10px]", isTodayRow ? "text-primary/70" : "text-muted-foreground")}>
+                ×{recommendedSize} needed
+              </span>
+            </button>
 
-                const bg = isFiltered
-                  ? "bg-green-200 dark:bg-green-900/40"
-                  : isEmpty
-                    ? "bg-red-100 dark:bg-red-900/30"
-                    : isMismatch
-                      ? "bg-yellow-100 dark:bg-yellow-900/30"
-                      : "";
+            {/* Week cells */}
+            {weekStarts.map((weekStart) => {
+              const key = `${weekStart.getTime()}-${dayIndex}`;
+              const cellEntries = cellMap.get(key) ?? [];
+              const isToday = weekStart.getTime() === todayMonday;
 
-                return (
-                  <button
-                    key={weekStart.getTime()}
-                    className={cn(
-                      "shrink-0 flex flex-col items-start justify-start gap-0.5 px-2 py-1.5 border-r border-border text-left transition-colors hover:brightness-95",
-                      isToday && "ring-2 ring-inset ring-primary/40",
-                      bg,
-                    )}
-                    style={{ width: ROSTER_CELL_WIDTH }}
-                    onClick={() => setEditCell({ weekStart, dayIndex })}
-                  >
-                    {cellEntries.map((e) => {
+              const isEmpty = cellEntries.length === 0;
+              const isMismatch =
+                !isEmpty && cellEntries.length !== recommendedSize;
+              const isFiltered =
+                filterMembershipId !== null &&
+                cellEntries.some((e) => e.membershipId === filterMembershipId);
+
+              const isTodayCell = isToday && isTodayRow;
+
+              const bg = isFiltered
+                ? "bg-emerald-100 dark:bg-emerald-900/30"
+                : isEmpty
+                  ? isTodayCell
+                    ? "bg-red-100 dark:bg-red-900/40"
+                    : "bg-red-50 dark:bg-red-950/40"
+                  : isMismatch
+                    ? isTodayCell
+                      ? "bg-amber-100 dark:bg-amber-900/40"
+                      : "bg-amber-50 dark:bg-amber-950/40"
+                    : isTodayCell
+                      ? "bg-primary/10"
+                      : isToday
+                        ? "bg-primary/5"
+                        : isTodayRow
+                          ? "bg-muted/30"
+                          : "";
+
+              return (
+                <button
+                  key={weekStart.getTime()}
+                  className={cn(
+                    "group flex-1 flex flex-col items-start justify-start gap-1 px-2 py-2 border-r border-border text-left transition-colors hover:brightness-[0.97] dark:hover:brightness-110 min-w-0",
+                    isToday && "border-l-2 border-l-primary/50",
+                    bg,
+                  )}
+                  onClick={() =>
+                    sidebar.open(
+                      `${DAY_LABELS[dayIndex]}, ${formatWeekDate(weekStart, dayIndex)}`,
+                      <EditCellPanel
+                        orgId={orgId}
+                        weekStart={weekStart}
+                        dayIndex={dayIndex}
+                        members={members}
+                        currentEntries={cellEntries}
+                        dayConfig={config ?? null}
+                        orgOpenTimeMin={orgOpenTimeMin}
+                        orgCloseTimeMin={orgCloseTimeMin}
+                      />,
+                    )
+                  }
+                >
+                  {isEmpty ? (
+                    <span className="text-xs text-muted-foreground/40 group-hover:text-muted-foreground/60 transition-colors mx-auto mt-auto mb-auto">
+                      —
+                    </span>
+                  ) : (
+                    cellEntries.map((e) => {
                       const name =
                         e.membership.botName ??
                         e.membership.user?.name ??
-                        "Unknown";
+                        "?";
                       const isHighlighted =
                         filterMembershipId === e.membershipId;
                       return (
                         <span
                           key={e.id}
                           className={cn(
-                            "text-xs leading-snug",
-                            isHighlighted && "font-bold",
+                            "inline-flex flex-col w-full rounded px-1.5 py-0.5 text-xs leading-tight truncate",
+                            isHighlighted
+                              ? "bg-emerald-600/15 text-emerald-800 dark:text-emerald-300 font-semibold"
+                              : "bg-background/70 dark:bg-white/8",
                           )}
                         >
-                          {name}
-                          {e.shiftStartMin !== null && e.shiftEndMin !== null && (
-                            <span className="ml-1 text-[10px] text-muted-foreground">
-                              {formatMinutes(e.shiftStartMin)}–
-                              {formatMinutes(e.shiftEndMin)}
-                            </span>
-                          )}
+                          <span className="truncate">{name}</span>
+                          {e.shiftStartMin !== null &&
+                            e.shiftEndMin !== null && (
+                              <span className="text-[10px] text-muted-foreground font-normal">
+                                {formatMinutes(e.shiftStartMin)}–
+                                {formatMinutes(e.shiftEndMin)}
+                              </span>
+                            )}
                         </span>
                       );
-                    })}
-                  </button>
-                );
-              })}
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Edit cell dialog */}
-      {editCell && (
-        <EditCellDialog
-          orgId={orgId}
-          weekStart={editCell.weekStart}
-          dayIndex={editCell.dayIndex}
-          members={members}
-          currentEntries={
-            cellMap.get(
-              `${editCell.weekStart.getTime()}-${editCell.dayIndex}`,
-            ) ?? []
-          }
-          onClose={() => setEditCell(null)}
-        />
-      )}
-
-      {/* Edit day config dialog */}
-      {editDayConfig !== null && (
-        <EditDayConfigDialog
-          orgId={orgId}
-          dayIndex={editDayConfig}
-          config={configMap.get(editDayConfig) ?? null}
-          onClose={() => setEditDayConfig(null)}
-        />
-      )}
-    </>
+                    })
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
   );
 }

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-client.tsx
@@ -1,115 +1,48 @@
 "use client";
 
-/**
- * RosterClient — client shell for the Roster board.
- *
- * Owns:
- *  - Week navigation (prev / today / next, showing WEEKS_SHOWN columns at once)
- *  - Filter by member (highlights matching cells in green, dims others)
- *  - Renders RosterBoard with derived props
- */
+import { useEffect, useRef, useState } from "react";
+import { RosterBoard, type RosterBoardProps } from "./roster-board";
+import {
+  ROSTER_CELL_WIDTH,
+  ROSTER_DAY_LABEL_WIDTH,
+} from "./roster-board-constants";
 
-import { useState, useMemo } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { RosterBoard } from "./roster-board";
-import type { RosterBoardProps } from "./roster-board";
+// Minimum px width per week column before we drop it from view.
+const MIN_CELL_WIDTH = ROSTER_CELL_WIDTH;
 
-const WEEKS_SHOWN = 5;
-
-function getMondayOfWeek(d: Date): Date {
-  const date = new Date(d);
-  const day = date.getUTCDay(); // 0=Sun
-  const diff = day === 0 ? -6 : 1 - day;
-  date.setUTCDate(date.getUTCDate() + diff);
-  date.setUTCHours(0, 0, 0, 0);
-  return date;
-}
-
-function addWeeks(date: Date, n: number): Date {
-  const d = new Date(date);
-  d.setUTCDate(d.getUTCDate() + n * 7);
-  return d;
-}
-
-function formatWeekRange(monday: Date): string {
-  const sunday = new Date(monday);
-  sunday.setUTCDate(monday.getUTCDate() + 6);
-  const fmt = (d: Date) =>
-    `${d.getUTCDate()}/${d.getUTCMonth() + 1}`;
-  return `${fmt(monday)} - ${fmt(sunday)}`;
-}
-
-type Props = Omit<RosterBoardProps, "weekStarts" | "todayMonday" | "onFilterChange"> & {
+type Props = Omit<RosterBoardProps, "onFilterChange"> & {
   filterMembershipId: string | null;
-  onFilterChange?: (id: string | null) => void;
 };
 
-export function RosterClient({
-  filterMembershipId,
-  onFilterChange,
-  ...boardProps
-}: Props) {
-  // Anchor: the Monday of the leftmost visible column
-  const [anchorMonday, setAnchorMonday] = useState<Date>(() =>
-    getMondayOfWeek(new Date()),
-  );
+export function RosterClient({ filterMembershipId, ...boardProps }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState(boardProps.weekStarts.length);
 
-  const weekStarts = useMemo(() => {
-    return Array.from({ length: WEEKS_SHOWN }, (_, i) =>
-      addWeeks(anchorMonday, i),
-    );
-  }, [anchorMonday]);
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver(([entry]) => {
+      const width = entry.contentRect.width;
+      const count = Math.max(
+        1,
+        Math.floor((width - ROSTER_DAY_LABEL_WIDTH) / MIN_CELL_WIDTH),
+      );
+      setVisibleCount(count);
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
 
-  const todayMonday = getMondayOfWeek(new Date()).getTime();
-
-  function goToToday() {
-    setAnchorMonday(getMondayOfWeek(new Date()));
-  }
+  const visibleWeeks = boardProps.weekStarts.slice(0, visibleCount);
 
   return (
-    <div className="flex flex-col h-full min-h-0">
-      {/* Week navigation toolbar */}
-      <div className="flex items-center gap-2 px-4 py-2 border-b border-border shrink-0">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setAnchorMonday((d) => addWeeks(d, -1))}
-        >
-          <ChevronLeft className="h-4 w-4" />
-        </Button>
-        <Button variant="outline" size="sm" onClick={goToToday}>
-          Today
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setAnchorMonday((d) => addWeeks(d, 1))}
-        >
-          <ChevronRight className="h-4 w-4" />
-        </Button>
-
-        {/* Week range labels */}
-        <div className="flex gap-1 ml-2 text-xs text-muted-foreground">
-          {weekStarts.map((w) => (
-            <span
-              key={w.getTime()}
-              className="w-[160px] text-center font-medium truncate"
-            >
-              {formatWeekRange(w)}
-            </span>
-          ))}
-        </div>
-      </div>
-
-      {/* Board */}
-      <div className="flex-1 overflow-auto">
+    <div ref={containerRef} className="flex-1 overflow-auto">
+      <div className="rounded-lg border border-border overflow-hidden">
         <RosterBoard
           {...boardProps}
-          weekStarts={weekStarts}
-          todayMonday={todayMonday}
-          filterMembershipId={filterMembershipId ?? null}
-          onFilterChange={onFilterChange ?? (() => {})}
+          weekStarts={visibleWeeks}
+          filterMembershipId={filterMembershipId}
+          onFilterChange={() => {}}
         />
       </div>
     </div>

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-client.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+/**
+ * RosterClient — client shell for the Roster board.
+ *
+ * Owns:
+ *  - Week navigation (prev / today / next, showing WEEKS_SHOWN columns at once)
+ *  - Filter by member (highlights matching cells in green, dims others)
+ *  - Renders RosterBoard with derived props
+ */
+
+import { useState, useMemo } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { RosterBoard } from "./roster-board";
+import type { RosterBoardProps } from "./roster-board";
+
+const WEEKS_SHOWN = 5;
+
+function getMondayOfWeek(d: Date): Date {
+  const date = new Date(d);
+  const day = date.getUTCDay(); // 0=Sun
+  const diff = day === 0 ? -6 : 1 - day;
+  date.setUTCDate(date.getUTCDate() + diff);
+  date.setUTCHours(0, 0, 0, 0);
+  return date;
+}
+
+function addWeeks(date: Date, n: number): Date {
+  const d = new Date(date);
+  d.setUTCDate(d.getUTCDate() + n * 7);
+  return d;
+}
+
+function formatWeekRange(monday: Date): string {
+  const sunday = new Date(monday);
+  sunday.setUTCDate(monday.getUTCDate() + 6);
+  const fmt = (d: Date) =>
+    `${d.getUTCDate()}/${d.getUTCMonth() + 1}`;
+  return `${fmt(monday)} - ${fmt(sunday)}`;
+}
+
+type Props = Omit<RosterBoardProps, "weekStarts" | "todayMonday" | "onFilterChange"> & {
+  filterMembershipId: string | null;
+  onFilterChange?: (id: string | null) => void;
+};
+
+export function RosterClient({
+  filterMembershipId,
+  onFilterChange,
+  ...boardProps
+}: Props) {
+  // Anchor: the Monday of the leftmost visible column
+  const [anchorMonday, setAnchorMonday] = useState<Date>(() =>
+    getMondayOfWeek(new Date()),
+  );
+
+  const weekStarts = useMemo(() => {
+    return Array.from({ length: WEEKS_SHOWN }, (_, i) =>
+      addWeeks(anchorMonday, i),
+    );
+  }, [anchorMonday]);
+
+  const todayMonday = getMondayOfWeek(new Date()).getTime();
+
+  function goToToday() {
+    setAnchorMonday(getMondayOfWeek(new Date()));
+  }
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      {/* Week navigation toolbar */}
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-border shrink-0">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setAnchorMonday((d) => addWeeks(d, -1))}
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <Button variant="outline" size="sm" onClick={goToToday}>
+          Today
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setAnchorMonday((d) => addWeeks(d, 1))}
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+
+        {/* Week range labels */}
+        <div className="flex gap-1 ml-2 text-xs text-muted-foreground">
+          {weekStarts.map((w) => (
+            <span
+              key={w.getTime()}
+              className="w-[160px] text-center font-medium truncate"
+            >
+              {formatWeekRange(w)}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Board */}
+      <div className="flex-1 overflow-auto">
+        <RosterBoard
+          {...boardProps}
+          weekStarts={weekStarts}
+          todayMonday={todayMonday}
+          filterMembershipId={filterMembershipId ?? null}
+          onFilterChange={onFilterChange ?? (() => {})}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-page-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-page-client.tsx
@@ -40,6 +40,7 @@ function getTodayDayIndex(tz: string): number {
 }
 
 type Role = { id: string; name: string; color: string };
+type RosterTemplate = { id: string; name: string; cycleWeeks: number };
 
 interface RosterPageClientProps {
   orgId: string;
@@ -47,6 +48,7 @@ interface RosterPageClientProps {
   dayConfigs: DayConfigRow[];
   members: OrgMember[];
   roles: Role[];
+  templates: RosterTemplate[];
   canManage: boolean;
   orgOpenTimeMin: number | null;
   orgCloseTimeMin: number | null;
@@ -59,6 +61,7 @@ export function RosterPageClient({
   dayConfigs,
   members,
   roles,
+  templates,
   canManage,
   orgOpenTimeMin,
   orgCloseTimeMin,
@@ -88,6 +91,7 @@ export function RosterPageClient({
           <RosterSidebarContent
             orgId={orgId}
             roles={roles}
+            templates={templates}
             canManage={canManage}
             members={members}
             filterMembershipId={filterMembershipId}

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-page-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-page-client.tsx
@@ -1,22 +1,56 @@
 "use client";
 
 /**
- * RosterPageClient — owns the filter state so it can be shared between
- * the page sidebar (filter list) and the board (highlight cells).
- * Registers its own sidebar so it can pass live filter state down.
+ * RosterPageClient — owns week-nav and filter state.
+ * Renders the Toolbar (nav only) and the board.
  */
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Toolbar } from "@/components/layout/toolbar";
 import { RegisterPageSidebar } from "@/components/layout/page-sidebar-context";
 import { RosterSidebarContent } from "./roster-sidebar-content";
 import { RosterClient } from "./roster-client";
 import type { RosterEntryRow, DayConfigRow, OrgMember } from "./roster-board";
+
+const WEEKS_SHOWN = 5;
+
+function getMondayOfWeek(d: Date): Date {
+  const date = new Date(d);
+  const day = date.getUTCDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  date.setUTCDate(date.getUTCDate() + diff);
+  date.setUTCHours(0, 0, 0, 0);
+  return date;
+}
+
+function addWeeks(date: Date, n: number): Date {
+  const d = new Date(date);
+  d.setUTCDate(d.getUTCDate() + n * 7);
+  return d;
+}
+
+/** Returns 0=Mon … 6=Sun for today in the given IANA timezone. */
+function getTodayDayIndex(tz: string): number {
+  const localDate = new Date().toLocaleDateString("en-CA", { timeZone: tz }); // YYYY-MM-DD
+  const d = new Date(localDate + "T12:00:00Z"); // noon UTC to avoid DST edge cases
+  const jsDay = d.getUTCDay(); // 0=Sun … 6=Sat
+  return jsDay === 0 ? 6 : jsDay - 1;
+}
+
+type Role = { id: string; name: string; color: string };
 
 interface RosterPageClientProps {
   orgId: string;
   entries: RosterEntryRow[];
   dayConfigs: DayConfigRow[];
   members: OrgMember[];
+  roles: Role[];
+  canManage: boolean;
+  orgOpenTimeMin: number | null;
+  orgCloseTimeMin: number | null;
+  orgTimezone: string;
 }
 
 export function RosterPageClient({
@@ -24,10 +58,28 @@ export function RosterPageClient({
   entries,
   dayConfigs,
   members,
+  roles,
+  canManage,
+  orgOpenTimeMin,
+  orgCloseTimeMin,
+  orgTimezone,
 }: RosterPageClientProps) {
+  const [anchorMonday, setAnchorMonday] = useState<Date>(() =>
+    getMondayOfWeek(new Date()),
+  );
   const [filterMembershipId, setFilterMembershipId] = useState<string | null>(
     null,
   );
+
+  const weekStarts = useMemo(
+    () =>
+      Array.from({ length: WEEKS_SHOWN }, (_, i) => addWeeks(anchorMonday, i)),
+    [anchorMonday],
+  );
+
+  const todayMonday = getMondayOfWeek(new Date()).getTime();
+  const todayDayIndex = getTodayDayIndex(orgTimezone);
+  const isTodayInView = anchorMonday.getTime() === todayMonday;
 
   return (
     <>
@@ -35,6 +87,8 @@ export function RosterPageClient({
         content={
           <RosterSidebarContent
             orgId={orgId}
+            roles={roles}
+            canManage={canManage}
             members={members}
             filterMembershipId={filterMembershipId}
             onFilterChange={setFilterMembershipId}
@@ -42,12 +96,42 @@ export function RosterPageClient({
         }
       />
 
+      <Toolbar>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setAnchorMonday((d) => addWeeks(d, -1))}
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={isTodayInView}
+          onClick={() => setAnchorMonday(getMondayOfWeek(new Date()))}
+        >
+          Today
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setAnchorMonday((d) => addWeeks(d, 1))}
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </Toolbar>
+
       <RosterClient
         orgId={orgId}
         entries={entries}
         dayConfigs={dayConfigs}
         members={members}
+        weekStarts={weekStarts}
+        todayMonday={todayMonday}
+        todayDayIndex={todayDayIndex}
         filterMembershipId={filterMembershipId}
+        orgOpenTimeMin={orgOpenTimeMin}
+        orgCloseTimeMin={orgCloseTimeMin}
       />
     </>
   );

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-page-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-page-client.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * RosterPageClient — owns the filter state so it can be shared between
+ * the page sidebar (filter list) and the board (highlight cells).
+ * Registers its own sidebar so it can pass live filter state down.
+ */
+
+import { useState } from "react";
+import { RegisterPageSidebar } from "@/components/layout/page-sidebar-context";
+import { RosterSidebarContent } from "./roster-sidebar-content";
+import { RosterClient } from "./roster-client";
+import type { RosterEntryRow, DayConfigRow, OrgMember } from "./roster-board";
+
+interface RosterPageClientProps {
+  orgId: string;
+  entries: RosterEntryRow[];
+  dayConfigs: DayConfigRow[];
+  members: OrgMember[];
+}
+
+export function RosterPageClient({
+  orgId,
+  entries,
+  dayConfigs,
+  members,
+}: RosterPageClientProps) {
+  const [filterMembershipId, setFilterMembershipId] = useState<string | null>(
+    null,
+  );
+
+  return (
+    <>
+      <RegisterPageSidebar
+        content={
+          <RosterSidebarContent
+            orgId={orgId}
+            members={members}
+            filterMembershipId={filterMembershipId}
+            onFilterChange={setFilterMembershipId}
+          />
+        }
+      />
+
+      <RosterClient
+        orgId={orgId}
+        entries={entries}
+        dayConfigs={dayConfigs}
+        members={members}
+        filterMembershipId={filterMembershipId}
+      />
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-sidebar-content.tsx
@@ -3,16 +3,21 @@
  */
 "use client";
 
+import { useRef } from "react";
 import { ArrowLeft, LayoutTemplate } from "lucide-react";
 import { SidebarNavItem } from "@/components/layout/sidebar-nav-item";
+import { Button } from "@/components/ui/button";
 import { MembersActions } from "../../../memberships/_components/action-sidebar/members-panel-triggers";
 import {
   SearchableCombobox,
   type ComboboxItem,
 } from "@/components/ui/searchable-combobox";
+import { useActionSidebar } from "@/components/layout/action-sidebar-context";
+import { ApplyTemplatePanel } from "./apply-template-panel";
 
 type Role = { id: string; name: string; color: string };
 type OrgMember = { id: string; botName: string | null; user: { name: string | null } | null };
+type RosterTemplate = { id: string; name: string; cycleWeeks: number };
 
 function memberName(m: OrgMember): string {
   return m.botName ?? m.user?.name ?? "Unknown";
@@ -21,6 +26,7 @@ function memberName(m: OrgMember): string {
 interface RosterSidebarContentProps {
   orgId: string;
   roles: Role[];
+  templates: RosterTemplate[];
   canManage: boolean;
   members: OrgMember[];
   filterMembershipId: string | null;
@@ -30,11 +36,15 @@ interface RosterSidebarContentProps {
 export function RosterSidebarContent({
   orgId,
   roles,
+  templates,
   canManage,
   members,
   filterMembershipId,
   onFilterChange,
 }: RosterSidebarContentProps) {
+  const { open, close, activeTitle } = useActionSidebar();
+  const applyKeyRef = useRef(0);
+
   const filterItems: ComboboxItem[] = [
     { id: "", name: "All members" },
     ...members.map((m) => ({ id: m.id, name: memberName(m) })),
@@ -45,6 +55,15 @@ export function RosterSidebarContent({
   function handleFilterSelect(item: ComboboxItem) {
     onFilterChange(item.id === "" ? null : item.id);
   }
+
+  function openApplyTemplate() {
+    const k = ++applyKeyRef.current;
+    open(
+      "Apply Template",
+      <ApplyTemplatePanel key={k} orgId={orgId} templates={templates} />,
+    );
+  }
+
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Title row */}
@@ -79,6 +98,15 @@ export function RosterSidebarContent({
             Actions
           </p>
           <div className="flex flex-col gap-2">
+            <Button
+              variant={activeTitle === "Apply Template" ? "default" : "outline"}
+              size="sm"
+              className="w-full justify-start gap-2"
+              onClick={openApplyTemplate}
+            >
+              <LayoutTemplate className="h-4 w-4 shrink-0" />
+              Apply Template
+            </Button>
             <MembersActions orgId={orgId} roles={roles} />
           </div>
         </div>

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-sidebar-content.tsx
@@ -42,7 +42,7 @@ export function RosterSidebarContent({
   filterMembershipId,
   onFilterChange,
 }: RosterSidebarContentProps) {
-  const { open, close, activeTitle } = useActionSidebar();
+  const { open, activeTitle } = useActionSidebar();
   const applyKeyRef = useRef(0);
 
   const filterItems: ComboboxItem[] = [

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-sidebar-content.tsx
@@ -1,16 +1,34 @@
 /**
  * RosterSidebarContent — page sidebar for `/orgs/[orgId]/tools/roster`.
- *
- * Follows the same pattern as `ItemListSidebarContent` and
- * `ConversionSidebarContent`: title row + Back link to the Tools hub.
- * Actions will be added here once the Roster feature is implemented.
  */
 "use client";
 
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, LayoutTemplate } from "lucide-react";
 
-export function RosterSidebarContent({ orgId }: { orgId: string }) {
+type OrgMember = {
+  id: string;
+  botName: string | null;
+  user: { name: string | null } | null;
+};
+
+interface RosterSidebarContentProps {
+  orgId: string;
+  members?: OrgMember[];
+  filterMembershipId?: string | null;
+  onFilterChange?: (id: string | null) => void;
+}
+
+function memberName(m: OrgMember): string {
+  return m.botName ?? m.user?.name ?? "Unknown";
+}
+
+export function RosterSidebarContent({
+  orgId,
+  members = [],
+  filterMembershipId,
+  onFilterChange,
+}: RosterSidebarContentProps) {
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Title row */}
@@ -28,6 +46,51 @@ export function RosterSidebarContent({ orgId }: { orgId: string }) {
         <ArrowLeft className="h-4 w-4" />
         Back
       </Link>
+
+      {/* Templates */}
+      <Link
+        href={`/orgs/${orgId}/tools/roster/templates`}
+        className="flex items-center gap-2 h-12 px-4 text-sm border-b border-border text-sidebar-foreground/70 hover:text-sidebar-foreground transition-colors shrink-0"
+      >
+        <LayoutTemplate className="h-4 w-4" />
+        Templates
+      </Link>
+
+      {/* Filters */}
+      {members.length > 0 && onFilterChange && (
+        <div className="flex flex-col gap-2 px-4 py-3 border-b border-border shrink-0">
+          <span className="text-[10px] font-medium uppercase tracking-wider text-sidebar-foreground/50">
+            Filter
+          </span>
+          <div className="flex flex-col gap-1">
+            <button
+              className={`text-xs text-left px-2 py-1 rounded transition-colors ${
+                filterMembershipId === null
+                  ? "bg-primary/10 font-semibold text-primary"
+                  : "text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-muted/50"
+              }`}
+              onClick={() => onFilterChange(null)}
+            >
+              All members
+            </button>
+            {members.map((m) => (
+              <button
+                key={m.id}
+                className={`text-xs text-left px-2 py-1 rounded transition-colors ${
+                  filterMembershipId === m.id
+                    ? "bg-green-100 dark:bg-green-900/40 font-semibold text-green-800 dark:text-green-300"
+                    : "text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-muted/50"
+                }`}
+                onClick={() =>
+                  onFilterChange(filterMembershipId === m.id ? null : m.id)
+                }
+              >
+                {memberName(m)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/(app)/orgs/[orgId]/tools/roster/_components/roster-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/_components/roster-sidebar-content.tsx
@@ -3,32 +3,48 @@
  */
 "use client";
 
-import Link from "next/link";
 import { ArrowLeft, LayoutTemplate } from "lucide-react";
+import { SidebarNavItem } from "@/components/layout/sidebar-nav-item";
+import { MembersActions } from "../../../memberships/_components/action-sidebar/members-panel-triggers";
+import {
+  SearchableCombobox,
+  type ComboboxItem,
+} from "@/components/ui/searchable-combobox";
 
-type OrgMember = {
-  id: string;
-  botName: string | null;
-  user: { name: string | null } | null;
-};
-
-interface RosterSidebarContentProps {
-  orgId: string;
-  members?: OrgMember[];
-  filterMembershipId?: string | null;
-  onFilterChange?: (id: string | null) => void;
-}
+type Role = { id: string; name: string; color: string };
+type OrgMember = { id: string; botName: string | null; user: { name: string | null } | null };
 
 function memberName(m: OrgMember): string {
   return m.botName ?? m.user?.name ?? "Unknown";
 }
 
+interface RosterSidebarContentProps {
+  orgId: string;
+  roles: Role[];
+  canManage: boolean;
+  members: OrgMember[];
+  filterMembershipId: string | null;
+  onFilterChange: (id: string | null) => void;
+}
+
 export function RosterSidebarContent({
   orgId,
-  members = [],
+  roles,
+  canManage,
+  members,
   filterMembershipId,
   onFilterChange,
 }: RosterSidebarContentProps) {
+  const filterItems: ComboboxItem[] = [
+    { id: "", name: "All members" },
+    ...members.map((m) => ({ id: m.id, name: memberName(m) })),
+  ];
+  const selectedMember = members.find((m) => m.id === filterMembershipId);
+  const filterLabel = selectedMember ? memberName(selectedMember) : "All members";
+
+  function handleFilterSelect(item: ComboboxItem) {
+    onFilterChange(item.id === "" ? null : item.id);
+  }
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Title row */}
@@ -39,58 +55,47 @@ export function RosterSidebarContent({
       </div>
 
       {/* Back */}
-      <Link
-        href={`/orgs/${orgId}/tools`}
-        className="flex items-center gap-2 h-12 px-4 text-sm border-b border-border text-sidebar-foreground/70 hover:text-sidebar-foreground transition-colors shrink-0"
-      >
-        <ArrowLeft className="h-4 w-4" />
-        Back
-      </Link>
+      <SidebarNavItem
+        title="Back"
+        url={`/orgs/${orgId}/tools`}
+        icon={ArrowLeft}
+        isActive={false}
+        variant="page"
+      />
 
       {/* Templates */}
-      <Link
-        href={`/orgs/${orgId}/tools/roster/templates`}
-        className="flex items-center gap-2 h-12 px-4 text-sm border-b border-border text-sidebar-foreground/70 hover:text-sidebar-foreground transition-colors shrink-0"
-      >
-        <LayoutTemplate className="h-4 w-4" />
-        Templates
-      </Link>
+      <SidebarNavItem
+        title="Templates"
+        url={`/orgs/${orgId}/tools/roster/templates`}
+        icon={LayoutTemplate}
+        isActive={false}
+        variant="page"
+      />
 
-      {/* Filters */}
-      {members.length > 0 && onFilterChange && (
-        <div className="flex flex-col gap-2 px-4 py-3 border-b border-border shrink-0">
-          <span className="text-[10px] font-medium uppercase tracking-wider text-sidebar-foreground/50">
-            Filter
-          </span>
-          <div className="flex flex-col gap-1">
-            <button
-              className={`text-xs text-left px-2 py-1 rounded transition-colors ${
-                filterMembershipId === null
-                  ? "bg-primary/10 font-semibold text-primary"
-                  : "text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-muted/50"
-              }`}
-              onClick={() => onFilterChange(null)}
-            >
-              All members
-            </button>
-            {members.map((m) => (
-              <button
-                key={m.id}
-                className={`text-xs text-left px-2 py-1 rounded transition-colors ${
-                  filterMembershipId === m.id
-                    ? "bg-green-100 dark:bg-green-900/40 font-semibold text-green-800 dark:text-green-300"
-                    : "text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-muted/50"
-                }`}
-                onClick={() =>
-                  onFilterChange(filterMembershipId === m.id ? null : m.id)
-                }
-              >
-                {memberName(m)}
-              </button>
-            ))}
+      {/* Actions */}
+      {canManage && (
+        <div className="px-3 pt-3 pb-3 border-t border-border">
+          <p className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider px-1 mb-2">
+            Actions
+          </p>
+          <div className="flex flex-col gap-2">
+            <MembersActions orgId={orgId} roles={roles} />
           </div>
         </div>
       )}
+
+      {/* Filter */}
+      <div className="px-3 pt-3 pb-3 border-t border-border">
+        <p className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider px-1 mb-2">
+          Filter
+        </p>
+        <SearchableCombobox
+          items={filterItems}
+          onSelect={handleFilterSelect}
+          triggerLabel={filterLabel}
+          placeholder="Search members…"
+        />
+      </div>
     </div>
   );
 }

--- a/app/(app)/orgs/[orgId]/tools/roster/_utils/time-utils.ts
+++ b/app/(app)/orgs/[orgId]/tools/roster/_utils/time-utils.ts
@@ -1,9 +1,17 @@
+/**
+ * Formats an integer minute offset (0–1440) as a zero-padded "HH:MM" string.
+ * e.g. 90 → "01:30", 1440 → "24:00"
+ */
 export function formatMinutes(min: number): string {
   const h = Math.floor(min / 60).toString().padStart(2, "0");
   const m = (min % 60).toString().padStart(2, "0");
   return `${h}:${m}`;
 }
 
+/**
+ * Returns a human-readable duration string (e.g. "7h 30m" or "8h") given start/end
+ * minute offsets. Returns "" when either value is null or the duration is ≤ 0.
+ */
 export function hoursWorked(startMin: number | null, endMin: number | null): string {
   if (startMin === null || endMin === null) return "";
   const diff = endMin - startMin;
@@ -13,6 +21,10 @@ export function hoursWorked(startMin: number | null, endMin: number | null): str
   return m > 0 ? `${h}h ${m}m` : `${h}h`;
 }
 
+/**
+ * Parses a "HH:MM" time string into a minute offset. Returns null for empty
+ * strings, malformed input, or non-numeric segments.
+ */
 export function timeToMinutes(time: string): number | null {
   if (!time) return null;
   const parts = time.split(":");

--- a/app/(app)/orgs/[orgId]/tools/roster/_utils/time-utils.ts
+++ b/app/(app)/orgs/[orgId]/tools/roster/_utils/time-utils.ts
@@ -1,0 +1,21 @@
+export function formatMinutes(min: number): string {
+  const h = Math.floor(min / 60).toString().padStart(2, "0");
+  const m = (min % 60).toString().padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+export function hoursWorked(startMin: number | null, endMin: number | null): string {
+  if (startMin === null || endMin === null) return "";
+  const diff = endMin - startMin;
+  if (diff <= 0) return "";
+  const h = Math.floor(diff / 60);
+  const m = diff % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+export function timeToMinutes(time: string): number | null {
+  if (!time) return null;
+  const [h, m] = time.split(":").map(Number);
+  if (isNaN(h) || isNaN(m)) return null;
+  return h * 60 + m;
+}

--- a/app/(app)/orgs/[orgId]/tools/roster/_utils/time-utils.ts
+++ b/app/(app)/orgs/[orgId]/tools/roster/_utils/time-utils.ts
@@ -15,7 +15,9 @@ export function hoursWorked(startMin: number | null, endMin: number | null): str
 
 export function timeToMinutes(time: string): number | null {
   if (!time) return null;
-  const [h, m] = time.split(":").map(Number);
+  const parts = time.split(":");
+  if (parts.length !== 2) return null;
+  const [h, m] = parts.map(Number);
   if (isNaN(h) || isNaN(m)) return null;
   return h * 60 + m;
 }

--- a/app/(app)/orgs/[orgId]/tools/roster/page.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/page.tsx
@@ -10,6 +10,7 @@ import {
   getRosterDayConfigs,
   getOrgMembersForRoster,
   getOrgSchedule,
+  getRosterTemplates,
 } from "@/lib/services/roster";
 import { RosterPageClient } from "./_components/roster-page-client";
 
@@ -39,7 +40,7 @@ export default async function RosterPage({
 
   const weekStarts = getInitialWeekStarts();
 
-  const [entries, dayConfigs, members, membership, roles, orgSchedule] =
+  const [entries, dayConfigs, members, membership, roles, orgSchedule, templates] =
     await Promise.all([
       getRosterEntries(orgId, weekStarts),
       getRosterDayConfigs(orgId),
@@ -47,6 +48,7 @@ export default async function RosterPage({
       getOrgMembership(orgId, userId),
       getRoles(orgId),
       getOrgSchedule(orgId),
+      getRosterTemplates(orgId),
     ]);
 
   const canManage = membership
@@ -64,6 +66,7 @@ export default async function RosterPage({
       dayConfigs={dayConfigs}
       members={members}
       roles={roles.map((r) => ({ id: r.id, name: r.name, color: r.color }))}
+      templates={templates.map((t) => ({ id: t.id, name: t.name, cycleWeeks: t.cycleWeeks }))}
       canManage={canManage}
       orgOpenTimeMin={orgSchedule.openTimeMin}
       orgCloseTimeMin={orgSchedule.closeTimeMin}

--- a/app/(app)/orgs/[orgId]/tools/roster/page.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/page.tsx
@@ -55,7 +55,7 @@ export default async function RosterPage({
     ? await memberHasPermission(
         membership.id,
         orgId,
-        PermissionAction.MANAGE_MEMBERS,
+        PermissionAction.MANAGE_TIMETABLE,
       )
     : false;
 

--- a/app/(app)/orgs/[orgId]/tools/roster/page.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/page.tsx
@@ -2,11 +2,14 @@
  * RosterPage — fetches roster data and renders the interactive board.
  */
 import { requireOrgMemberPage } from "@/lib/authz";
-import { Toolbar } from "@/components/layout/toolbar";
+import { memberHasPermission, getOrgMembership } from "@/lib/authz/_shared";
+import { PermissionAction } from "@prisma/client";
+import { getRoles } from "@/lib/services/roles";
 import {
   getRosterEntries,
   getRosterDayConfigs,
   getOrgMembersForRoster,
+  getOrgSchedule,
 } from "@/lib/services/roster";
 import { RosterPageClient } from "./_components/roster-page-client";
 
@@ -32,28 +35,39 @@ export default async function RosterPage({
   params: Promise<{ orgId: string }>;
 }) {
   const { orgId } = await params;
-  await requireOrgMemberPage(orgId);
+  const { userId } = await requireOrgMemberPage(orgId);
 
   const weekStarts = getInitialWeekStarts();
 
-  const [entries, dayConfigs, members] = await Promise.all([
-    getRosterEntries(orgId, weekStarts),
-    getRosterDayConfigs(orgId),
-    getOrgMembersForRoster(orgId),
-  ]);
+  const [entries, dayConfigs, members, membership, roles, orgSchedule] =
+    await Promise.all([
+      getRosterEntries(orgId, weekStarts),
+      getRosterDayConfigs(orgId),
+      getOrgMembersForRoster(orgId),
+      getOrgMembership(orgId, userId),
+      getRoles(orgId),
+      getOrgSchedule(orgId),
+    ]);
+
+  const canManage = membership
+    ? await memberHasPermission(
+        membership.id,
+        orgId,
+        PermissionAction.MANAGE_MEMBERS,
+      )
+    : false;
 
   return (
-    <>
-      <Toolbar>
-        <h1 className="text-sm font-semibold">Roster</h1>
-      </Toolbar>
-
-      <RosterPageClient
-        orgId={orgId}
-        entries={entries}
-        dayConfigs={dayConfigs}
-        members={members}
-      />
-    </>
+    <RosterPageClient
+      orgId={orgId}
+      entries={entries}
+      dayConfigs={dayConfigs}
+      members={members}
+      roles={roles.map((r) => ({ id: r.id, name: r.name, color: r.color }))}
+      canManage={canManage}
+      orgOpenTimeMin={orgSchedule.openTimeMin}
+      orgCloseTimeMin={orgSchedule.closeTimeMin}
+      orgTimezone={orgSchedule.timezone}
+    />
   );
 }

--- a/app/(app)/orgs/[orgId]/tools/roster/page.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/page.tsx
@@ -1,14 +1,30 @@
 /**
- * RosterPage — stub page for the Roster tool.
- *
- * Registers `RosterSidebarContent` as the page sidebar so the Back link and
- * title row are rendered. Content is a placeholder until the Roster feature
- * is implemented.
+ * RosterPage — fetches roster data and renders the interactive board.
  */
 import { requireOrgMemberPage } from "@/lib/authz";
-import { RegisterPageSidebar } from "@/components/layout/page-sidebar-context";
-import { RosterSidebarContent } from "./_components/roster-sidebar-content";
 import { Toolbar } from "@/components/layout/toolbar";
+import {
+  getRosterEntries,
+  getRosterDayConfigs,
+  getOrgMembersForRoster,
+} from "@/lib/services/roster";
+import { RosterPageClient } from "./_components/roster-page-client";
+
+// Pre-fetch 8 weeks centred on today so the initial render has data
+// without a client round-trip. The client can navigate further freely.
+function getInitialWeekStarts(): Date[] {
+  const today = new Date();
+  const day = today.getUTCDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  const monday = new Date(today);
+  monday.setUTCDate(today.getUTCDate() + diff);
+  monday.setUTCHours(0, 0, 0, 0);
+  return Array.from({ length: 8 }, (_, i) => {
+    const d = new Date(monday);
+    d.setUTCDate(monday.getUTCDate() + i * 7);
+    return d;
+  });
+}
 
 export default async function RosterPage({
   params,
@@ -18,16 +34,26 @@ export default async function RosterPage({
   const { orgId } = await params;
   await requireOrgMemberPage(orgId);
 
+  const weekStarts = getInitialWeekStarts();
+
+  const [entries, dayConfigs, members] = await Promise.all([
+    getRosterEntries(orgId, weekStarts),
+    getRosterDayConfigs(orgId),
+    getOrgMembersForRoster(orgId),
+  ]);
+
   return (
     <>
-      <RegisterPageSidebar content={<RosterSidebarContent orgId={orgId} />} />
       <Toolbar>
         <h1 className="text-sm font-semibold">Roster</h1>
       </Toolbar>
 
-      <div className="flex flex-col items-center justify-center py-20 text-center">
-        <p className="text-sm text-muted-foreground">No roster entries yet.</p>
-      </div>
+      <RosterPageClient
+        orgId={orgId}
+        entries={entries}
+        dayConfigs={dayConfigs}
+        members={members}
+      />
     </>
   );
 }

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/edit-template-cell-panel.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/edit-template-cell-panel.tsx
@@ -9,6 +9,7 @@ import { SearchableCombobox } from "@/components/ui/searchable-combobox";
 import { setRosterTemplateCellMembersAction } from "@/app/actions/roster";
 import { useActionSidebar } from "@/components/layout/action-sidebar-context";
 import type { OrgMember } from "@/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board";
+import { formatMinutes, hoursWorked, timeToMinutes } from "@/app/(app)/orgs/[orgId]/tools/roster/_utils/time-utils";
 
 function memberDisplayName(m: OrgMember): string {
   return m.botName ?? m.user?.name ?? "Unknown";
@@ -16,25 +17,11 @@ function memberDisplayName(m: OrgMember): string {
 
 function minToTime(min: number | null): string {
   if (min === null) return "";
-  const h = Math.floor(min / 60).toString().padStart(2, "0");
-  const m = (min % 60).toString().padStart(2, "0");
-  return `${h}:${m}`;
+  return formatMinutes(min);
 }
 
 function timeToMin(time: string): number | null {
-  if (!time) return null;
-  const [h, m] = time.split(":").map(Number);
-  if (isNaN(h) || isNaN(m)) return null;
-  return h * 60 + m;
-}
-
-function hoursWorked(startMin: number | null, endMin: number | null): string {
-  if (startMin === null || endMin === null) return "";
-  const diff = endMin - startMin;
-  if (diff <= 0) return "";
-  const h = Math.floor(diff / 60);
-  const m = diff % 60;
-  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  return timeToMinutes(time);
 }
 
 type MemberShift = {

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/edit-template-cell-panel.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/edit-template-cell-panel.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { Minus, Loader2 } from "lucide-react";
 import { toast } from "sonner";
-import { Minus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SearchableCombobox } from "@/components/ui/searchable-combobox";
-import { setRosterCellMembersAction } from "@/app/actions/roster";
+import { setRosterTemplateCellMembersAction } from "@/app/actions/roster";
 import { useActionSidebar } from "@/components/layout/action-sidebar-context";
-import type { RosterEntryRow, OrgMember, DayConfigRow } from "./roster-board";
+import type { OrgMember } from "@/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board";
 
 function memberDisplayName(m: OrgMember): string {
   return m.botName ?? m.user?.name ?? "Unknown";
@@ -39,36 +39,49 @@ function hoursWorked(startMin: number | null, endMin: number | null): string {
 
 type MemberShift = {
   membershipId: string;
-  startTime: string; // "HH:MM"
+  startTime: string;
   endTime: string;
 };
 
-interface EditCellPanelProps {
+export type TemplateEntryRow = {
+  id: string;
+  membershipId: string;
+  weekIndex: number;
+  dayIndex: number;
+  shiftStartMin: number | null;
+  shiftEndMin: number | null;
+  membership: {
+    id: string;
+    botName: string | null;
+    user: { name: string | null } | null;
+  };
+};
+
+interface EditTemplateCellPanelProps {
   orgId: string;
-  weekStart: Date;
+  templateId: string;
+  weekIndex: number;
   dayIndex: number;
   members: OrgMember[];
-  currentEntries: RosterEntryRow[];
-  dayConfig: DayConfigRow | null;
+  currentEntries: TemplateEntryRow[];
   orgOpenTimeMin: number | null;
   orgCloseTimeMin: number | null;
 }
 
-export function EditCellPanel({
+export function EditTemplateCellPanel({
   orgId,
-  weekStart,
+  templateId,
+  weekIndex,
   dayIndex,
   members,
   currentEntries,
-  dayConfig,
   orgOpenTimeMin,
   orgCloseTimeMin,
-}: EditCellPanelProps) {
+}: EditTemplateCellPanelProps) {
   const { close } = useActionSidebar();
 
-  // Default shift = day config times, falling back to org times
-  const defaultStart = minToTime(dayConfig?.openTimeMin ?? orgOpenTimeMin);
-  const defaultEnd = minToTime(dayConfig?.closeTimeMin ?? orgCloseTimeMin);
+  const defaultStart = minToTime(orgOpenTimeMin);
+  const defaultEnd = minToTime(orgCloseTimeMin);
 
   const [shifts, setShifts] = useState<MemberShift[]>(
     currentEntries.map((e) => ({
@@ -101,9 +114,10 @@ export function EditCellPanel({
 
   function handleSave() {
     startTransition(async () => {
-      const result = await setRosterCellMembersAction(
+      const result = await setRosterTemplateCellMembersAction(
         orgId,
-        weekStart,
+        templateId,
+        weekIndex,
         dayIndex,
         shifts.map((s) => ({
           membershipId: s.membershipId,
@@ -121,7 +135,6 @@ export function EditCellPanel({
 
   return (
     <div className="flex flex-col gap-3 p-4">
-        {/* Member picker */}
         {available.length > 0 && (
           <SearchableCombobox
             items={available.map((m) => ({ id: m.id, name: memberDisplayName(m) }))}
@@ -131,11 +144,8 @@ export function EditCellPanel({
           />
         )}
 
-        {/* Rostered members with shift times */}
         {shifts.length === 0 ? (
-          <p className="text-xs text-muted-foreground py-2">
-            No members rostered.
-          </p>
+          <p className="text-xs text-muted-foreground py-2">No members assigned.</p>
         ) : (
           shifts.map((s) => {
             const member = members.find((m) => m.id === s.membershipId);
@@ -174,7 +184,7 @@ export function EditCellPanel({
                   </div>
                 </div>
                 {worked && (
-                  <p className="text-xs text-muted-foreground text-right">{worked}</p>
+                  <span className="text-[10px] text-muted-foreground">{worked}</span>
                 )}
               </div>
             );
@@ -186,7 +196,7 @@ export function EditCellPanel({
           Cancel
         </Button>
         <Button size="sm" onClick={handleSave} disabled={isPending}>
-          {isPending ? "Saving…" : "Save"}
+          {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save"}
         </Button>
       </div>
     </div>

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/edit-template-cell-panel.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/edit-template-cell-panel.tsx
@@ -141,7 +141,7 @@ export function EditTemplateCellPanel({
             return (
               <div key={s.membershipId} className="flex flex-col gap-2 rounded-md border border-border p-2.5">
                 <div className="flex items-start justify-between gap-2">
-                  <span className="text-sm font-medium break-words min-w-0">{memberDisplayName(member)}</span>
+                  <span className="text-sm font-medium break-all min-w-0">{memberDisplayName(member)}</span>
                   <button
                     type="button"
                     onClick={() => removeMember(s.membershipId)}

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-board.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-board.tsx
@@ -12,23 +12,9 @@ import {
   type TemplateEntryRow,
 } from "./edit-template-cell-panel";
 import type { OrgMember } from "@/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board";
+import { formatMinutes, hoursWorked } from "@/app/(app)/orgs/[orgId]/tools/roster/_utils/time-utils";
 
 const DAY_ABBR = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
-
-function formatMinutes(min: number): string {
-  const h = Math.floor(min / 60).toString().padStart(2, "0");
-  const m = (min % 60).toString().padStart(2, "0");
-  return `${h}:${m}`;
-}
-
-function hoursWorked(startMin: number | null, endMin: number | null): string {
-  if (startMin === null || endMin === null) return "";
-  const diff = endMin - startMin;
-  if (diff <= 0) return "";
-  const h = Math.floor(diff / 60);
-  const m = diff % 60;
-  return m > 0 ? `${h}h ${m}m` : `${h}h`;
-}
 
 export type RosterTemplateBoardProps = {
   orgId: string;

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-board.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-board.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useActionSidebar } from "@/components/layout/action-sidebar-context";
+import {
+  DAY_LABELS,
+  ROSTER_DAY_LABEL_WIDTH,
+  ROSTER_CELL_MIN_HEIGHT,
+} from "@/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board-constants";
+import {
+  EditTemplateCellPanel,
+  type TemplateEntryRow,
+} from "./edit-template-cell-panel";
+import type { OrgMember } from "@/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board";
+
+const DAY_ABBR = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+function formatMinutes(min: number): string {
+  const h = Math.floor(min / 60).toString().padStart(2, "0");
+  const m = (min % 60).toString().padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+function hoursWorked(startMin: number | null, endMin: number | null): string {
+  if (startMin === null || endMin === null) return "";
+  const diff = endMin - startMin;
+  if (diff <= 0) return "";
+  const h = Math.floor(diff / 60);
+  const m = diff % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+export type RosterTemplateBoardProps = {
+  orgId: string;
+  templateId: string;
+  entries: TemplateEntryRow[];
+  members: OrgMember[];
+  weekIndices: number[]; // e.g. [0, 1, 2] for a 3-week template
+  orgOpenTimeMin: number | null;
+  orgCloseTimeMin: number | null;
+};
+
+export function RosterTemplateBoard({
+  orgId,
+  templateId,
+  entries,
+  members,
+  weekIndices,
+  orgOpenTimeMin,
+  orgCloseTimeMin,
+}: RosterTemplateBoardProps) {
+  const sidebar = useActionSidebar();
+
+  // Build lookup: "weekIndex-dayIndex" → TemplateEntryRow[]
+  const cellMap = new Map<string, TemplateEntryRow[]>();
+  for (const entry of entries) {
+    const key = `${entry.weekIndex}-${entry.dayIndex}`;
+    const existing = cellMap.get(key) ?? [];
+    existing.push(entry);
+    cellMap.set(key, existing);
+  }
+
+  return (
+    <div className="w-full">
+      {/* ── Header row: week labels ── */}
+      <div className="flex border-b border-border bg-muted/30 sticky top-0 z-10">
+        <div
+          className="shrink-0 border-r border-border"
+          style={{ width: ROSTER_DAY_LABEL_WIDTH }}
+        />
+        {weekIndices.map((wi) => (
+          <div
+            key={wi}
+            className="flex-1 text-center text-xs font-medium py-2.5 border-r border-border text-muted-foreground"
+          >
+            Week {wi + 1}
+          </div>
+        ))}
+      </div>
+
+      {/* ── Day rows ── */}
+      {DAY_LABELS.map((label, dayIndex) => {
+        const isLastDay = dayIndex === DAY_LABELS.length - 1;
+
+        return (
+          <div
+            key={dayIndex}
+            className={cn("flex", isLastDay ? "" : "border-b border-border")}
+            style={{ minHeight: ROSTER_CELL_MIN_HEIGHT }}
+          >
+            {/* Day label (read-only in template mode) */}
+            <div
+              className="shrink-0 flex flex-col items-start justify-center gap-0.5 px-3 py-2 border-r border-border"
+              style={{ width: ROSTER_DAY_LABEL_WIDTH }}
+            >
+              <span className="text-sm font-semibold">{DAY_ABBR[dayIndex]}</span>
+              <span className="text-[10px] text-muted-foreground">{label}</span>
+            </div>
+
+            {/* Week cells */}
+            {weekIndices.map((wi) => {
+              const key = `${wi}-${dayIndex}`;
+              const cellEntries = cellMap.get(key) ?? [];
+              const isEmpty = cellEntries.length === 0;
+
+              return (
+                <button
+                  key={wi}
+                  className={cn(
+                    "group flex-1 flex flex-col items-start justify-start gap-1 px-2 py-2 border-r border-border text-left transition-colors cursor-pointer hover:brightness-[0.93] dark:hover:brightness-125 min-w-0",
+                    isEmpty ? "bg-muted/20" : "",
+                  )}
+                  onClick={() =>
+                    sidebar.open(
+                      `${label} — Week ${wi + 1}`,
+                      <EditTemplateCellPanel
+                        key={`${wi}-${dayIndex}`}
+                        orgId={orgId}
+                        templateId={templateId}
+                        weekIndex={wi}
+                        dayIndex={dayIndex}
+                        members={members}
+                        currentEntries={cellEntries}
+                        orgOpenTimeMin={orgOpenTimeMin}
+                        orgCloseTimeMin={orgCloseTimeMin}
+                      />,
+                    )
+                  }
+                >
+                  {isEmpty ? (
+                    <span className="text-xs text-muted-foreground/40 group-hover:text-muted-foreground/60 transition-colors mx-auto mt-auto mb-auto">
+                      —
+                    </span>
+                  ) : (
+                    cellEntries.map((e) => {
+                      const name =
+                        e.membership.botName ?? e.membership.user?.name ?? "?";
+                      return (
+                        <span
+                          key={e.id}
+                          className="inline-flex flex-col w-full rounded px-1.5 py-0.5 text-xs leading-tight truncate bg-background/70 dark:bg-white/8"
+                        >
+                          <span className="truncate">{name}</span>
+                          {e.shiftStartMin !== null && e.shiftEndMin !== null && (
+                            <span className="text-[10px] text-muted-foreground">
+                              {formatMinutes(e.shiftStartMin)}–{formatMinutes(e.shiftEndMin)}
+                              {" · "}
+                              {hoursWorked(e.shiftStartMin, e.shiftEndMin)}
+                            </span>
+                          )}
+                        </span>
+                      );
+                    })
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-editor-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-editor-client.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import { ArrowLeft, ChevronLeft, ChevronRight, Loader2, Minus, Plus, TriangleAlert } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Toolbar } from "@/components/layout/toolbar";
+import { RegisterPageSidebar } from "@/components/layout/page-sidebar-context";
+import { SidebarNavItem } from "@/components/layout/sidebar-nav-item";
+import {
+  updateRosterTemplateCycleWeeksAction,
+  clearRosterTemplateWeekAction,
+} from "@/app/actions/roster";
+import { RosterTemplateBoard } from "./roster-template-board";
+import {
+  ROSTER_CELL_WIDTH,
+  ROSTER_DAY_LABEL_WIDTH,
+} from "@/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board-constants";
+import type { OrgMember } from "@/app/(app)/orgs/[orgId]/tools/roster/_components/roster-board";
+import type { TemplateEntryRow } from "./edit-template-cell-panel";
+
+const MIN_CELL_WIDTH = ROSTER_CELL_WIDTH;
+
+interface RosterTemplateEditorSidebarProps {
+  orgId: string;
+  templateId: string;
+  templateName: string;
+  cycleWeeks: number;
+  entries: TemplateEntryRow[];
+  onCycleWeeksChange: (val: number) => void;
+  canManage: boolean;
+}
+
+function RosterTemplateEditorSidebar({
+  orgId,
+  templateId,
+  templateName,
+  cycleWeeks,
+  entries,
+  onCycleWeeksChange,
+  canManage,
+}: RosterTemplateEditorSidebarProps) {
+  const [isPending, startTransition] = useTransition();
+  const [confirmWeek, setConfirmWeek] = useState<number | null>(null);
+
+  function handleDecrement() {
+    const weekToRemove = cycleWeeks - 1; // 0-based last week
+    const hasEntries = entries.some((e) => e.weekIndex === weekToRemove);
+    if (hasEntries) {
+      setConfirmWeek(weekToRemove);
+    } else {
+      applyDecrement(weekToRemove, false);
+    }
+  }
+
+  function applyDecrement(weekToRemove: number, needsClear: boolean) {
+    const next = cycleWeeks - 1;
+    onCycleWeeksChange(next);
+    setConfirmWeek(null);
+    startTransition(async () => {
+      if (needsClear) {
+        const clearResult = await clearRosterTemplateWeekAction(orgId, templateId, weekToRemove);
+        if (!clearResult.ok) {
+          toast.error(clearResult.error ?? "Failed to clear week");
+          onCycleWeeksChange(cycleWeeks);
+          return;
+        }
+      }
+      const result = await updateRosterTemplateCycleWeeksAction(orgId, templateId, next);
+      if (!result.ok) {
+        toast.error(result.error ?? "Failed to update");
+        onCycleWeeksChange(cycleWeeks);
+      }
+    });
+  }
+
+  function handleIncrement() {
+    const next = cycleWeeks + 1;
+    if (next > 12) return;
+    onCycleWeeksChange(next);
+    startTransition(async () => {
+      const result = await updateRosterTemplateCycleWeeksAction(orgId, templateId, next);
+      if (!result.ok) {
+        toast.error(result.error ?? "Failed to update");
+        onCycleWeeksChange(cycleWeeks);
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <div className="h-12 flex items-center px-4 border-b border-border shrink-0">
+        <span className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider truncate">
+          {templateName}
+        </span>
+      </div>
+
+      <SidebarNavItem
+        title="Back to Templates"
+        url={`/orgs/${orgId}/tools/roster/templates`}
+        icon={ArrowLeft}
+        isActive={false}
+        variant="page"
+      />
+
+      {canManage && (
+        <div className="px-3 pt-3 pb-3 border-t border-border flex flex-col gap-3">
+          <p className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider px-1">
+            Actions
+          </p>
+
+          {/* Cycle weeks stepper */}
+          <div className="flex flex-col gap-1.5 px-1">
+            <span className="text-xs text-muted-foreground">Cycle weeks</span>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-7 w-7 shrink-0"
+                disabled={cycleWeeks <= 1 || isPending}
+                onClick={handleDecrement}
+              >
+                <Minus className="h-3 w-3" />
+              </Button>
+              <span className="flex-1 text-center text-sm font-medium tabular-nums">
+                {isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin mx-auto" />
+                ) : (
+                  cycleWeeks
+                )}
+              </span>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-7 w-7 shrink-0"
+                disabled={cycleWeeks >= 12 || isPending}
+                onClick={handleIncrement}
+              >
+                <Plus className="h-3 w-3" />
+              </Button>
+            </div>
+          </div>
+
+          {/* Inline confirm when last week has entries */}
+          {confirmWeek !== null && (
+            <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5 flex flex-col gap-2.5">
+              <div className="flex gap-2 items-start">
+                <TriangleAlert className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+                <p className="text-xs text-amber-800 dark:text-amber-300">
+                  Week {confirmWeek + 1} has shifts assigned. Removing it will delete all of them.
+                </p>
+              </div>
+              <div className="flex gap-1.5">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex-1 h-7 text-xs"
+                  onClick={() => setConfirmWeek(null)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  className="flex-1 h-7 text-xs bg-amber-600 hover:bg-amber-700 text-white border-0"
+                  onClick={() => applyDecrement(confirmWeek, true)}
+                  disabled={isPending}
+                >
+                  Remove
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface RosterTemplateEditorClientProps {
+  orgId: string;
+  templateId: string;
+  templateName: string;
+  cycleWeeks: number;
+  entries: TemplateEntryRow[];
+  members: OrgMember[];
+  canManage: boolean;
+  orgOpenTimeMin: number | null;
+  orgCloseTimeMin: number | null;
+}
+
+export function RosterTemplateEditorClient({
+  orgId,
+  templateId,
+  templateName,
+  cycleWeeks: initialCycleWeeks,
+  entries,
+  members,
+  canManage,
+  orgOpenTimeMin,
+  orgCloseTimeMin,
+}: RosterTemplateEditorClientProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [cycleWeeks, setCycleWeeks] = useState(initialCycleWeeks);
+  const [visibleCount, setVisibleCount] = useState(initialCycleWeeks);
+  const [weekOffset, setWeekOffset] = useState(0);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver(([entry]) => {
+      const width = entry.contentRect.width;
+      const count = Math.max(
+        1,
+        Math.floor((width - ROSTER_DAY_LABEL_WIDTH) / MIN_CELL_WIDTH),
+      );
+      setVisibleCount(count);
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  // Clamp offset when cycleWeeks shrinks
+  const maxOffset = Math.max(0, cycleWeeks - visibleCount);
+  const clampedOffset = Math.min(weekOffset, maxOffset);
+  if (clampedOffset !== weekOffset) setWeekOffset(clampedOffset);
+
+  const shown = Math.min(visibleCount, cycleWeeks);
+  const weekIndices = Array.from({ length: shown }, (_, i) => i + clampedOffset);
+  const canGoPrev = clampedOffset > 0;
+  const canGoNext = clampedOffset < maxOffset;
+
+  return (
+    <>
+      <RegisterPageSidebar
+        content={
+          <RosterTemplateEditorSidebar
+            orgId={orgId}
+            templateId={templateId}
+            templateName={templateName}
+            cycleWeeks={cycleWeeks}
+            entries={entries}
+            onCycleWeeksChange={setCycleWeeks}
+            canManage={canManage}
+          />
+        }
+      />
+
+      <Toolbar>
+        {maxOffset > 0 && (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!canGoPrev}
+              onClick={() => setWeekOffset((o) => Math.max(0, o - 1))}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm font-medium tabular-nums">
+              Week {clampedOffset + 1}–{clampedOffset + shown}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!canGoNext}
+              onClick={() => setWeekOffset((o) => Math.min(maxOffset, o + 1))}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </>
+        )}
+        <span className="text-sm font-medium">{templateName}</span>
+        <span className="text-xs text-muted-foreground">
+          {cycleWeeks === 1 ? "1-week cycle" : `${cycleWeeks}-week cycle`}
+        </span>
+      </Toolbar>
+
+      <div ref={containerRef} className="flex-1 overflow-auto p-4">
+        <div className="rounded-lg border border-border overflow-hidden">
+          <RosterTemplateBoard
+            orgId={orgId}
+            templateId={templateId}
+            entries={entries}
+            members={members}
+            weekIndices={weekIndices}
+            orgOpenTimeMin={orgOpenTimeMin}
+            orgCloseTimeMin={orgCloseTimeMin}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-editor-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-editor-client.tsx
@@ -219,17 +219,12 @@ export function RosterTemplateEditorClient({
     return () => obs.disconnect();
   }, []);
 
-  // Clamp offset when cycleWeeks shrinks
-  useEffect(() => {
-    const maxOffset = Math.max(0, cycleWeeks - visibleCount);
-    const clampedOffset = Math.min(weekOffset, maxOffset);
-    if (clampedOffset !== weekOffset) {
-      setWeekOffset(clampedOffset);
-    }
-  }, [cycleWeeks, visibleCount, weekOffset]);
-
   const maxOffset = Math.max(0, cycleWeeks - visibleCount);
   const clampedOffset = Math.min(weekOffset, maxOffset);
+  // Synchronously correct offset during render (avoids extra async re-render from useEffect)
+  if (weekOffset !== clampedOffset) {
+    setWeekOffset(clampedOffset);
+  }
 
   const shown = Math.min(visibleCount, cycleWeeks);
   const weekIndices = Array.from({ length: shown }, (_, i) => i + clampedOffset);

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-editor-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-editor-client.tsx
@@ -220,9 +220,16 @@ export function RosterTemplateEditorClient({
   }, []);
 
   // Clamp offset when cycleWeeks shrinks
+  useEffect(() => {
+    const maxOffset = Math.max(0, cycleWeeks - visibleCount);
+    const clampedOffset = Math.min(weekOffset, maxOffset);
+    if (clampedOffset !== weekOffset) {
+      setWeekOffset(clampedOffset);
+    }
+  }, [cycleWeeks, visibleCount, weekOffset]);
+
   const maxOffset = Math.max(0, cycleWeeks - visibleCount);
   const clampedOffset = Math.min(weekOffset, maxOffset);
-  if (clampedOffset !== weekOffset) setWeekOffset(clampedOffset);
 
   const shown = Math.min(visibleCount, cycleWeeks);
   const weekIndices = Array.from({ length: shown }, (_, i) => i + clampedOffset);

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-editor-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-editor-client.tsx
@@ -219,14 +219,6 @@ export function RosterTemplateEditorClient({
     return () => obs.disconnect();
   }, []);
 
-  // Clamp offset when cycleWeeks shrinks or visibleCount grows.
-  // Functional update avoids adding weekOffset to the dep array (which would
-  // cause a cascading effect chain on every offset change).
-  useEffect(() => {
-    const maxOffset = Math.max(0, cycleWeeks - visibleCount);
-    setWeekOffset((current) => Math.min(current, maxOffset));
-  }, [cycleWeeks, visibleCount]);
-
   const maxOffset = Math.max(0, cycleWeeks - visibleCount);
   const clampedOffset = Math.min(weekOffset, maxOffset);
 
@@ -258,7 +250,7 @@ export function RosterTemplateEditorClient({
               variant="outline"
               size="sm"
               disabled={!canGoPrev}
-              onClick={() => setWeekOffset((o) => Math.max(0, o - 1))}
+              onClick={() => setWeekOffset(Math.max(0, clampedOffset - 1))}
             >
               <ChevronLeft className="h-4 w-4" />
             </Button>
@@ -269,7 +261,7 @@ export function RosterTemplateEditorClient({
               variant="outline"
               size="sm"
               disabled={!canGoNext}
-              onClick={() => setWeekOffset((o) => Math.min(maxOffset, o + 1))}
+              onClick={() => setWeekOffset(Math.min(maxOffset, clampedOffset + 1))}
             >
               <ChevronRight className="h-4 w-4" />
             </Button>

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-editor-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/_components/roster-template-editor-client.tsx
@@ -219,12 +219,16 @@ export function RosterTemplateEditorClient({
     return () => obs.disconnect();
   }, []);
 
+  // Clamp offset when cycleWeeks shrinks or visibleCount grows.
+  // Functional update avoids adding weekOffset to the dep array (which would
+  // cause a cascading effect chain on every offset change).
+  useEffect(() => {
+    const maxOffset = Math.max(0, cycleWeeks - visibleCount);
+    setWeekOffset((current) => Math.min(current, maxOffset));
+  }, [cycleWeeks, visibleCount]);
+
   const maxOffset = Math.max(0, cycleWeeks - visibleCount);
   const clampedOffset = Math.min(weekOffset, maxOffset);
-  // Synchronously correct offset during render (avoids extra async re-render from useEffect)
-  if (weekOffset !== clampedOffset) {
-    setWeekOffset(clampedOffset);
-  }
 
   const shown = Math.min(visibleCount, cycleWeeks);
   const weekIndices = Array.from({ length: shown }, (_, i) => i + clampedOffset);

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/page.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/[templateId]/page.tsx
@@ -1,0 +1,46 @@
+import { notFound } from "next/navigation";
+import { requireOrgMemberPage } from "@/lib/authz";
+import { memberHasPermission, getOrgMembership } from "@/lib/authz/_shared";
+import { PermissionAction } from "@prisma/client";
+import {
+  getRosterTemplate,
+  getOrgMembersForRoster,
+  getOrgSchedule,
+} from "@/lib/services/roster";
+import { RosterTemplateEditorClient } from "./_components/roster-template-editor-client";
+
+export default async function RosterTemplateEditorPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; templateId: string }>;
+}) {
+  const { orgId, templateId } = await params;
+  const { userId } = await requireOrgMemberPage(orgId);
+
+  const [template, members, membership, orgSchedule] = await Promise.all([
+    getRosterTemplate(orgId, templateId),
+    getOrgMembersForRoster(orgId),
+    getOrgMembership(orgId, userId),
+    getOrgSchedule(orgId),
+  ]);
+
+  if (!template) notFound();
+
+  const canManage = membership
+    ? await memberHasPermission(membership.id, orgId, PermissionAction.MANAGE_TIMETABLE)
+    : false;
+
+  return (
+    <RosterTemplateEditorClient
+      orgId={orgId}
+      templateId={template.id}
+      templateName={template.name}
+      cycleWeeks={template.cycleWeeks}
+      entries={template.entries}
+      members={members}
+      canManage={canManage}
+      orgOpenTimeMin={orgSchedule.openTimeMin}
+      orgCloseTimeMin={orgSchedule.closeTimeMin}
+    />
+  );
+}

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/_components/roster-templates-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/_components/roster-templates-client.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { LayoutTemplate, Pencil, Trash2, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { deleteRosterTemplateAction } from "@/app/actions/roster";
+import { useActionSidebar } from "@/components/layout/action-sidebar-context";
+
+type TemplateRow = {
+  id: string;
+  name: string;
+  cycleWeeks: number;
+  _count: { entries: number };
+};
+
+function ConfirmDeletePanel({
+  orgId,
+  templateId,
+  name,
+}: {
+  orgId: string;
+  templateId: string;
+  name: string;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const sidebar = useActionSidebar();
+  const router = useRouter();
+
+  function handleDelete() {
+    startTransition(async () => {
+      const result = await deleteRosterTemplateAction(orgId, templateId);
+      if (!result.ok) {
+        toast.error(result.error ?? "Failed to delete template");
+        return;
+      }
+      toast.success("Template deleted");
+      sidebar.close();
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <p className="text-sm text-muted-foreground">
+        Delete <span className="font-semibold text-foreground">{name}</span>? This cannot be undone.
+      </p>
+      <div className="flex gap-2">
+        <Button variant="outline" className="flex-1" onClick={() => sidebar.close()}>
+          Cancel
+        </Button>
+        <Button variant="destructive" className="flex-1" onClick={handleDelete} disabled={isPending}>
+          {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Delete"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+interface RosterTemplatesClientProps {
+  orgId: string;
+  templates: TemplateRow[];
+  canManage: boolean;
+}
+
+export function RosterTemplatesClient({
+  orgId,
+  templates,
+  canManage,
+}: RosterTemplatesClientProps) {
+  const sidebar = useActionSidebar();
+
+  if (templates.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
+        <LayoutTemplate className="h-10 w-10 text-muted-foreground/30" />
+        <p className="text-sm text-muted-foreground">No templates yet</p>
+        {canManage && (
+          <p className="text-xs text-muted-foreground/60">
+            Use the sidebar to create your first template.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {templates.map((t) => (
+        <div
+          key={t.id}
+          className="group relative flex flex-col gap-2 rounded-xl border bg-card p-5 shadow-sm hover:border-primary/40 hover:shadow-md transition-all"
+        >
+          <Link
+            href={`/orgs/${orgId}/tools/roster/templates/${t.id}`}
+            className="absolute inset-0 rounded-xl"
+            aria-label={`Open template ${t.name}`}
+          />
+
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <LayoutTemplate className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="font-semibold text-sm truncate">{t.name}</span>
+            </div>
+
+            {canManage && (
+              <div className="relative flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0"
+                  title="Edit"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    window.location.href = `/orgs/${orgId}/tools/roster/templates/${t.id}`;
+                  }}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                  title="Delete"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    sidebar.open(
+                      "Delete template",
+                      <ConfirmDeletePanel orgId={orgId} templateId={t.id} name={t.name} />,
+                    );
+                  }}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            )}
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            {t.cycleWeeks === 1 ? "1-week cycle" : `${t.cycleWeeks}-week cycle`}
+            {" · "}
+            {t._count.entries} {t._count.entries === 1 ? "entry" : "entries"}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/_components/roster-templates-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/_components/roster-templates-client.tsx
@@ -71,6 +71,7 @@ export function RosterTemplatesClient({
   canManage,
 }: RosterTemplatesClientProps) {
   const sidebar = useActionSidebar();
+  const router = useRouter();
 
   if (templates.length === 0) {
     return (
@@ -114,7 +115,7 @@ export function RosterTemplatesClient({
                   title="Edit"
                   onClick={(e) => {
                     e.preventDefault();
-                    window.location.href = `/orgs/${orgId}/tools/roster/templates/${t.id}`;
+                    router.push(`/orgs/${orgId}/tools/roster/templates/${t.id}`);
                   }}
                 >
                   <Pencil className="h-3.5 w-3.5" />

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/_components/roster-templates-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/_components/roster-templates-sidebar-content.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { ArrowLeft, LayoutTemplate, Plus, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { SidebarNavItem } from "@/components/layout/sidebar-nav-item";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useActionSidebar } from "@/components/layout/action-sidebar-context";
+import { createRosterTemplateAction } from "@/app/actions/roster";
+
+function AddTemplatePanel({ orgId }: { orgId: string }) {
+  const [name, setName] = useState("");
+  const [weeks, setWeeks] = useState(1);
+  const [isPending, startTransition] = useTransition();
+  const sidebar = useActionSidebar();
+  const router = useRouter();
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    startTransition(async () => {
+      const result = await createRosterTemplateAction(orgId, name.trim(), weeks);
+      if (!result.ok) {
+        toast.error(result.error ?? "Failed to create template");
+        return;
+      }
+      toast.success("Template created");
+      sidebar.close();
+      router.push(`/orgs/${orgId}/tools/roster/templates/${result.templateId}`);
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
+      <div className="flex flex-col gap-1.5">
+        <label className="text-xs font-medium text-muted-foreground">Name</label>
+        <Input
+          autoFocus
+          placeholder="e.g. Default Week"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          maxLength={80}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-xs font-medium text-muted-foreground">
+          Cycle length (weeks)
+        </label>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={() => setWeeks((w) => Math.max(1, w - 1))}
+          >
+            −
+          </Button>
+          <span className="w-8 text-center text-sm font-medium tabular-nums">{weeks}</span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={() => setWeeks((w) => Math.min(12, w + 1))}
+          >
+            +
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            {weeks === 1 ? "single week" : `${weeks}-week cycle`}
+          </span>
+        </div>
+      </div>
+
+      <Button type="submit" disabled={!name.trim() || isPending}>
+        {isPending ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          "Create template"
+        )}
+      </Button>
+    </form>
+  );
+}
+
+interface RosterTemplatesSidebarContentProps {
+  orgId: string;
+  canManage: boolean;
+}
+
+export function RosterTemplatesSidebarContent({
+  orgId,
+  canManage,
+}: RosterTemplatesSidebarContentProps) {
+  const sidebar = useActionSidebar();
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Title row */}
+      <div className="h-12 flex items-center px-4 border-b border-border shrink-0">
+        <span className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider">
+          Roster
+        </span>
+      </div>
+
+      {/* Back to roster */}
+      <SidebarNavItem
+        title="Back"
+        url={`/orgs/${orgId}/tools/roster`}
+        icon={ArrowLeft}
+        isActive={false}
+        variant="page"
+      />
+
+      {/* Templates (active) */}
+      <SidebarNavItem
+        title="Templates"
+        url={`/orgs/${orgId}/tools/roster/templates`}
+        icon={LayoutTemplate}
+        isActive={true}
+        variant="page"
+      />
+
+      {/* Actions */}
+      {canManage && (
+        <div className="px-3 pt-3 pb-3 border-t border-border">
+          <p className="text-xs font-medium text-sidebar-foreground/50 uppercase tracking-wider px-1 mb-2">
+            Actions
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full justify-start gap-2"
+            onClick={() =>
+              sidebar.open("New template", <AddTemplatePanel orgId={orgId} />)
+            }
+          >
+            <Plus className="h-4 w-4" />
+            Add Template
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tools/roster/templates/page.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/templates/page.tsx
@@ -1,0 +1,48 @@
+import { requireOrgMemberPage } from "@/lib/authz";
+import { memberHasPermission, getOrgMembership } from "@/lib/authz/_shared";
+import { PermissionAction } from "@prisma/client";
+import { getRosterTemplates } from "@/lib/services/roster";
+import { RegisterPageSidebar } from "@/components/layout/page-sidebar-context";
+import { Toolbar } from "@/components/layout/toolbar";
+import { RosterTemplatesSidebarContent } from "./_components/roster-templates-sidebar-content";
+import { RosterTemplatesClient } from "./_components/roster-templates-client";
+
+export default async function RosterTemplatesPage({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) {
+  const { orgId } = await params;
+  const { userId } = await requireOrgMemberPage(orgId);
+
+  const [templates, membership] = await Promise.all([
+    getRosterTemplates(orgId),
+    getOrgMembership(orgId, userId),
+  ]);
+
+  const canManage = membership
+    ? await memberHasPermission(membership.id, orgId, PermissionAction.MANAGE_TIMETABLE)
+    : false;
+
+  return (
+    <>
+      <RegisterPageSidebar
+        content={
+          <RosterTemplatesSidebarContent orgId={orgId} canManage={canManage} />
+        }
+      />
+
+      <Toolbar>
+        <span className="text-sm font-medium">Roster Templates</span>
+      </Toolbar>
+
+      <div className="p-6">
+        <RosterTemplatesClient
+          orgId={orgId}
+          templates={templates}
+          canManage={canManage}
+        />
+      </div>
+    </>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tools/tools-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/tools-client.tsx
@@ -31,29 +31,35 @@ interface RecentSet {
 interface ToolsClientProps {
   orgId: string;
   recentSets: RecentSet[];
+  hasRoster: boolean;
 }
 
-export function ToolsClient({ orgId, recentSets }: ToolsClientProps) {
+export function ToolsClient({ orgId, recentSets, hasRoster }: ToolsClientProps) {
   const recent = recentSets.slice(0, 5);
+  const showRecent = recent.length > 0 || hasRoster;
 
   return (
     <>
       <Toolbar />
 
       <div className="max-w-2xl mx-auto w-full px-1 py-6 flex flex-col gap-8">
-        {/* Recent conversion sets */}
-        {recent.length > 0 && (
+        {/* Recent */}
+        {showRecent && (
           <section className="flex flex-col gap-3">
             <div className="flex items-center justify-between">
               <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Recent</h2>
-              <Link
-                href={`/orgs/${orgId}/tools/conversion`}
-                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-              >
-                View all
-              </Link>
             </div>
             <div className="flex flex-col gap-2">
+              {hasRoster && (
+                <Link
+                  href={`/orgs/${orgId}/tools/roster`}
+                  className="flex items-center gap-3 rounded-xl border bg-card px-4 py-3 shadow-sm hover:border-primary/40 hover:shadow-md transition-all group"
+                >
+                  <Users className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="text-sm font-medium flex-1">Roster</span>
+                  <ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                </Link>
+              )}
               {recent.map((set) => (
                 <Link
                   key={set.id}

--- a/app/actions/roster.ts
+++ b/app/actions/roster.ts
@@ -174,7 +174,9 @@ export async function applyRosterTemplateAction(
   const parsed = new Date(startDateStr + "T00:00:00Z");
   if (isNaN(parsed.getTime())) return { ok: false, error: "Invalid date" };
   const day = parsed.getUTCDay();
-  const diff = day === 0 ? -6 : 1 - day;
+  const prev = 1 - day;
+  const next = prev + 7;
+  const diff = Math.abs(prev) <= Math.abs(next) ? prev : next;
   parsed.setUTCDate(parsed.getUTCDate() + diff);
 
   const result = await applyRosterTemplate(orgId, templateId, parsed, cycleRepeats, force);

--- a/app/actions/roster.ts
+++ b/app/actions/roster.ts
@@ -1,3 +1,9 @@
+/**
+ * @file app/actions/roster.ts
+ * Server actions for the Roster tool.
+ * All write actions require MANAGE_TIMETABLE permission.
+ * Thin wrappers: validate auth → delegate to lib/services/roster → revalidatePath.
+ */
 "use server";
 
 import { PermissionAction } from "@prisma/client";

--- a/app/actions/roster.ts
+++ b/app/actions/roster.ts
@@ -6,11 +6,25 @@ import { revalidatePath } from "next/cache";
 import {
   setRosterCellMembers,
   upsertRosterDayConfig,
+  createRosterTemplate,
+  deleteRosterTemplate,
+  renameRosterTemplate,
+  setRosterTemplateCellMembers,
+  updateRosterTemplateCycleWeeks,
+  clearRosterTemplateWeek,
+  applyRosterTemplate,
   type RosterCellMember,
+  type RosterTemplateCellMember,
 } from "@/lib/services/roster";
 
 function rosterPath(orgId: string) {
   return `/orgs/${orgId}/tools/roster`;
+}
+function rosterTemplatesPath(orgId: string) {
+  return `/orgs/${orgId}/tools/roster/templates`;
+}
+function rosterTemplateEditorPath(orgId: string, templateId: string) {
+  return `/orgs/${orgId}/tools/roster/templates/${templateId}`;
 }
 
 export async function setRosterCellMembersAction(
@@ -49,6 +63,125 @@ export async function upsertRosterDayConfigAction(
 
   const result = await upsertRosterDayConfig(orgId, dayIndex, data);
   if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(rosterPath(orgId));
+  return { ok: true };
+}
+
+// ─── Template actions ──────────────────────────────────────────────────────────
+
+export async function createRosterTemplateAction(
+  orgId: string,
+  name: string,
+  cycleWeeks: number = 1,
+): Promise<{ ok: boolean; error?: string; templateId?: string }> {
+  const authz = await requireOrgPermissionAction(orgId, PermissionAction.MANAGE_TIMETABLE);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const result = await createRosterTemplate(orgId, name, cycleWeeks);
+  if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(rosterTemplatesPath(orgId));
+  return { ok: true, templateId: result.data.id };
+}
+
+export async function deleteRosterTemplateAction(
+  orgId: string,
+  templateId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const authz = await requireOrgPermissionAction(orgId, PermissionAction.MANAGE_TIMETABLE);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const result = await deleteRosterTemplate(orgId, templateId);
+  if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(rosterTemplatesPath(orgId));
+  return { ok: true };
+}
+
+export async function renameRosterTemplateAction(
+  orgId: string,
+  templateId: string,
+  name: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const authz = await requireOrgPermissionAction(orgId, PermissionAction.MANAGE_TIMETABLE);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const result = await renameRosterTemplate(orgId, templateId, name);
+  if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(rosterTemplateEditorPath(orgId, templateId));
+  return { ok: true };
+}
+
+export async function setRosterTemplateCellMembersAction(
+  orgId: string,
+  templateId: string,
+  weekIndex: number,
+  dayIndex: number,
+  members: RosterTemplateCellMember[],
+): Promise<{ ok: boolean; error?: string }> {
+  const authz = await requireOrgPermissionAction(orgId, PermissionAction.MANAGE_TIMETABLE);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const result = await setRosterTemplateCellMembers(orgId, templateId, weekIndex, dayIndex, members);
+  if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(rosterTemplateEditorPath(orgId, templateId));
+  return { ok: true };
+}
+
+export async function updateRosterTemplateCycleWeeksAction(
+  orgId: string,
+  templateId: string,
+  cycleWeeks: number,
+): Promise<{ ok: boolean; error?: string }> {
+  const authz = await requireOrgPermissionAction(orgId, PermissionAction.MANAGE_TIMETABLE);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const result = await updateRosterTemplateCycleWeeks(orgId, templateId, cycleWeeks);
+  if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(rosterTemplateEditorPath(orgId, templateId));
+  return { ok: true };
+}
+
+export async function clearRosterTemplateWeekAction(
+  orgId: string,
+  templateId: string,
+  weekIndex: number,
+): Promise<{ ok: boolean; error?: string }> {
+  const authz = await requireOrgPermissionAction(orgId, PermissionAction.MANAGE_TIMETABLE);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const result = await clearRosterTemplateWeek(orgId, templateId, weekIndex);
+  if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(rosterTemplateEditorPath(orgId, templateId));
+  return { ok: true };
+}
+
+export async function applyRosterTemplateAction(
+  orgId: string,
+  templateId: string,
+  startDateStr: string,
+  cycleRepeats: number,
+  force: boolean,
+): Promise<{ ok: boolean; error?: string; conflict?: boolean }> {
+  const authz = await requireOrgPermissionAction(orgId, PermissionAction.MANAGE_TIMETABLE);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const parsed = new Date(startDateStr + "T00:00:00Z");
+  if (isNaN(parsed.getTime())) return { ok: false, error: "Invalid date" };
+  const day = parsed.getUTCDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  parsed.setUTCDate(parsed.getUTCDate() + diff);
+
+  const result = await applyRosterTemplate(orgId, templateId, parsed, cycleRepeats, force);
+  if (!result.ok) {
+    if (result.code === "CONFLICT") return { ok: false, conflict: true };
+    return { ok: false, error: result.error };
+  }
 
   revalidatePath(rosterPath(orgId));
   return { ok: true };

--- a/app/actions/roster.ts
+++ b/app/actions/roster.ts
@@ -6,6 +6,7 @@ import { revalidatePath } from "next/cache";
 import {
   setRosterCellMembers,
   upsertRosterDayConfig,
+  type RosterCellMember,
 } from "@/lib/services/roster";
 
 function rosterPath(orgId: string) {
@@ -16,7 +17,7 @@ export async function setRosterCellMembersAction(
   orgId: string,
   weekStart: Date,
   dayIndex: number,
-  membershipIds: string[],
+  members: RosterCellMember[],
 ): Promise<{ ok: boolean; error?: string }> {
   const authz = await requireOrgPermissionAction(
     orgId,
@@ -24,12 +25,7 @@ export async function setRosterCellMembersAction(
   );
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
-  const result = await setRosterCellMembers(
-    orgId,
-    weekStart,
-    dayIndex,
-    membershipIds,
-  );
+  const result = await setRosterCellMembers(orgId, weekStart, dayIndex, members);
   if (!result.ok) return { ok: false, error: result.error };
 
   revalidatePath(rosterPath(orgId));

--- a/app/actions/roster.ts
+++ b/app/actions/roster.ts
@@ -1,0 +1,59 @@
+"use server";
+
+import { PermissionAction } from "@prisma/client";
+import { requireOrgPermissionAction } from "@/lib/authz";
+import { revalidatePath } from "next/cache";
+import {
+  setRosterCellMembers,
+  upsertRosterDayConfig,
+} from "@/lib/services/roster";
+
+function rosterPath(orgId: string) {
+  return `/orgs/${orgId}/tools/roster`;
+}
+
+export async function setRosterCellMembersAction(
+  orgId: string,
+  weekStart: Date,
+  dayIndex: number,
+  membershipIds: string[],
+): Promise<{ ok: boolean; error?: string }> {
+  const authz = await requireOrgPermissionAction(
+    orgId,
+    PermissionAction.MANAGE_TIMETABLE,
+  );
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const result = await setRosterCellMembers(
+    orgId,
+    weekStart,
+    dayIndex,
+    membershipIds,
+  );
+  if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(rosterPath(orgId));
+  return { ok: true };
+}
+
+export async function upsertRosterDayConfigAction(
+  orgId: string,
+  dayIndex: number,
+  data: {
+    recommendedSize?: number;
+    openTimeMin?: number | null;
+    closeTimeMin?: number | null;
+  },
+): Promise<{ ok: boolean; error?: string }> {
+  const authz = await requireOrgPermissionAction(
+    orgId,
+    PermissionAction.MANAGE_TIMETABLE,
+  );
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const result = await upsertRosterDayConfig(orgId, dayIndex, data);
+  if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(rosterPath(orgId));
+  return { ok: true };
+}

--- a/app/actions/tools.ts
+++ b/app/actions/tools.ts
@@ -28,6 +28,7 @@ import {
   updateConversionRate,
   createConversionTemplate,
   deleteConversionTemplate,
+  duplicateConversionTemplate,
   upsertTemplateEntry,
   deleteTemplateEntry,
 } from "@/lib/services/tools";
@@ -332,6 +333,34 @@ export async function deleteConversionTemplateAction(
       P2025: "Template not found.",
     });
     return { ok: false as const, error: mappedError ?? "Failed to delete template." };
+  }
+}
+
+/**
+ * Duplicates an existing template (name + all entries) under a new name.
+ * Returns the new template so the client can switch to it immediately.
+ */
+export async function duplicateConversionTemplateAction(
+  orgId: string,
+  setId: string,
+  templateId: string,
+  newName: string,
+) {
+  const auth = await requireOrgPermissionAction(orgId, PermissionAction.MANAGE_TASKS);
+  if (!auth.ok) return { ok: false as const };
+
+  const trimmed = newName.trim();
+  if (!trimmed) return { ok: false as const, error: "Name is required." };
+
+  try {
+    const template = await duplicateConversionTemplate(orgId, templateId, trimmed);
+    revalidatePath(`/orgs/${orgId}/tools/conversion/${setId}`);
+    return { ok: true as const, template };
+  } catch (err: unknown) {
+    const mappedError = mapPrismaError(err, {
+      P2002: "A template with that name already exists.",
+    });
+    return { ok: false as const, error: mappedError ?? "Failed to duplicate template." };
   }
 }
 

--- a/app/api/orgs/[orgId]/entity-name/route.ts
+++ b/app/api/orgs/[orgId]/entity-name/route.ts
@@ -47,7 +47,7 @@ export async function GET(
       });
       name = row?.name ?? null;
     } else if (type === "templates") {
-      const row = await prisma.template.findFirst({
+      const row = await prisma.timetableTemplate.findFirst({
         where: { id, orgId },
         select: { name: true },
       });

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,7 +13,7 @@ html,
 body {
   overflow: hidden;
   height: 100%;
-  font-weight: 730;
+  font-weight: 700;
 }
 
 @theme inline {
@@ -61,15 +61,15 @@ body {
 
   /* Shift the entire font-weight scale up slightly so all utilities
      (font-normal, font-medium, etc.) render a bit heavier. */
-  --font-weight-thin: 130;
-  --font-weight-extralight: 230;
-  --font-weight-light: 330;
-  --font-weight-normal: 430;
-  --font-weight-medium: 530;
-  --font-weight-semibold: 630;
-  --font-weight-bold: 730;
-  --font-weight-extrabold: 830;
-  --font-weight-black: 920;
+  --font-weight-thin: 700;
+  --font-weight-extralight: 700;
+  --font-weight-light: 700;
+  --font-weight-normal: 700;
+  --font-weight-medium: 700;
+  --font-weight-semibold: 700;
+  --font-weight-bold: 700;
+  --font-weight-extrabold: 700;
+  --font-weight-black: 700;
 }
 
 :root {

--- a/app/globals.css
+++ b/app/globals.css
@@ -61,12 +61,12 @@ body {
 
   /* Shift the entire font-weight scale up slightly so all utilities
      (font-normal, font-medium, etc.) render a bit heavier. */
-  --font-weight-thin: 730;
-  --font-weight-extralight: 730;
-  --font-weight-light: 730;
-  --font-weight-normal: 730;
-  --font-weight-medium: 730;
-  --font-weight-semibold: 730;
+  --font-weight-thin: 130;
+  --font-weight-extralight: 230;
+  --font-weight-light: 330;
+  --font-weight-normal: 430;
+  --font-weight-medium: 530;
+  --font-weight-semibold: 630;
   --font-weight-bold: 730;
   --font-weight-extrabold: 830;
   --font-weight-black: 920;

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,6 +13,7 @@ html,
 body {
   overflow: hidden;
   height: 100%;
+  font-weight: 730;
 }
 
 @theme inline {
@@ -57,6 +58,18 @@ body {
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+
+  /* Shift the entire font-weight scale up slightly so all utilities
+     (font-normal, font-medium, etc.) render a bit heavier. */
+  --font-weight-thin: 730;
+  --font-weight-extralight: 730;
+  --font-weight-light: 730;
+  --font-weight-normal: 730;
+  --font-weight-medium: 730;
+  --font-weight-semibold: 730;
+  --font-weight-bold: 730;
+  --font-weight-extrabold: 830;
+  --font-weight-black: 920;
 }
 
 :root {

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -120,21 +120,23 @@ export const NavBar = async () => {
                   variant="ghost"
                   size="icon"
                   aria-label="Open user menu"
-                  className="h-7 w-7 rounded-full bg-primary hover:bg-primary/90 overflow-hidden p-0 flex items-center justify-center"
+                  className="h-10 w-10 min-h-[40px] min-w-[40px] rounded-full hover:bg-accent p-0 flex items-center justify-center"
                 >
-                  {user.image ? (
-                    <Image
-                      src={user.image}
-                      alt={user.name ?? "User"}
-                      width={28}
-                      height={28}
-                      className="rounded-full object-cover"
-                    />
-                  ) : (
-                    <span className="text-xs font-semibold text-primary-foreground">
-                      {user.name?.[0]?.toUpperCase() ?? "?"}
-                    </span>
-                  )}
+                  <div className="h-7 w-7 rounded-full bg-primary hover:bg-primary/90 overflow-hidden flex items-center justify-center">
+                    {user.image ? (
+                      <Image
+                        src={user.image}
+                        alt={user.name ?? "User"}
+                        width={28}
+                        height={28}
+                        className="rounded-full object-cover"
+                      />
+                    ) : (
+                      <span className="text-xs font-semibold text-primary-foreground">
+                        {user.name?.[0]?.toUpperCase() ?? "?"}
+                      </span>
+                    )}
+                  </div>
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-56">

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -120,18 +120,18 @@ export const NavBar = async () => {
                   variant="ghost"
                   size="icon"
                   aria-label="Open user menu"
-                  className="h-9 w-9 rounded-full bg-primary hover:bg-primary/90 overflow-hidden p-0 flex items-center justify-center"
+                  className="h-7 w-7 rounded-full bg-primary hover:bg-primary/90 overflow-hidden p-0 flex items-center justify-center"
                 >
                   {user.image ? (
                     <Image
                       src={user.image}
                       alt={user.name ?? "User"}
-                      width={36}
-                      height={36}
+                      width={28}
+                      height={28}
                       className="rounded-full object-cover"
                     />
                   ) : (
-                    <span className="text-sm font-semibold text-primary-foreground">
+                    <span className="text-xs font-semibold text-primary-foreground">
                       {user.name?.[0]?.toUpperCase() ?? "?"}
                     </span>
                   )}

--- a/components/layout/org-switcher.tsx
+++ b/components/layout/org-switcher.tsx
@@ -8,16 +8,39 @@
  */
 import { useRouter, usePathname } from "next/navigation";
 import { useTransition } from "react";
-import { ChevronsUpDown, Loader2 } from "lucide-react";
+import { Check, ChevronsUpDown, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 
 type Org = { id: string; name: string };
+
+/** Returns a stable hue (0–359) based on the org id string. */
+function orgHue(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+  return h % 360;
+}
+
+function OrgBadge({ org }: { org: Org }) {
+  const hue = orgHue(org.id);
+  return (
+    <span
+      className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[10px] font-bold text-white select-none"
+      style={{ background: `hsl(${hue} 60% 45%)` }}
+      aria-hidden
+    >
+      {org.name[0]?.toUpperCase() ?? "?"}
+    </span>
+  );
+}
 
 export function OrgSwitcher({ orgs }: { orgs: Org[] }) {
   const router = useRouter();
@@ -34,9 +57,12 @@ export function OrgSwitcher({ orgs }: { orgs: Org[] }) {
         <Button
           variant="outline"
           size="sm"
-          className="gap-2 max-w-48"
+          className="gap-1.5 max-w-48 pl-1.5"
           disabled={isPending}
         >
+          {activeOrg ? (
+            <OrgBadge org={activeOrg} />
+          ) : null}
           <span className="truncate max-w-28 sm:max-w-40">
             {activeOrg?.name ?? "Select Org"}
           </span>
@@ -47,20 +73,40 @@ export function OrgSwitcher({ orgs }: { orgs: Org[] }) {
           )}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-48">
+      <DropdownMenuContent align="start" className="w-52">
         {orgs.length === 0 ? (
-          <DropdownMenuItem disabled>No organizations</DropdownMenuItem>
+          <>
+            <DropdownMenuLabel className="text-xs font-medium text-muted-foreground">
+              Organizations
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem disabled>No organizations</DropdownMenuItem>
+          </>
         ) : (
-          orgs.map((org) => (
-            <DropdownMenuItem
-              key={org.id}
-              onSelect={() =>
-                startTransition(() => router.push(`/orgs/${org.id}`))
-              }
-            >
-              {org.name}
-            </DropdownMenuItem>
-          ))
+          <>
+            <DropdownMenuLabel className="text-xs font-medium text-muted-foreground">
+              Organizations
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {orgs.map((org) => {
+              const isActive = org.id === activeOrgId;
+              return (
+                <DropdownMenuItem
+                  key={org.id}
+                  onSelect={() =>
+                    startTransition(() => router.push(`/orgs/${org.id}`))
+                  }
+                  className="gap-2"
+                >
+                  <OrgBadge org={org} />
+                  <span className={cn("flex-1 truncate", isActive && "font-medium")}>
+                    {org.name}
+                  </span>
+                  {isActive && <Check className="h-3.5 w-3.5 shrink-0 text-primary" />}
+                </DropdownMenuItem>
+              );
+            })}
+          </>
         )}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/lib/services/franchise.ts
+++ b/lib/services/franchise.ts
@@ -160,7 +160,7 @@ export async function cloneTemplatesFromParent(
   childOrgId: string,
   taskIdMap: Map<string, string>,
 ) {
-  const parentTemplates = await tx.template.findMany({
+  const parentTemplates = await tx.timetableTemplate.findMany({
     where: { orgId: parentOrgId },
     include: {
       entries: {
@@ -178,7 +178,7 @@ export async function cloneTemplatesFromParent(
 
   const clonedTemplates = await Promise.all(
     parentTemplates.map((template) =>
-      tx.template.create({
+      tx.timetableTemplate.create({
         data: {
           orgId: childOrgId,
           name: template.name,

--- a/lib/services/roster.ts
+++ b/lib/services/roster.ts
@@ -184,3 +184,256 @@ export async function upsertRosterDayConfig(
 
   return { ok: true, data: null };
 }
+
+// ─── Roster Templates ─────────────────────────────────────────────────────────
+
+export async function getRosterTemplates(orgId: string) {
+  return prisma.rosterTemplate.findMany({
+    where: { orgId },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      name: true,
+      cycleWeeks: true,
+      createdAt: true,
+      _count: { select: { entries: true } },
+    },
+  });
+}
+
+export async function getRosterTemplate(orgId: string, templateId: string) {
+  return prisma.rosterTemplate.findFirst({
+    where: { id: templateId, orgId },
+    include: {
+      entries: {
+        include: {
+          membership: {
+            select: {
+              id: true,
+              botName: true,
+              user: { select: { name: true } },
+            },
+          },
+        },
+        orderBy: [{ weekIndex: "asc" }, { dayIndex: "asc" }],
+      },
+    },
+  });
+}
+
+export type RosterTemplateCellMember = {
+  membershipId: string;
+  shiftStartMin: number | null;
+  shiftEndMin: number | null;
+};
+
+export async function setRosterTemplateCellMembers(
+  orgId: string,
+  templateId: string,
+  weekIndex: number,
+  dayIndex: number,
+  members: RosterTemplateCellMember[],
+): Promise<ServiceResult<null>> {
+  if (dayIndex < 0 || dayIndex > 6)
+    return { ok: false, error: "Invalid day index", code: "INVALID" };
+
+  const template = await prisma.rosterTemplate.findFirst({
+    where: { id: templateId, orgId },
+    select: { id: true, cycleWeeks: true },
+  });
+  if (!template)
+    return { ok: false, error: "Template not found", code: "NOT_FOUND" };
+  if (weekIndex < 0 || weekIndex >= template.cycleWeeks)
+    return { ok: false, error: "Invalid week index", code: "INVALID" };
+
+  const membershipIds = members.map((m) => m.membershipId);
+  if (membershipIds.length > 0) {
+    const count = await prisma.membership.count({
+      where: { id: { in: membershipIds }, orgId },
+    });
+    if (count !== membershipIds.length)
+      return { ok: false, error: "Invalid membership", code: "NOT_FOUND" };
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.rosterTemplateEntry.deleteMany({
+      where: { templateId, weekIndex, dayIndex },
+    });
+    if (members.length > 0) {
+      await tx.rosterTemplateEntry.createMany({
+        data: members.map((m) => ({
+          templateId,
+          membershipId: m.membershipId,
+          weekIndex,
+          dayIndex,
+          shiftStartMin: m.shiftStartMin,
+          shiftEndMin: m.shiftEndMin,
+        })),
+      });
+    }
+  });
+
+  return { ok: true, data: null };
+}
+
+export async function createRosterTemplate(
+  orgId: string,
+  name: string,
+  cycleWeeks: number = 1,
+): Promise<ServiceResult<{ id: string }>> {
+  const trimmed = name.trim();
+  if (!trimmed) return { ok: false, error: "Name required", code: "INVALID" };
+  if (cycleWeeks < 1 || cycleWeeks > 12)
+    return { ok: false, error: "Cycle weeks must be 1–12", code: "INVALID" };
+
+  const existing = await prisma.rosterTemplate.findFirst({
+    where: { orgId, name: trimmed },
+  });
+  if (existing)
+    return { ok: false, error: "A template with that name already exists", code: "CONFLICT" };
+
+  const template = await prisma.rosterTemplate.create({
+    data: { orgId, name: trimmed, cycleWeeks },
+    select: { id: true },
+  });
+  return { ok: true, data: template };
+}
+
+export async function deleteRosterTemplate(
+  orgId: string,
+  templateId: string,
+): Promise<ServiceResult<null>> {
+  const template = await prisma.rosterTemplate.findFirst({
+    where: { id: templateId, orgId },
+  });
+  if (!template)
+    return { ok: false, error: "Template not found", code: "NOT_FOUND" };
+
+  await prisma.rosterTemplate.delete({ where: { id: templateId } });
+  return { ok: true, data: null };
+}
+
+export async function renameRosterTemplate(
+  orgId: string,
+  templateId: string,
+  name: string,
+): Promise<ServiceResult<null>> {
+  const trimmed = name.trim();
+  if (!trimmed) return { ok: false, error: "Name required", code: "INVALID" };
+
+  const template = await prisma.rosterTemplate.findFirst({
+    where: { id: templateId, orgId },
+  });
+  if (!template)
+    return { ok: false, error: "Template not found", code: "NOT_FOUND" };
+
+  const conflict = await prisma.rosterTemplate.findFirst({
+    where: { orgId, name: trimmed, id: { not: templateId } },
+  });
+  if (conflict)
+    return { ok: false, error: "A template with that name already exists", code: "CONFLICT" };
+
+  await prisma.rosterTemplate.update({
+    where: { id: templateId },
+    data: { name: trimmed },
+  });
+  return { ok: true, data: null };
+}
+
+export async function updateRosterTemplateCycleWeeks(
+  orgId: string,
+  templateId: string,
+  cycleWeeks: number,
+): Promise<ServiceResult<null>> {
+  if (cycleWeeks < 1 || cycleWeeks > 12)
+    return { ok: false, error: "Cycle weeks must be between 1 and 12", code: "INVALID" };
+
+  const template = await prisma.rosterTemplate.findFirst({
+    where: { id: templateId, orgId },
+  });
+  if (!template)
+    return { ok: false, error: "Template not found", code: "NOT_FOUND" };
+
+  await prisma.rosterTemplate.update({
+    where: { id: templateId },
+    data: { cycleWeeks },
+  });
+  return { ok: true, data: null };
+}
+
+export async function clearRosterTemplateWeek(
+  orgId: string,
+  templateId: string,
+  weekIndex: number,
+): Promise<ServiceResult<null>> {
+  const template = await prisma.rosterTemplate.findFirst({
+    where: { id: templateId, orgId },
+  });
+  if (!template)
+    return { ok: false, error: "Template not found", code: "NOT_FOUND" };
+
+  await prisma.rosterTemplateEntry.deleteMany({
+    where: { templateId, weekIndex },
+  });
+  return { ok: true, data: null };
+}
+
+export async function applyRosterTemplate(
+  orgId: string,
+  templateId: string,
+  startMonday: Date,
+  cycleRepeats: number,
+  force: boolean,
+): Promise<ServiceResult<null>> {
+  if (cycleRepeats < 1 || cycleRepeats > 52)
+    return { ok: false, error: "cycleRepeats must be 1–52", code: "INVALID" };
+
+  const template = await prisma.rosterTemplate.findFirst({
+    where: { id: templateId, orgId },
+    include: { entries: true },
+  });
+  if (!template)
+    return { ok: false, error: "Template not found", code: "NOT_FOUND" };
+
+  // All week starts affected: cycleWeeks * cycleRepeats consecutive weeks
+  const totalWeeks = template.cycleWeeks * cycleRepeats;
+  const weekStarts: Date[] = Array.from({ length: totalWeeks }, (_, i) => {
+    const d = new Date(startMonday);
+    d.setUTCDate(d.getUTCDate() + i * 7);
+    return d;
+  });
+
+  if (!force) {
+    const conflictCount = await prisma.rosterEntry.count({
+      where: { orgId, weekStart: { in: weekStarts } },
+    });
+    if (conflictCount > 0)
+      return { ok: false, error: "Target weeks already have entries", code: "CONFLICT" };
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.rosterEntry.deleteMany({ where: { orgId, weekStart: { in: weekStarts } } });
+
+    const insertData = [];
+    for (let r = 0; r < cycleRepeats; r++) {
+      for (const entry of template.entries) {
+        const weekStart = new Date(startMonday);
+        weekStart.setUTCDate(
+          weekStart.getUTCDate() + (r * template.cycleWeeks + entry.weekIndex) * 7,
+        );
+        insertData.push({
+          orgId,
+          membershipId: entry.membershipId,
+          weekStart,
+          dayIndex: entry.dayIndex,
+          shiftStartMin: entry.shiftStartMin,
+          shiftEndMin: entry.shiftEndMin,
+        });
+      }
+    }
+    if (insertData.length > 0)
+      await tx.rosterEntry.createMany({ data: insertData, skipDuplicates: true });
+  });
+
+  return { ok: true, data: null };
+}

--- a/lib/services/roster.ts
+++ b/lib/services/roster.ts
@@ -50,11 +50,12 @@ export async function getOrgSchedule(
  * Returns true if the org has any roster entries or day configs (i.e. has used the Roster tool).
  */
 export async function hasRosterActivity(orgId: string): Promise<boolean> {
-  const [entries, configs] = await Promise.all([
+  const [entries, configs, templates] = await Promise.all([
     prisma.rosterEntry.count({ where: { orgId } }),
     prisma.rosterDayConfig.count({ where: { orgId } }),
+    prisma.rosterTemplate.count({ where: { orgId } }),
   ]);
-  return entries > 0 || configs > 0;
+  return entries > 0 || configs > 0 || templates > 0;
 }
 
 /**
@@ -144,6 +145,7 @@ export async function setRosterCellMembers(
         data: members.map((m) => ({
           orgId,
           membershipId: m.membershipId,
+          membershipOrgId: orgId,
           weekStart,
           dayIndex,
           shiftStartMin: m.shiftStartMin,
@@ -264,6 +266,7 @@ export async function setRosterTemplateCellMembers(
         data: members.map((m) => ({
           templateId,
           membershipId: m.membershipId,
+          membershipOrgId: orgId,
           weekIndex,
           dayIndex,
           shiftStartMin: m.shiftStartMin,
@@ -354,6 +357,17 @@ export async function updateRosterTemplateCycleWeeks(
   if (!template)
     return { ok: false, error: "Template not found", code: "NOT_FOUND" };
 
+  // Check if any entries would be out of range
+  const outOfRangeCount = await prisma.rosterTemplateEntry.count({
+    where: { templateId, weekIndex: { gte: cycleWeeks } },
+  });
+  if (outOfRangeCount > 0)
+    return {
+      ok: false,
+      error: `Cannot reduce cycle: ${outOfRangeCount} ${outOfRangeCount === 1 ? "entry has" : "entries have"} weekIndex >= ${cycleWeeks}`,
+      code: "INVALID",
+    };
+
   await prisma.rosterTemplate.update({
     where: { id: templateId },
     data: { cycleWeeks },
@@ -424,6 +438,7 @@ export async function applyRosterTemplate(
         insertData.push({
           orgId,
           membershipId: entry.membershipId,
+          membershipOrgId: orgId,
           weekStart,
           dayIndex: entry.dayIndex,
           shiftStartMin: entry.shiftStartMin,

--- a/lib/services/roster.ts
+++ b/lib/services/roster.ts
@@ -189,6 +189,10 @@ export async function upsertRosterDayConfig(
 
 // ─── Roster Templates ─────────────────────────────────────────────────────────
 
+/**
+ * Returns a summary list of all roster templates for the org, ordered by creation date.
+ * Includes `_count.entries` so the list view can show how many cells are filled.
+ */
 export async function getRosterTemplates(orgId: string) {
   return prisma.rosterTemplate.findMany({
     where: { orgId },
@@ -203,6 +207,10 @@ export async function getRosterTemplates(orgId: string) {
   });
 }
 
+/**
+ * Returns a single roster template with all entries expanded (membership + user name).
+ * Returns null if the template doesn't exist or doesn't belong to the org.
+ */
 export async function getRosterTemplate(orgId: string, templateId: string) {
   return prisma.rosterTemplate.findFirst({
     where: { id: templateId, orgId },
@@ -229,6 +237,11 @@ export type RosterTemplateCellMember = {
   shiftEndMin: number | null;
 };
 
+/**
+ * Replaces all entries in a single (weekIndex, dayIndex) cell of a roster template.
+ * Validates that weekIndex is within the template's cycleWeeks and that all
+ * membershipIds belong to the org. Runs delete + insert in a transaction.
+ */
 export async function setRosterTemplateCellMembers(
   orgId: string,
   templateId: string,
@@ -279,6 +292,10 @@ export async function setRosterTemplateCellMembers(
   return { ok: true, data: null };
 }
 
+/**
+ * Creates a new roster template for the org. Name must be unique within the org.
+ * `cycleWeeks` defaults to 1 and is capped at 12.
+ */
 export async function createRosterTemplate(
   orgId: string,
   name: string,
@@ -302,6 +319,9 @@ export async function createRosterTemplate(
   return { ok: true, data: template };
 }
 
+/**
+ * Deletes a roster template and all its entries (cascade via Prisma schema).
+ */
 export async function deleteRosterTemplate(
   orgId: string,
   templateId: string,
@@ -316,6 +336,9 @@ export async function deleteRosterTemplate(
   return { ok: true, data: null };
 }
 
+/**
+ * Renames a roster template. The new name must be unique within the org.
+ */
 export async function renameRosterTemplate(
   orgId: string,
   templateId: string,
@@ -343,6 +366,10 @@ export async function renameRosterTemplate(
   return { ok: true, data: null };
 }
 
+/**
+ * Changes `cycleWeeks` on a roster template. Rejects the update if any existing
+ * entries have a `weekIndex >= cycleWeeks` (would become unreachable).
+ */
 export async function updateRosterTemplateCycleWeeks(
   orgId: string,
   templateId: string,
@@ -375,6 +402,9 @@ export async function updateRosterTemplateCycleWeeks(
   return { ok: true, data: null };
 }
 
+/**
+ * Removes all entries in a single week column from a roster template.
+ */
 export async function clearRosterTemplateWeek(
   orgId: string,
   templateId: string,
@@ -392,6 +422,12 @@ export async function clearRosterTemplateWeek(
   return { ok: true, data: null };
 }
 
+/**
+ * Stamps a roster template onto the live roster starting at `startMonday`.
+ * Repeats the full cycle `cycleRepeats` times (total weeks = cycleWeeks × cycleRepeats).
+ * If `force` is false and any target week already has entries, returns CONFLICT.
+ * If `force` is true, all existing entries in the affected weeks are replaced.
+ */
 export async function applyRosterTemplate(
   orgId: string,
   templateId: string,

--- a/lib/services/roster.ts
+++ b/lib/services/roster.ts
@@ -30,6 +30,34 @@ export type RosterDayConfigRow = {
 // ─── Queries ──────────────────────────────────────────────────────────────────
 
 /**
+ * Returns the org's default open/close times.
+ */
+export async function getOrgSchedule(
+  orgId: string,
+): Promise<{ openTimeMin: number | null; closeTimeMin: number | null; timezone: string }> {
+  const org = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: { openTimeMin: true, closeTimeMin: true, timezone: true },
+  });
+  return {
+    openTimeMin: org?.openTimeMin ?? null,
+    closeTimeMin: org?.closeTimeMin ?? null,
+    timezone: org?.timezone ?? "UTC",
+  };
+}
+
+/**
+ * Returns true if the org has any roster entries or day configs (i.e. has used the Roster tool).
+ */
+export async function hasRosterActivity(orgId: string): Promise<boolean> {
+  const [entries, configs] = await Promise.all([
+    prisma.rosterEntry.count({ where: { orgId } }),
+    prisma.rosterDayConfig.count({ where: { orgId } }),
+  ]);
+  return entries > 0 || configs > 0;
+}
+
+/**
  * Returns all RosterEntry rows for the given org and list of weekStart dates,
  * grouped by dayIndex within each weekStart.
  */
@@ -77,6 +105,12 @@ export async function getOrgMembersForRoster(orgId: string) {
 
 // ─── Mutations ────────────────────────────────────────────────────────────────
 
+export type RosterCellMember = {
+  membershipId: string;
+  shiftStartMin: number | null;
+  shiftEndMin: number | null;
+};
+
 /**
  * Replaces all members assigned to a specific (weekStart, dayIndex) cell.
  * Runs in a transaction: deletes existing, then inserts new.
@@ -85,10 +119,12 @@ export async function setRosterCellMembers(
   orgId: string,
   weekStart: Date,
   dayIndex: number,
-  membershipIds: string[],
+  members: RosterCellMember[],
 ): Promise<ServiceResult<null>> {
   if (dayIndex < 0 || dayIndex > 6)
     return { ok: false, error: "Invalid day index", code: "INVALID" };
+
+  const membershipIds = members.map((m) => m.membershipId);
 
   // Verify all memberships belong to this org
   if (membershipIds.length > 0) {
@@ -103,13 +139,15 @@ export async function setRosterCellMembers(
     await tx.rosterEntry.deleteMany({
       where: { orgId, weekStart, dayIndex },
     });
-    if (membershipIds.length > 0) {
+    if (members.length > 0) {
       await tx.rosterEntry.createMany({
-        data: membershipIds.map((membershipId) => ({
+        data: members.map((m) => ({
           orgId,
-          membershipId,
+          membershipId: m.membershipId,
           weekStart,
           dayIndex,
+          shiftStartMin: m.shiftStartMin,
+          shiftEndMin: m.shiftEndMin,
         })),
       });
     }

--- a/lib/services/roster.ts
+++ b/lib/services/roster.ts
@@ -1,0 +1,148 @@
+/**
+ * @file roster.ts
+ * Service functions for reading and mutating roster entries and day configs.
+ */
+import { prisma } from "@/lib/prisma";
+import type { ServiceResult } from "./types";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type RosterMember = {
+  membershipId: string;
+  name: string;
+  shiftStartMin: number | null;
+  shiftEndMin: number | null;
+};
+
+export type RosterCell = {
+  dayIndex: number;
+  weekStart: Date;
+  members: RosterMember[];
+};
+
+export type RosterDayConfigRow = {
+  dayIndex: number;
+  recommendedSize: number;
+  openTimeMin: number | null;
+  closeTimeMin: number | null;
+};
+
+// ─── Queries ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns all RosterEntry rows for the given org and list of weekStart dates,
+ * grouped by dayIndex within each weekStart.
+ */
+export async function getRosterEntries(orgId: string, weekStarts: Date[]) {
+  if (weekStarts.length === 0) return [];
+  return prisma.rosterEntry.findMany({
+    where: { orgId, weekStart: { in: weekStarts } },
+    include: {
+      membership: {
+        select: {
+          id: true,
+          botName: true,
+          user: { select: { name: true } },
+        },
+      },
+    },
+    orderBy: [{ weekStart: "asc" }, { dayIndex: "asc" }],
+  });
+}
+
+/**
+ * Returns all RosterDayConfig rows for the org, keyed by dayIndex.
+ */
+export async function getRosterDayConfigs(orgId: string) {
+  return prisma.rosterDayConfig.findMany({
+    where: { orgId },
+    orderBy: { dayIndex: "asc" },
+  });
+}
+
+/**
+ * Returns all active memberships for the org (for the member picker).
+ */
+export async function getOrgMembersForRoster(orgId: string) {
+  return prisma.membership.findMany({
+    where: { orgId, status: "ACTIVE" },
+    select: {
+      id: true,
+      botName: true,
+      user: { select: { name: true } },
+    },
+    orderBy: { joinedAt: "asc" },
+  });
+}
+
+// ─── Mutations ────────────────────────────────────────────────────────────────
+
+/**
+ * Replaces all members assigned to a specific (weekStart, dayIndex) cell.
+ * Runs in a transaction: deletes existing, then inserts new.
+ */
+export async function setRosterCellMembers(
+  orgId: string,
+  weekStart: Date,
+  dayIndex: number,
+  membershipIds: string[],
+): Promise<ServiceResult<null>> {
+  if (dayIndex < 0 || dayIndex > 6)
+    return { ok: false, error: "Invalid day index", code: "INVALID" };
+
+  // Verify all memberships belong to this org
+  if (membershipIds.length > 0) {
+    const count = await prisma.membership.count({
+      where: { id: { in: membershipIds }, orgId },
+    });
+    if (count !== membershipIds.length)
+      return { ok: false, error: "Invalid membership", code: "NOT_FOUND" };
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.rosterEntry.deleteMany({
+      where: { orgId, weekStart, dayIndex },
+    });
+    if (membershipIds.length > 0) {
+      await tx.rosterEntry.createMany({
+        data: membershipIds.map((membershipId) => ({
+          orgId,
+          membershipId,
+          weekStart,
+          dayIndex,
+        })),
+      });
+    }
+  });
+
+  return { ok: true, data: null };
+}
+
+/**
+ * Upserts the RosterDayConfig for a given dayIndex.
+ */
+export async function upsertRosterDayConfig(
+  orgId: string,
+  dayIndex: number,
+  data: {
+    recommendedSize?: number;
+    openTimeMin?: number | null;
+    closeTimeMin?: number | null;
+  },
+): Promise<ServiceResult<null>> {
+  if (dayIndex < 0 || dayIndex > 6)
+    return { ok: false, error: "Invalid day index", code: "INVALID" };
+  if (
+    data.recommendedSize !== undefined &&
+    (data.recommendedSize < 0 || data.recommendedSize > 100)
+  )
+    return { ok: false, error: "Invalid recommended size", code: "INVALID" };
+
+  await prisma.rosterDayConfig.upsert({
+    where: { orgId_dayIndex: { orgId, dayIndex } },
+    create: { orgId, dayIndex, ...data },
+    update: data,
+  });
+
+  return { ok: true, data: null };
+}

--- a/lib/services/templates.ts
+++ b/lib/services/templates.ts
@@ -19,7 +19,7 @@ import {
  * Includes the total number of entries on each template via `_count`.
  */
 export async function getTimetableTemplates(orgId: string) {
-  return prisma.template.findMany({
+  return prisma.timetableTemplate.findMany({
     where: { orgId },
     include: {
       _count: { select: { entries: true } },
@@ -34,7 +34,7 @@ export async function getTimetableTemplates(orgId: string) {
  * Returns `null` if no matching template exists in the org.
  */
 export async function getTimetableTemplate(orgId: string, templateId: string) {
-  return prisma.template.findFirst({
+  return prisma.timetableTemplate.findFirst({
     where: { id: templateId, orgId },
     include: {
       entries: {
@@ -68,7 +68,7 @@ export async function createTemplate(
   cycleLengthDays: number,
   actorId?: string | null,
 ): Promise<ServiceResult<{ id: string }>> {
-  const template = await prisma.template.create({
+  const template = await prisma.timetableTemplate.create({
     data: { orgId, name, cycleLengthDays },
     select: { id: true },
   });
@@ -104,7 +104,7 @@ export async function addTemplateInstance(
       where: { id: taskId, orgId },
       select: { id: true, durationMin: true },
     }),
-    prisma.template.findFirst({
+    prisma.timetableTemplate.findFirst({
       where: { id: templateId, orgId },
       select: { id: true, cycleLengthDays: true },
     }),
@@ -124,7 +124,7 @@ export async function addTemplateInstance(
   }
 
   const endTimeMin = Math.min(startTimeMin + task.durationMin, 1440);
-  await prisma.templateEntry.create({
+  await prisma.timetableTemplateEntry.create({
     data: { taskId, templateId, dayIndex, startTimeMin, endTimeMin },
   });
   log.info("Template instance added", { orgId, templateId, taskId });
@@ -138,13 +138,13 @@ export async function removeTemplateInstance(
   orgId: string,
   instanceId: string,
 ): Promise<ServiceResult<null>> {
-  const entry = await prisma.templateEntry.findFirst({
+  const entry = await prisma.timetableTemplateEntry.findFirst({
     where: { id: instanceId, template: { orgId } },
     select: { id: true },
   });
   if (!entry) return { ok: false, error: "Not found", code: "NOT_FOUND" };
 
-  await prisma.templateEntry.delete({ where: { id: instanceId } });
+  await prisma.timetableTemplateEntry.delete({ where: { id: instanceId } });
   log.info("Template instance removed", { orgId, instanceId });
   return { ok: true, data: null };
 }
@@ -157,7 +157,7 @@ export async function updateTemplateInstance(
   instanceId: string,
   update: { dayIndex?: number; startTimeMin?: number },
 ): Promise<ServiceResult<null>> {
-  const entry = await prisma.templateEntry.findFirst({
+  const entry = await prisma.timetableTemplateEntry.findFirst({
     where: { id: instanceId, template: { orgId } },
     select: {
       id: true,
@@ -169,7 +169,7 @@ export async function updateTemplateInstance(
   if (!entry) return { ok: false, error: "Not found", code: "NOT_FOUND" };
 
   if (update.dayIndex !== undefined) {
-    const template = await prisma.template.findFirst({
+    const template = await prisma.timetableTemplate.findFirst({
       where: { id: entry.templateId, orgId },
       select: { cycleLengthDays: true },
     });
@@ -195,7 +195,7 @@ export async function updateTemplateInstance(
     return { ok: false, error: "Invalid time", code: "INVALID" };
   }
 
-  await prisma.templateEntry.update({
+  await prisma.timetableTemplateEntry.update({
     where: { id: instanceId },
     data: {
       ...(update.dayIndex !== undefined && { dayIndex: update.dayIndex }),
@@ -229,7 +229,7 @@ export async function updateTemplateDays(
     return { ok: false, error: "Invalid cycle length", code: "INVALID" };
   }
 
-  const stranded = await prisma.templateEntry.count({
+  const stranded = await prisma.timetableTemplateEntry.count({
     where: {
       templateId,
       template: { orgId },
@@ -244,7 +244,7 @@ export async function updateTemplateDays(
     };
   }
 
-  const updated = await prisma.template.updateMany({
+  const updated = await prisma.timetableTemplate.updateMany({
     where: { id: templateId, orgId },
     data: { cycleLengthDays },
   });
@@ -268,7 +268,7 @@ export async function addTemplateInstanceAssignee(
   membershipId: string,
 ): Promise<ServiceResult<null>> {
   const [entry, membership] = await Promise.all([
-    prisma.templateEntry.findFirst({
+    prisma.timetableTemplateEntry.findFirst({
       where: { id: instanceId, template: { orgId } },
       select: { id: true },
     }),
@@ -282,7 +282,7 @@ export async function addTemplateInstanceAssignee(
   if (!membership)
     return { ok: false, error: "Membership not found", code: "NOT_FOUND" };
 
-  await prisma.templateEntryAssignee.upsert({
+  await prisma.timetableTemplateEntryAssignee.upsert({
     where: {
       templateEntryId_membershipId: {
         templateEntryId: instanceId,
@@ -308,7 +308,7 @@ export async function removeTemplateInstanceAssignee(
   instanceId: string,
   membershipId: string,
 ): Promise<ServiceResult<null>> {
-  const assignee = await prisma.templateEntryAssignee.findFirst({
+  const assignee = await prisma.timetableTemplateEntryAssignee.findFirst({
     where: {
       templateEntryId: instanceId,
       membershipId,
@@ -318,7 +318,7 @@ export async function removeTemplateInstanceAssignee(
   });
   if (!assignee) return { ok: false, error: "Not found", code: "NOT_FOUND" };
 
-  await prisma.templateEntryAssignee.delete({ where: { id: assignee.id } });
+  await prisma.timetableTemplateEntryAssignee.delete({ where: { id: assignee.id } });
   log.info("Template instance assignee removed", {
     orgId,
     instanceId,
@@ -399,7 +399,7 @@ export async function applyTemplate(
       where: { id: orgId },
       select: { timezone: true },
     }),
-    prisma.template.findFirst({
+    prisma.timetableTemplate.findFirst({
       where: { id: templateId, orgId },
       include: {
         entries: {
@@ -532,13 +532,13 @@ export async function renameTemplate(
   if (!trimmed)
     return { ok: false, error: "Name is required", code: "INVALID" };
 
-  const existing = await prisma.template.findFirst({
+  const existing = await prisma.timetableTemplate.findFirst({
     where: { id: templateId, orgId },
     select: { name: true },
   });
 
   try {
-    const updated = await prisma.template.updateMany({
+    const updated = await prisma.timetableTemplate.updateMany({
       where: { id: templateId, orgId },
       data: { name: trimmed },
     });
@@ -581,7 +581,7 @@ export async function duplicateTemplate(
   templateId: string,
   actorId?: string | null,
 ): Promise<ServiceResult<{ id: string }>> {
-  const template = await prisma.template.findFirst({
+  const template = await prisma.timetableTemplate.findFirst({
     where: { id: templateId, orgId },
     include: {
       entries: {
@@ -601,7 +601,7 @@ export async function duplicateTemplate(
       attempt === 0 ? baseName : `${baseName} (${attempt + 1})`;
 
     try {
-      const copy = await prisma.template.create({
+      const copy = await prisma.timetableTemplate.create({
         data: {
           orgId,
           name: candidateName,
@@ -674,11 +674,11 @@ export async function deleteTemplate(
   templateId: string,
   actorId?: string | null,
 ): Promise<ServiceResult<null>> {
-  const existing = await prisma.template.findFirst({
+  const existing = await prisma.timetableTemplate.findFirst({
     where: { id: templateId, orgId },
     select: { name: true, cycleLengthDays: true },
   });
-  const deleted = await prisma.template.deleteMany({
+  const deleted = await prisma.timetableTemplate.deleteMany({
     where: { id: templateId, orgId },
   });
   if (deleted.count === 0)

--- a/lib/services/tools.ts
+++ b/lib/services/tools.ts
@@ -247,6 +247,41 @@ export async function createConversionTemplate(setId: string, name: string, orgI
 }
 
 /**
+ * Duplicates a template and all its entries into a new template with the given name.
+ * Runs in a single transaction so either everything succeeds or nothing changes.
+ */
+export async function duplicateConversionTemplate(
+  orgId: string,
+  templateId: string,
+  newName: string,
+) {
+  return prisma.$transaction(async (tx) => {
+    // Fetch source template (scoped to org)
+    const source = await tx.conversionTemplate.findFirst({
+      where: { id: templateId, set: { orgId } },
+      select: { setId: true, entries: { select: { itemId: true, quantity: true, pinnedOutput: true } } },
+    });
+    if (!source) throw new Error("Template not found or access denied");
+
+    const created = await tx.conversionTemplate.create({
+      data: {
+        setId: source.setId,
+        name: newName,
+        entries: {
+          create: source.entries.map((e) => ({
+            itemId: e.itemId,
+            quantity: e.quantity,
+            pinnedOutput: e.pinnedOutput,
+          })),
+        },
+      },
+      select: { id: true, name: true },
+    });
+    return created;
+  });
+}
+
+/**
  * Deletes a template and all its entries.
  * The "Default" template guard is enforced in the server action layer, not here.
  */

--- a/prisma/migrations/20260513023554_rename_template_to_timetable_template_add_roster/migration.sql
+++ b/prisma/migrations/20260513023554_rename_template_to_timetable_template_add_roster/migration.sql
@@ -1,0 +1,144 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Template` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `TemplateEntry` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `TemplateEntryAssignee` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Template" DROP CONSTRAINT "Template_orgId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "TemplateEntry" DROP CONSTRAINT "TemplateEntry_taskId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "TemplateEntry" DROP CONSTRAINT "TemplateEntry_templateId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "TemplateEntryAssignee" DROP CONSTRAINT "TemplateEntryAssignee_membershipId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "TemplateEntryAssignee" DROP CONSTRAINT "TemplateEntryAssignee_templateEntryId_fkey";
+
+-- DropTable
+DROP TABLE "Template";
+
+-- DropTable
+DROP TABLE "TemplateEntry";
+
+-- DropTable
+DROP TABLE "TemplateEntryAssignee";
+
+-- CreateTable
+CREATE TABLE "TimetableTemplate" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "cycleLengthDays" INTEGER NOT NULL DEFAULT 7,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TimetableTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TimetableTemplateEntry" (
+    "id" TEXT NOT NULL,
+    "templateId" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "priority" INTEGER NOT NULL DEFAULT 0,
+    "durationMin" INTEGER,
+    "dayIndex" INTEGER NOT NULL,
+    "startTimeMin" INTEGER NOT NULL,
+    "endTimeMin" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TimetableTemplateEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TimetableTemplateEntryAssignee" (
+    "id" TEXT NOT NULL,
+    "templateEntryId" TEXT NOT NULL,
+    "membershipId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TimetableTemplateEntryAssignee_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RosterEntry" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "membershipId" TEXT NOT NULL,
+    "weekStart" TIMESTAMP(3) NOT NULL,
+    "dayIndex" INTEGER NOT NULL,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RosterEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RosterDayConfig" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "dayIndex" INTEGER NOT NULL,
+    "recommendedSize" INTEGER NOT NULL DEFAULT 1,
+
+    CONSTRAINT "RosterDayConfig_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TimetableTemplate_orgId_idx" ON "TimetableTemplate"("orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TimetableTemplate_name_orgId_key" ON "TimetableTemplate"("name", "orgId");
+
+-- CreateIndex
+CREATE INDEX "TimetableTemplateEntryAssignee_membershipId_idx" ON "TimetableTemplateEntryAssignee"("membershipId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TimetableTemplateEntryAssignee_templateEntryId_membershipId_key" ON "TimetableTemplateEntryAssignee"("templateEntryId", "membershipId");
+
+-- CreateIndex
+CREATE INDEX "RosterEntry_orgId_weekStart_idx" ON "RosterEntry"("orgId", "weekStart");
+
+-- CreateIndex
+CREATE INDEX "RosterEntry_membershipId_idx" ON "RosterEntry"("membershipId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RosterEntry_orgId_membershipId_weekStart_dayIndex_key" ON "RosterEntry"("orgId", "membershipId", "weekStart", "dayIndex");
+
+-- CreateIndex
+CREATE INDEX "RosterDayConfig_orgId_idx" ON "RosterDayConfig"("orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RosterDayConfig_orgId_dayIndex_key" ON "RosterDayConfig"("orgId", "dayIndex");
+
+-- AddForeignKey
+ALTER TABLE "TimetableTemplate" ADD CONSTRAINT "TimetableTemplate_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TimetableTemplateEntry" ADD CONSTRAINT "TimetableTemplateEntry_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "TimetableTemplate"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TimetableTemplateEntry" ADD CONSTRAINT "TimetableTemplateEntry_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TimetableTemplateEntryAssignee" ADD CONSTRAINT "TimetableTemplateEntryAssignee_templateEntryId_fkey" FOREIGN KEY ("templateEntryId") REFERENCES "TimetableTemplateEntry"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TimetableTemplateEntryAssignee" ADD CONSTRAINT "TimetableTemplateEntryAssignee_membershipId_fkey" FOREIGN KEY ("membershipId") REFERENCES "Membership"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RosterEntry" ADD CONSTRAINT "RosterEntry_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RosterEntry" ADD CONSTRAINT "RosterEntry_membershipId_fkey" FOREIGN KEY ("membershipId") REFERENCES "Membership"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RosterDayConfig" ADD CONSTRAINT "RosterDayConfig_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260513023554_rename_template_to_timetable_template_add_roster/migration.sql
+++ b/prisma/migrations/20260513023554_rename_template_to_timetable_template_add_roster/migration.sql
@@ -1,74 +1,39 @@
 /*
-  Warnings:
+  SAFE RENAME MIGRATION — data is preserved via ALTER TABLE RENAME.
 
-  - You are about to drop the `Template` table. If the table is not empty, all the data it contains will be lost.
-  - You are about to drop the `TemplateEntry` table. If the table is not empty, all the data it contains will be lost.
-  - You are about to drop the `TemplateEntryAssignee` table. If the table is not empty, all the data it contains will be lost.
+  Original Prisma-generated SQL used DROP TABLE + CREATE TABLE, which would
+  destroy all TimetableTemplate data on production deploy. This has been
+  rewritten to rename tables/constraints/indexes in place.
 
+  ⚠️  Local dev note: if you already applied the old (DROP-based) version,
+  your local _prisma_migrations checksum will mismatch. Run
+  `pnpm prisma migrate reset` to resync your local DB from scratch.
 */
--- DropForeignKey
-ALTER TABLE "Template" DROP CONSTRAINT "Template_orgId_fkey";
 
--- DropForeignKey
-ALTER TABLE "TemplateEntry" DROP CONSTRAINT "TemplateEntry_taskId_fkey";
+-- Rename tables (all rows are preserved)
+ALTER TABLE "Template" RENAME TO "TimetableTemplate";
+ALTER TABLE "TemplateEntry" RENAME TO "TimetableTemplateEntry";
+ALTER TABLE "TemplateEntryAssignee" RENAME TO "TimetableTemplateEntryAssignee";
 
--- DropForeignKey
-ALTER TABLE "TemplateEntry" DROP CONSTRAINT "TemplateEntry_templateId_fkey";
+-- Rename primary key constraints
+ALTER TABLE "TimetableTemplate" RENAME CONSTRAINT "Template_pkey" TO "TimetableTemplate_pkey";
+ALTER TABLE "TimetableTemplateEntry" RENAME CONSTRAINT "TemplateEntry_pkey" TO "TimetableTemplateEntry_pkey";
+ALTER TABLE "TimetableTemplateEntryAssignee" RENAME CONSTRAINT "TemplateEntryAssignee_pkey" TO "TimetableTemplateEntryAssignee_pkey";
 
--- DropForeignKey
-ALTER TABLE "TemplateEntryAssignee" DROP CONSTRAINT "TemplateEntryAssignee_membershipId_fkey";
+-- Rename indexes
+ALTER INDEX "Template_orgId_idx" RENAME TO "TimetableTemplate_orgId_idx";
+ALTER INDEX "Template_name_orgId_key" RENAME TO "TimetableTemplate_name_orgId_key";
+ALTER INDEX "TemplateEntryAssignee_membershipId_idx" RENAME TO "TimetableTemplateEntryAssignee_membershipId_idx";
+ALTER INDEX "TemplateEntryAssignee_templateEntryId_membershipId_key" RENAME TO "TimetableTemplateEntryAssignee_templateEntryId_membershipId_key";
 
--- DropForeignKey
-ALTER TABLE "TemplateEntryAssignee" DROP CONSTRAINT "TemplateEntryAssignee_templateEntryId_fkey";
+-- Rename foreign key constraints
+ALTER TABLE "TimetableTemplate" RENAME CONSTRAINT "Template_orgId_fkey" TO "TimetableTemplate_orgId_fkey";
+ALTER TABLE "TimetableTemplateEntry" RENAME CONSTRAINT "TemplateEntry_templateId_fkey" TO "TimetableTemplateEntry_templateId_fkey";
+ALTER TABLE "TimetableTemplateEntry" RENAME CONSTRAINT "TemplateEntry_taskId_fkey" TO "TimetableTemplateEntry_taskId_fkey";
+ALTER TABLE "TimetableTemplateEntryAssignee" RENAME CONSTRAINT "TemplateEntryAssignee_templateEntryId_fkey" TO "TimetableTemplateEntryAssignee_templateEntryId_fkey";
+ALTER TABLE "TimetableTemplateEntryAssignee" RENAME CONSTRAINT "TemplateEntryAssignee_membershipId_fkey" TO "TimetableTemplateEntryAssignee_membershipId_fkey";
 
--- DropTable
-DROP TABLE "Template";
-
--- DropTable
-DROP TABLE "TemplateEntry";
-
--- DropTable
-DROP TABLE "TemplateEntryAssignee";
-
--- CreateTable
-CREATE TABLE "TimetableTemplate" (
-    "id" TEXT NOT NULL,
-    "name" TEXT NOT NULL,
-    "orgId" TEXT NOT NULL,
-    "cycleLengthDays" INTEGER NOT NULL DEFAULT 7,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
-
-    CONSTRAINT "TimetableTemplate_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "TimetableTemplateEntry" (
-    "id" TEXT NOT NULL,
-    "templateId" TEXT NOT NULL,
-    "taskId" TEXT NOT NULL,
-    "priority" INTEGER NOT NULL DEFAULT 0,
-    "durationMin" INTEGER,
-    "dayIndex" INTEGER NOT NULL,
-    "startTimeMin" INTEGER NOT NULL,
-    "endTimeMin" INTEGER NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
-
-    CONSTRAINT "TimetableTemplateEntry_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "TimetableTemplateEntryAssignee" (
-    "id" TEXT NOT NULL,
-    "templateEntryId" TEXT NOT NULL,
-    "membershipId" TEXT NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CONSTRAINT "TimetableTemplateEntryAssignee_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
+-- CreateTable (genuinely new — no existing data)
 CREATE TABLE "RosterEntry" (
     "id" TEXT NOT NULL,
     "orgId" TEXT NOT NULL,
@@ -82,7 +47,7 @@ CREATE TABLE "RosterEntry" (
     CONSTRAINT "RosterEntry_pkey" PRIMARY KEY ("id")
 );
 
--- CreateTable
+-- CreateTable (genuinely new — no existing data)
 CREATE TABLE "RosterDayConfig" (
     "id" TEXT NOT NULL,
     "orgId" TEXT NOT NULL,
@@ -91,18 +56,6 @@ CREATE TABLE "RosterDayConfig" (
 
     CONSTRAINT "RosterDayConfig_pkey" PRIMARY KEY ("id")
 );
-
--- CreateIndex
-CREATE INDEX "TimetableTemplate_orgId_idx" ON "TimetableTemplate"("orgId");
-
--- CreateIndex
-CREATE UNIQUE INDEX "TimetableTemplate_name_orgId_key" ON "TimetableTemplate"("name", "orgId");
-
--- CreateIndex
-CREATE INDEX "TimetableTemplateEntryAssignee_membershipId_idx" ON "TimetableTemplateEntryAssignee"("membershipId");
-
--- CreateIndex
-CREATE UNIQUE INDEX "TimetableTemplateEntryAssignee_templateEntryId_membershipId_key" ON "TimetableTemplateEntryAssignee"("templateEntryId", "membershipId");
 
 -- CreateIndex
 CREATE INDEX "RosterEntry_orgId_weekStart_idx" ON "RosterEntry"("orgId", "weekStart");
@@ -120,21 +73,6 @@ CREATE INDEX "RosterDayConfig_orgId_idx" ON "RosterDayConfig"("orgId");
 CREATE UNIQUE INDEX "RosterDayConfig_orgId_dayIndex_key" ON "RosterDayConfig"("orgId", "dayIndex");
 
 -- AddForeignKey
-ALTER TABLE "TimetableTemplate" ADD CONSTRAINT "TimetableTemplate_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "TimetableTemplateEntry" ADD CONSTRAINT "TimetableTemplateEntry_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "TimetableTemplate"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "TimetableTemplateEntry" ADD CONSTRAINT "TimetableTemplateEntry_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "TimetableTemplateEntryAssignee" ADD CONSTRAINT "TimetableTemplateEntryAssignee_templateEntryId_fkey" FOREIGN KEY ("templateEntryId") REFERENCES "TimetableTemplateEntry"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "TimetableTemplateEntryAssignee" ADD CONSTRAINT "TimetableTemplateEntryAssignee_membershipId_fkey" FOREIGN KEY ("membershipId") REFERENCES "Membership"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
 ALTER TABLE "RosterEntry" ADD CONSTRAINT "RosterEntry_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
@@ -142,3 +80,4 @@ ALTER TABLE "RosterEntry" ADD CONSTRAINT "RosterEntry_membershipId_fkey" FOREIGN
 
 -- AddForeignKey
 ALTER TABLE "RosterDayConfig" ADD CONSTRAINT "RosterDayConfig_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/migrations/20260513030121_add_shift_times_to_roster_entry/migration.sql
+++ b/prisma/migrations/20260513030121_add_shift_times_to_roster_entry/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "RosterEntry" ADD COLUMN     "shiftEndMin" INTEGER,
+ADD COLUMN     "shiftStartMin" INTEGER;

--- a/prisma/migrations/20260513031027_add_open_close_time_to_roster_day_config/migration.sql
+++ b/prisma/migrations/20260513031027_add_open_close_time_to_roster_day_config/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "RosterDayConfig" ADD COLUMN     "closeTimeMin" INTEGER,
+ADD COLUMN     "openTimeMin" INTEGER;

--- a/prisma/migrations/20260513122627_add_roster_template/migration.sql
+++ b/prisma/migrations/20260513122627_add_roster_template/migration.sql
@@ -1,0 +1,49 @@
+-- CreateTable
+CREATE TABLE "RosterTemplate" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RosterTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RosterTemplateEntry" (
+    "id" TEXT NOT NULL,
+    "templateId" TEXT NOT NULL,
+    "membershipId" TEXT NOT NULL,
+    "dayIndex" INTEGER NOT NULL,
+    "shiftStartMin" INTEGER,
+    "shiftEndMin" INTEGER,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RosterTemplateEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "RosterTemplate_orgId_idx" ON "RosterTemplate"("orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RosterTemplate_orgId_name_key" ON "RosterTemplate"("orgId", "name");
+
+-- CreateIndex
+CREATE INDEX "RosterTemplateEntry_templateId_idx" ON "RosterTemplateEntry"("templateId");
+
+-- CreateIndex
+CREATE INDEX "RosterTemplateEntry_membershipId_idx" ON "RosterTemplateEntry"("membershipId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RosterTemplateEntry_templateId_membershipId_dayIndex_key" ON "RosterTemplateEntry"("templateId", "membershipId", "dayIndex");
+
+-- AddForeignKey
+ALTER TABLE "RosterTemplate" ADD CONSTRAINT "RosterTemplate_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RosterTemplateEntry" ADD CONSTRAINT "RosterTemplateEntry_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "RosterTemplate"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RosterTemplateEntry" ADD CONSTRAINT "RosterTemplateEntry_membershipId_fkey" FOREIGN KEY ("membershipId") REFERENCES "Membership"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260513123326_roster_template_cycle_weeks/migration.sql
+++ b/prisma/migrations/20260513123326_roster_template_cycle_weeks/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[templateId,membershipId,weekIndex,dayIndex]` on the table `RosterTemplateEntry` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "RosterTemplateEntry_templateId_membershipId_dayIndex_key";
+
+-- AlterTable
+ALTER TABLE "RosterTemplate" ADD COLUMN     "cycleWeeks" INTEGER NOT NULL DEFAULT 1;
+
+-- AlterTable
+ALTER TABLE "RosterTemplateEntry" ADD COLUMN     "weekIndex" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RosterTemplateEntry_templateId_membershipId_weekIndex_dayIn_key" ON "RosterTemplateEntry"("templateId", "membershipId", "weekIndex", "dayIndex");

--- a/prisma/migrations/20260514000000_add_check_constraints/migration.sql
+++ b/prisma/migrations/20260514000000_add_check_constraints/migration.sql
@@ -1,0 +1,51 @@
+-- Add CHECK constraints to enforce documented day/time bounds.
+--
+-- dayIndex   : 0–6  (Mon=0 … Sun=6)
+-- *TimeMin   : 0–1440  (0 = midnight, 1440 = midnight next day)
+-- *StartMin / *EndMin : 0–1440 (nullable columns must also allow NULL)
+-- cycleWeeks : 1–12  (enforced in service layer; mirrored here)
+-- weekIndex  : >= 0
+
+-- ─── TimetableTemplateEntry ───────────────────────────────────────────────────
+-- dayIndex upper-bound is variable (cycleLengthDays), so only a lower-bound is enforced.
+ALTER TABLE "TimetableTemplateEntry"
+  ADD CONSTRAINT "TimetableTemplateEntry_dayIndex_check"
+    CHECK ("dayIndex" >= 0),
+  ADD CONSTRAINT "TimetableTemplateEntry_startTimeMin_check"
+    CHECK ("startTimeMin" >= 0 AND "startTimeMin" <= 1439),
+  ADD CONSTRAINT "TimetableTemplateEntry_endTimeMin_check"
+    CHECK ("endTimeMin" >= 0 AND "endTimeMin" <= 1439);
+
+-- ─── RosterEntry ─────────────────────────────────────────────────────────────
+ALTER TABLE "RosterEntry"
+  ADD CONSTRAINT "RosterEntry_dayIndex_check"
+    CHECK ("dayIndex" >= 0 AND "dayIndex" <= 6),
+  ADD CONSTRAINT "RosterEntry_shiftStartMin_check"
+    CHECK ("shiftStartMin" IS NULL OR ("shiftStartMin" >= 0 AND "shiftStartMin" <= 1440)),
+  ADD CONSTRAINT "RosterEntry_shiftEndMin_check"
+    CHECK ("shiftEndMin" IS NULL OR ("shiftEndMin" >= 0 AND "shiftEndMin" <= 1440));
+
+-- ─── RosterDayConfig ─────────────────────────────────────────────────────────
+ALTER TABLE "RosterDayConfig"
+  ADD CONSTRAINT "RosterDayConfig_dayIndex_check"
+    CHECK ("dayIndex" >= 0 AND "dayIndex" <= 6),
+  ADD CONSTRAINT "RosterDayConfig_openTimeMin_check"
+    CHECK ("openTimeMin" IS NULL OR ("openTimeMin" >= 0 AND "openTimeMin" <= 1440)),
+  ADD CONSTRAINT "RosterDayConfig_closeTimeMin_check"
+    CHECK ("closeTimeMin" IS NULL OR ("closeTimeMin" >= 0 AND "closeTimeMin" <= 1440));
+
+-- ─── RosterTemplate ──────────────────────────────────────────────────────────
+ALTER TABLE "RosterTemplate"
+  ADD CONSTRAINT "RosterTemplate_cycleWeeks_check"
+    CHECK ("cycleWeeks" >= 1 AND "cycleWeeks" <= 12);
+
+-- ─── RosterTemplateEntry ─────────────────────────────────────────────────────
+ALTER TABLE "RosterTemplateEntry"
+  ADD CONSTRAINT "RosterTemplateEntry_weekIndex_check"
+    CHECK ("weekIndex" >= 0),
+  ADD CONSTRAINT "RosterTemplateEntry_dayIndex_check"
+    CHECK ("dayIndex" >= 0 AND "dayIndex" <= 6),
+  ADD CONSTRAINT "RosterTemplateEntry_shiftStartMin_check"
+    CHECK ("shiftStartMin" IS NULL OR ("shiftStartMin" >= 0 AND "shiftStartMin" <= 1440)),
+  ADD CONSTRAINT "RosterTemplateEntry_shiftEndMin_check"
+    CHECK ("shiftEndMin" IS NULL OR ("shiftEndMin" >= 0 AND "shiftEndMin" <= 1440));

--- a/prisma/migrations/20260514000000_add_check_constraints/migration.sql
+++ b/prisma/migrations/20260514000000_add_check_constraints/migration.sql
@@ -1,8 +1,7 @@
 -- Add CHECK constraints to enforce documented day/time bounds.
 --
 -- dayIndex   : 0–6  (Mon=0 … Sun=6)
--- *TimeMin   : 0–1440  (0 = midnight, 1440 = midnight next day)
--- *StartMin / *EndMin : 0–1440 (nullable columns must also allow NULL)
+-- *TimeMin   : 0–1440  (0 = midnight, 1440 = midnight next day — all scheduling models)
 -- cycleWeeks : 1–12  (enforced in service layer; mirrored here)
 -- weekIndex  : >= 0
 
@@ -12,9 +11,9 @@ ALTER TABLE "TimetableTemplateEntry"
   ADD CONSTRAINT "TimetableTemplateEntry_dayIndex_check"
     CHECK ("dayIndex" >= 0),
   ADD CONSTRAINT "TimetableTemplateEntry_startTimeMin_check"
-    CHECK ("startTimeMin" >= 0 AND "startTimeMin" <= 1439),
+    CHECK ("startTimeMin" >= 0 AND "startTimeMin" <= 1440),
   ADD CONSTRAINT "TimetableTemplateEntry_endTimeMin_check"
-    CHECK ("endTimeMin" >= 0 AND "endTimeMin" <= 1439);
+    CHECK ("endTimeMin" >= 0 AND "endTimeMin" <= 1440);
 
 -- ─── RosterEntry ─────────────────────────────────────────────────────────────
 ALTER TABLE "RosterEntry"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -197,6 +197,7 @@ model Membership {
 
   // Real users: one membership per org. Bots have null userId so no unique conflict.
   @@unique([userId, orgId])
+  @@unique([id, orgId])
   @@index([orgId])
   @@index([userId])
 }
@@ -497,8 +498,9 @@ model RosterEntry {
   orgId        String
   organization Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
 
-  membershipId String
-  membership   Membership @relation(fields: [membershipId], references: [id], onDelete: Cascade)
+  membershipId    String
+  membershipOrgId String
+  membership      Membership @relation(fields: [membershipId, membershipOrgId], references: [id, orgId], onDelete: Cascade)
 
   weekStart    DateTime // Always Monday 00:00:00 UTC
   dayIndex     Int      // 0=Mon … 6=Sun
@@ -554,8 +556,9 @@ model RosterTemplateEntry {
   templateId   String
   template     RosterTemplate @relation(fields: [templateId], references: [id], onDelete: Cascade)
 
-  membershipId String
-  membership   Membership @relation(fields: [membershipId], references: [id], onDelete: Cascade)
+  membershipId    String
+  membershipOrgId String
+  membership      Membership @relation(fields: [membershipId, membershipOrgId], references: [id, orgId], onDelete: Cascade)
 
   weekIndex     Int   @default(0) // 0-based week within the template cycle
   dayIndex      Int   // 0=Mon … 6=Sun

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,7 +149,9 @@ model Organization {
   tags                Tag[]
   timetableEntries    TimetableEntry[]
   timetableSettings   TimetableSettings?
-  templates           Template[]
+  timetableTemplates  TimetableTemplate[]
+  rosterEntries       RosterEntry[]
+  rosterDayConfigs    RosterDayConfig[]
   franchiseTokens     FranchiseToken[]
   invites             Invite[]
   auditLogs           AuditLog[]
@@ -185,7 +187,8 @@ model Membership {
 
   memberRoles         MemberRole[]
   taskAssignments     TimetableEntryAssignee[]
-  templateAssignments TemplateEntryAssignee[]
+  timetableTemplateAssignments TimetableTemplateEntryAssignee[]
+  rosterEntries                RosterEntry[]
 
   joinedAt      DateTime @default(now())
   updatedAt     DateTime @updatedAt
@@ -284,7 +287,7 @@ model Task {
   eligibility           TaskEligibility[]
   tags                  TaskTag[]
   timetableEntries      TimetableEntry[]
-  templateEntries       TemplateEntry[]
+  timetableTemplateEntries TimetableTemplateEntry[]
 
   createdAt             DateTime @default(now())
   updatedAt             DateTime @updatedAt
@@ -424,10 +427,10 @@ model TimetableSettings {
 }
 
 // ─────────────────────────────────────
-// 14. TEMPLATE
+// 14. TIMETABLE TEMPLATE
 // ─────────────────────────────────────
 
-model Template {
+model TimetableTemplate {
   id              String   @id @default(cuid())
   name            String
 
@@ -436,7 +439,7 @@ model Template {
 
   cycleLengthDays Int      @default(7)
 
-  entries         TemplateEntry[]
+  entries         TimetableTemplateEntry[]
 
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
@@ -445,11 +448,11 @@ model Template {
   @@index([orgId])
 }
 
-model TemplateEntry {
+model TimetableTemplateEntry {
   id            String   @id @default(cuid())
 
   templateId    String
-  template      Template @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  template      TimetableTemplate @relation(fields: [templateId], references: [id], onDelete: Cascade)
 
   taskId        String
   task          Task     @relation(fields: [taskId], references: [id], onDelete: Cascade)
@@ -462,24 +465,63 @@ model TemplateEntry {
   startTimeMin  Int      // 0-1439
   endTimeMin    Int      // 0-1439
 
-  assignees     TemplateEntryAssignee[]
+  assignees     TimetableTemplateEntryAssignee[]
 
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 }
 
-model TemplateEntryAssignee {
+model TimetableTemplateEntryAssignee {
   id                String @id @default(cuid())
   templateEntryId   String
   membershipId      String
 
-  templateEntry     TemplateEntry @relation(fields: [templateEntryId], references: [id], onDelete: Cascade)
-  membership        Membership    @relation(fields: [membershipId], references: [id], onDelete: Cascade)
+  templateEntry     TimetableTemplateEntry @relation(fields: [templateEntryId], references: [id], onDelete: Cascade)
+  membership        Membership             @relation(fields: [membershipId], references: [id], onDelete: Cascade)
 
   createdAt         DateTime @default(now())
 
   @@unique([templateEntryId, membershipId])
   @@index([membershipId])
+}
+
+// ─────────────────────────────────────
+// ROSTER
+// ─────────────────────────────────────
+
+model RosterEntry {
+  id           String   @id @default(cuid())
+
+  orgId        String
+  organization Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  membershipId String
+  membership   Membership @relation(fields: [membershipId], references: [id], onDelete: Cascade)
+
+  weekStart    DateTime // Always Monday 00:00:00 UTC
+  dayIndex     Int      // 0=Mon … 6=Sun
+
+  note         String?
+
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@unique([orgId, membershipId, weekStart, dayIndex])
+  @@index([orgId, weekStart])
+  @@index([membershipId])
+}
+
+model RosterDayConfig {
+  id              String @id @default(cuid())
+
+  orgId           String
+  organization    Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  dayIndex        Int    // 0=Mon … 6=Sun
+  recommendedSize Int    @default(1)
+
+  @@unique([orgId, dayIndex])
+  @@index([orgId])
 }
 
 // ─────────────────────────────────────

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -152,6 +152,7 @@ model Organization {
   timetableTemplates  TimetableTemplate[]
   rosterEntries       RosterEntry[]
   rosterDayConfigs    RosterDayConfig[]
+  rosterTemplates     RosterTemplate[]
   franchiseTokens     FranchiseToken[]
   invites             Invite[]
   auditLogs           AuditLog[]
@@ -189,6 +190,7 @@ model Membership {
   taskAssignments     TimetableEntryAssignee[]
   timetableTemplateAssignments TimetableTemplateEntryAssignee[]
   rosterEntries                RosterEntry[]
+  rosterTemplateEntries        RosterTemplateEntry[]
 
   joinedAt      DateTime @default(now())
   updatedAt     DateTime @updatedAt
@@ -527,6 +529,46 @@ model RosterDayConfig {
 
   @@unique([orgId, dayIndex])
   @@index([orgId])
+}
+
+model RosterTemplate {
+  id        String   @id @default(cuid())
+  name      String
+  cycleWeeks Int     @default(1) // Number of weeks in this template cycle
+
+  orgId     String
+  organization Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  entries   RosterTemplateEntry[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([orgId, name])
+  @@index([orgId])
+}
+
+model RosterTemplateEntry {
+  id           String   @id @default(cuid())
+
+  templateId   String
+  template     RosterTemplate @relation(fields: [templateId], references: [id], onDelete: Cascade)
+
+  membershipId String
+  membership   Membership @relation(fields: [membershipId], references: [id], onDelete: Cascade)
+
+  weekIndex     Int   @default(0) // 0-based week within the template cycle
+  dayIndex      Int   // 0=Mon … 6=Sun
+  shiftStartMin Int?  // null = unspecified / all day
+  shiftEndMin   Int?  // 0-1440
+  note          String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([templateId, membershipId, weekIndex, dayIndex])
+  @@index([templateId])
+  @@index([membershipId])
 }
 
 // ─────────────────────────────────────

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -501,6 +501,9 @@ model RosterEntry {
   weekStart    DateTime // Always Monday 00:00:00 UTC
   dayIndex     Int      // 0=Mon … 6=Sun
 
+  shiftStartMin Int?   // null = unspecified / all day
+  shiftEndMin   Int?   // 0-1440
+
   note         String?
 
   createdAt    DateTime @default(now())
@@ -519,6 +522,8 @@ model RosterDayConfig {
 
   dayIndex        Int    // 0=Mon … 6=Sun
   recommendedSize Int    @default(1)
+  openTimeMin     Int?   // null = inherit org default
+  closeTimeMin    Int?   // 0-1440
 
   @@unique([orgId, dayIndex])
   @@index([orgId])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -69,10 +69,10 @@ function makeDateUtils(tz: string) {
 
 async function cleanDatabase() {
   await prisma.timetableEntryAssignee.deleteMany();
-  await prisma.templateEntryAssignee.deleteMany();
+  await prisma.timetableTemplateEntryAssignee.deleteMany();
   await prisma.timetableEntry.deleteMany();
-  await prisma.templateEntry.deleteMany();
-  await prisma.template.deleteMany();
+  await prisma.timetableTemplateEntry.deleteMany();
+  await prisma.timetableTemplate.deleteMany();
   await prisma.taskEligibility.deleteMany();
   await prisma.task.deleteMany();
   await prisma.permission.deleteMany();
@@ -798,13 +798,13 @@ async function seedOrg1(users: Users) {
   console.log("→ Creating templates...");
 
   const [tplWeek1, tplWeekend, tplCleaning] = await Promise.all([
-    prisma.template.create({
+    prisma.timetableTemplate.create({
       data: { orgId: org.id, name: "Weekday Rotation", cycleLengthDays: 5 },
     }),
-    prisma.template.create({
+    prisma.timetableTemplate.create({
       data: { orgId: org.id, name: "Weekend Shift", cycleLengthDays: 2 },
     }),
-    prisma.template.create({
+    prisma.timetableTemplate.create({
       data: {
         orgId: org.id,
         name: "Weekly Cleaning Schedule",
@@ -813,7 +813,7 @@ async function seedOrg1(users: Users) {
     }),
   ]);
 
-  await prisma.templateEntry.createMany({
+  await prisma.timetableTemplateEntry.createMany({
     data: [
       // Weekday Rotation (5-day cycle)
       {
@@ -1965,11 +1965,11 @@ async function seedOrg2(users: Users) {
     skipDuplicates: true,
   });
 
-  const template = await prisma.template.create({
+  const template = await prisma.timetableTemplate.create({
     data: { orgId: org.id, name: "Standard Week", cycleLengthDays: 7 },
   });
 
-  await prisma.templateEntry.createMany({
+  await prisma.timetableTemplateEntry.createMany({
     data: [
       {
         templateId: template.id,
@@ -2723,11 +2723,11 @@ async function seedOrg3(users: Users) {
     skipDuplicates: true,
   });
 
-  const template = await prisma.template.create({
+  const template = await prisma.timetableTemplate.create({
     data: { orgId: org.id, name: "5-Day Rotation", cycleLengthDays: 5 },
   });
 
-  await prisma.templateEntry.createMany({
+  await prisma.timetableTemplateEntry.createMany({
     data: [
       {
         templateId: template.id,

--- a/scripts/seed-donut-shop-a.ts
+++ b/scripts/seed-donut-shop-a.ts
@@ -771,13 +771,13 @@ async function main() {
   console.log("→ Creating templates...");
 
   const [tplWeek1, tplWeekend, tplCleaning] = await Promise.all([
-    prisma.template.create({
+    prisma.timetableTemplate.create({
       data: { orgId: org.id, name: "Weekday Rotation", cycleLengthDays: 5 },
     }),
-    prisma.template.create({
+    prisma.timetableTemplate.create({
       data: { orgId: org.id, name: "Weekend Shift", cycleLengthDays: 2 },
     }),
-    prisma.template.create({
+    prisma.timetableTemplate.create({
       data: {
         orgId: org.id,
         name: "Weekly Cleaning Schedule",
@@ -786,7 +786,7 @@ async function main() {
     }),
   ]);
 
-  await prisma.templateEntry.createMany({
+  await prisma.timetableTemplateEntry.createMany({
     data: [
       // Weekday Rotation (5-day cycle)
       {


### PR DESCRIPTION
## What Changed

Adds a full **Roster Templates** system — create reusable shift patterns (cycle of N weeks) and apply them to real roster weeks.

**Template Editor**
- New `/orgs/[orgId]/tools/roster/templates` list page and `[templateId]` editor page
- Cycle-week grid with column navigation (prev/next) when more weeks than fit on screen — nav matches roster board style (left-side, outline buttons, "Week X–Y" label)
- Hover effects (cursor-pointer + darker brightness) on both the roster board and template board cells
- Safe week removal: if the last week has entries, shows an inline confirm panel before decrementing; clears entries then decrements in one go

**Apply Template**
- `applyRosterTemplate` service: checks for conflicts (existing `RosterEntry` rows in target weeks), returns `code: "CONFLICT"` without `force`, performs a delete + bulk-insert in a transaction with `force: true`
- `applyRosterTemplateAction`: snaps start date to nearest Monday, delegates to service, revalidates roster path
- `ApplyTemplatePanel` action-sidebar panel: template picker, start-date input (defaults to this Monday), repeat-cycle stepper, conflict warning with **Replace** / **Cancel** flow
- Apply Template button wired into the roster page sidebar via `ActionSidebar` pattern (active-state toggle, `keyRef` remount to reset panel on each open)

**Schema**
- `RosterTemplate` (id, orgId, name, cycleWeeks, timestamps)
- `RosterTemplateEntry` (id, templateId, weekIndex, dayIndex, membershipId, shiftStartMin, shiftEndMin)
- Two migrations: initial model + `cycleWeeks` column addition

## Why

Allows franchisees to build a standard week rotation once and stamp it onto multiple weeks instead of filling the roster by hand every cycle.

## Type

- [ ] 🐛 Bug fix
- [x] ✨ Enhancement / Feature
- [ ] 🔧 Refactor
- [ ] 📝 Documentation
- [ ] 🎨 UI / Styling

## How to Test

1. Go to **Roster → Templates** and create a template (e.g. 2-week cycle)
2. Add shifts to each week's cells
3. Try decrementing the cycle weeks when entries exist — confirm dialog should appear
4. From the main Roster page open the sidebar → **Apply Template**
5. Pick the template, choose a start Monday, set repeat count, click **Apply**
6. Verify the correct `RosterEntry` rows appear in the roster board
7. Apply again over the same range — conflict warning should appear; click **Replace** to force-overwrite

## Screenshots / Recordings

<!-- Before & after if UI changed -->

## Checklist

- [ ] Tested on desktop (Chrome)
- [ ] Tested on mobile (iPhone Safari)
- [ ] No lint errors (`pnpm lint`)
- [ ] Build passes (`pnpm build`)
- [ ] Smoke test updated (if applicable)

## Smoke Test Issues Resolved

- [ ] #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Roster tool: weekly roster board, roster pages/clients, roster templates, apply/edit panels, day configs, and roster template editor with cycle-week management.
  * Schedule-mode task panel for timed template assignments.
  * Conversion template duplication and roster template creation/duplication.

* **UI/UX Improvements**
  * Roster links added across Tools and sidebars; sidebar navigation standardized.
  * Smaller user avatar and updated global font-weight styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IvanTran-2001/FriendChise/pull/132)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->