### PR TITLE
fix(feedback): store screenshots in private bucket with signed read URLs

### DIFF
--- a/app/actions/storage.ts
+++ b/app/actions/storage.ts
@@ -250,7 +250,7 @@ export async function getFeedbackImageUploadUrl(
   const uuid = crypto.randomUUID();
   const storagePath = `feedback/${authz.userId}/${uuid}.${ext}`;
 
-  return createSignedUploadUrlPublic(storagePath, FEEDBACK_IMAGE_MAX_BYTES);
+  return createSignedUploadUrl(storagePath, FEEDBACK_IMAGE_MAX_BYTES);
 }
 
 /**
@@ -264,16 +264,14 @@ export async function getFeedbackImageReadUrl(
   const authz = await requireSuperAdminAction();
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
-  // Validate path format (must be feedback/...)
   if (!storagePath.startsWith("feedback/")) {
     return { ok: false, error: "Invalid path" };
   }
 
   const { createSignedReadUrl } = await import("@/lib/supabase-storage");
-  const signedUrl = await createSignedReadUrl(storagePath, 3600); // 1 hour expiry
-  if (!signedUrl) {
-    return { ok: false, error: "Failed to generate signed URL" };
-  }
+  const signedUrl = await createSignedReadUrl(storagePath, 3600);
+  if (!signedUrl) return { ok: false, error: "Failed to generate signed URL" };
 
   return { ok: true, signedUrl };
 }
+

--- a/app/admin/feedback/_components/admin-feedback-client.tsx
+++ b/app/admin/feedback/_components/admin-feedback-client.tsx
@@ -59,14 +59,20 @@ export function AdminFeedbackClient({
   useEffect(() => {
     const load = async () => {
       const map: Record<string, string> = {};
-      await Promise.all(
+      const results = await Promise.allSettled(
         initial
           .filter((f) => f.imageUrl)
           .map(async (f) => {
             const res = await getFeedbackImageReadUrl(f.imageUrl!);
-            if (res.ok) map[f.imageUrl!] = res.signedUrl;
+            if (res.ok) return { imageUrl: f.imageUrl!, signedUrl: res.signedUrl };
+            return null;
           }),
       );
+      results.forEach((result) => {
+        if (result.status === "fulfilled" && result.value) {
+          map[result.value.imageUrl] = result.value.signedUrl;
+        }
+      });
       setImageUrls(map);
     };
     load();

--- a/app/admin/feedback/_components/admin-feedback-client.tsx
+++ b/app/admin/feedback/_components/admin-feedback-client.tsx
@@ -55,24 +55,24 @@ export function AdminFeedbackClient({
   const [, startTransition] = useTransition();
   const [imageUrls, setImageUrls] = useState<Record<string, string>>({});
 
-  const displayed = filter === "all" ? feedback : feedback.filter((f) => !f.reviewed);
-
-  // Load signed URLs for all images on mount
+  // Fetch short-lived signed read URLs for all images (private bucket)
   useEffect(() => {
-    const loadImageUrls = async () => {
-      const urlMap: Record<string, string> = {};
-      for (const item of feedback) {
-        if (item.imageUrl) {
-          const result = await getFeedbackImageReadUrl(item.imageUrl);
-          if (result.ok) {
-            urlMap[item.imageUrl] = result.signedUrl;
-          }
-        }
-      }
-      setImageUrls(urlMap);
+    const load = async () => {
+      const map: Record<string, string> = {};
+      await Promise.all(
+        initial
+          .filter((f) => f.imageUrl)
+          .map(async (f) => {
+            const res = await getFeedbackImageReadUrl(f.imageUrl!);
+            if (res.ok) map[f.imageUrl!] = res.signedUrl;
+          }),
+      );
+      setImageUrls(map);
     };
-    loadImageUrls();
-  }, [feedback]);
+    load();
+  }, [initial]);
+
+  const displayed = filter === "all" ? feedback : feedback.filter((f) => !f.reviewed);
 
   function toggleReviewed(id: string, next: boolean) {
     setFeedback((prev) =>


### PR DESCRIPTION
## What Changed

Feedback screenshots are now stored in the **private** Supabase bucket (`friendchise-private`) instead of the public bucket. The admin panel fetches short-lived signed read URLs (1-hour expiry) for each image instead of using permanent public URLs.

## Why

Screenshots may contain sensitive app content (task details, member lists, org data). Storing them publicly means anyone with the URL can view them indefinitely with no auth check. Private storage ensures only authenticated super-admins can view feedback images.

Closes #

## Type

- [x] 🐛 Bug fix

## How to Test

1. Submit feedback with a screenshot attached
2. Go to `/admin/feedback` as an admin user
3. Confirm the screenshot thumbnail renders correctly
4. Confirm the "open full size" link works
5. Confirm the image URL is a short-lived signed URL (not a permanent public URL)
6. Confirm a non-admin cannot access the signed URL generation action

## Screenshots / Recordings

<!-- Before & after if UI changed -->

## Checklist

- [ ] Tested on desktop (Chrome)
- [ ] Tested on mobile (iPhone Safari)
- [ ] No lint errors (`pnpm lint`)
- [ ] Build passes (`pnpm build`)
- [ ] Smoke test updated (if applicable)

## Smoke Test Issues Resolved

- [ ] #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feedback screenshot uploads now use private, secure storage instead of public access for improved data protection
  * Enhanced security controls for screenshot viewing with restricted access
  
* **Refactor**
  * Improved loading performance for feedback pages with multiple screenshots through optimized resource handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IvanTran-2001/FriendChise/pull/137)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->