### PR TITLE
feat: task comments, UI improvements, and cookie-based pref restoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,8 +846,8 @@ Org members with `MANAGE_TASKS` can additionally pin and delete any comment.
 | ------------------------------------------------- | ----------------------------------------------------- |
 | `canUserCommentOnTask(taskId, userOrgId)`          | Franchise root check — returns `true` if allowed      |
 | `getTaskComments(taskId)`                         | All top-level comments + one level of replies (asc)   |
-| `createComment(taskId, orgId, authorId, input)`   | Insert a new comment or reply                         |
-| `editComment(commentId, authorId, input)`         | Update content and set `editedAt`; author-only guard  |
+| `createComment(taskId, orgId, authorId, authorName, authorImage, input)`   | Insert a new comment or reply with author snapshot                         |
+| `editComment(taskId, commentId, authorId, input)`         | Update content and set `editedAt`; author-only guard  |
 | `softDeleteComment(commentId)`                    | Sets `isDeleted = true`; content replaced at render   |
 | `voteOnComment(commentId, userId, type)`          | Upserts a `TaskCommentVote`; removes vote if same type toggled |
 | `setPinComment(commentId, isPinned)`              | Toggles `isPinned` and `pinnedAt`                     |

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Provider: PostgreSQL (Supabase), managed via Prisma ORM.
 | `AdminUser`                      | Super-admin allow-list. Any `User` whose email appears here gains access to `/admin/*` routes and admin-only server actions.                                                                                                                                                                                                                                    |
 | `TaskInheritance`                | Tracks which orgs have added a GLOBAL task to their library. Created when a franchisee clicks "Add" on a shared task; deleted when they remove it. The owning org also gets an auto-created row on task creation. Unique on `(taskId, orgId)`.                                                                                                                  |
 | `TaskSectionLayout`              | Per-org, per-task section configuration. Stores `type` (e.g. `"PICTURE"`, `"DETAIL"`, `"COMMENT"`), display `title`, `scope` (`ORG`/`GLOBAL`), `position` (sort order), and `visible` flag. Defaults are seeded on task creation and copied from the parent org on inheritance. Unique on `(taskId, orgId, type)`.                                              |
+| `TaskComment`                    | One comment on a task. Scoped to both a `Task` and an `Organization` (the commenter's org). Supports one level of threading via `parentId`. `authorName`/`authorImage` are snapshotted at post time so display survives account deletion (`authorId` set to `NULL` via `onDelete: SetNull`). Soft-deletable (`isDeleted`). Supports pinning (`isPinned`, `pinnedAt`) and inline editing (`editedAt`). Indexed on `(taskId, orgId)`, `parentId`, and `authorId`. |
+| `TaskCommentVote`                | Up/down vote cast by a `User` on a `TaskComment`. Composite PK on `(commentId, userId)` prevents double-voting. `type` is `VoteType` (`UPVOTE` / `DOWNVOTE`). Cascades on comment and user deletion.                                                                                                                                                             |
 
 ### Enums
 
@@ -136,6 +138,7 @@ Provider: PostgreSQL (Supabase), managed via Prisma ORM.
 | `InviteType`       | `MEMBER`, `FRANCHISE`                                                                                     |
 | `ViewType`         | `DAILY`, `WEEKLY`                                                                                         |
 | `FeedbackType`     | `ISSUE`, `IDEA`                                                                                           |
+| `VoteType`         | `UPVOTE`, `DOWNVOTE` — used by `TaskCommentVote`                                                          |
 | `TaskScope`        | `ORG` (private — visible to owning org only), `GLOBAL` (shared — franchisees can discover and inherit)    |
 | `SectionScope`     | `ORG` (section interaction limited to the viewing org), `GLOBAL` (shared back to the franchisor)          |
 
@@ -172,6 +175,7 @@ pnpm seed
 | `20260514000000_add_check_constraints`                            | DB-level CHECK constraints enforcing field bounds: time fields 0–1440, `dayIndex` 0–6, `cycleWeeks` 1–12.                                                                                                                                                                                                                     |
 | _(schema push)_                                                   | `Feedback` model (`userId`, `orgId?`, `type`, `message`, `imageUrl?`, `reviewed`) and `AdminUser` model (`email unique`) added. Applied via `prisma db push` (dev DB had migration drift).                                                                                                                                    |
 | _(schema push)_                                                   | `TaskInheritance` (`taskId`, `orgId`, `inheritedAt`) and `TaskSectionLayout` (`taskId`, `orgId`, `type`, `title`, `scope`, `position`, `visible`) models added. `Task.scope` (`TaskScope` enum, default `ORG`) added. `SectionScope` enum added. Applied via `prisma db push` on the `feat/task-inheritance-sections` branch. |
+| _(schema push)_                                                   | `TaskComment` and `TaskCommentVote` models added. `VoteType` enum (`UPVOTE`, `DOWNVOTE`) added. `Task.comments`, `Organization.taskComments`, `User.taskComments`/`taskCommentVotes` relations added. Applied via `prisma db push` on the `feature/task-comment-section` branch.                                               |
 
 ## Authentication
 
@@ -388,6 +392,12 @@ app/
           layout.tsx            # Registers TasksSidebarShell for all tasks routes
           [taskId]/       # Task detail view (links from timetable)
             edit/         # Edit task form (includes color picker)
+            comments/     # Task comment section
+              index.tsx             # Async server component — gates access, fetches comments, passes to client
+              comment-section.tsx   # Client shell — owns reply/edit open state, calls router.refresh() after mutations
+              comment-item.tsx      # One comment row — votes (optimistic), pin, edit, delete, reply
+              comment-input.tsx     # Controlled textarea for posting/replying
+              types.ts              # CommentFE type (ISO string dates, aggregated votes)
           task-form.tsx   # Shared create/edit form — title, color picker, image upload (crop dialog), eligibility
           _components/
             tasks-config.ts             # Shared sort constants (SortOption, SORT_OPTIONS) — plain module, no "use client"
@@ -441,10 +451,11 @@ app/
     franchisee.ts
     roles.ts
     tags.ts               # Tag CRUD mutations (createTag, updateTag, deleteTag) — all require MANAGE_TASKS
-    roster.ts             # Roster entry and day-config mutations
+    roster.ts             # Roster entry and day-config mutations (requires MANAGE_MEMBERS)
     feedback.ts           # submitFeedbackAction — creates a Feedback row + optional screenshot upload
     tools.ts              # Conversion tool mutations — all require MANAGE_TASKS
     storage.ts            # Image upload actions for task images (private) and org logos (public)
+    task-comments.ts      # addCommentAction, editCommentAction, deleteCommentAction, voteCommentAction, pinCommentAction
   api/                    # REST API route handlers (session-authenticated)
     auth/[...nextauth]/
     orgs/
@@ -509,6 +520,7 @@ lib/
     feedback.ts         # submitFeedback — creates Feedback row, resolves storage path
     roster.ts           # RosterEntry + RosterDayConfig CRUD, template-apply helper
     tools.ts            # ConversionSet · ToolItem · ConversionRate · ConversionTemplate · ConversionTemplateEntry CRUD
+    task-comments.ts    # getTaskComments, canUserCommentOnTask, createComment, editComment, softDeleteComment, voteOnComment, setPinComment
   validators/
     org.ts
     membership.ts
@@ -516,6 +528,7 @@ lib/
     task-instance.ts
     assignee.ts
     role.ts
+    task-comment.ts     # addCommentSchema (content + optional parentId), editCommentSchema (content only)
 
 prisma/
   schema.prisma         # Role.color String (non-nullable), Task.color String (non-nullable)
@@ -776,7 +789,7 @@ RosterTemplate         — reusable pattern with cycleWeeks (1–12)
 
 ### Server actions (`app/actions/roster.ts`)
 
-All write actions require `MANAGE_TIMETABLE` permission.
+All write actions require `MANAGE_MEMBERS` permission.
 
 | Action                                 | Description                                                                              |
 | -------------------------------------- | ---------------------------------------------------------------------------------------- |
@@ -804,6 +817,60 @@ All write actions require `MANAGE_TIMETABLE` permission.
 | `formatMinutes(min)`      | Integer minutes → `"HH:MM"` string (e.g. 90 → `"01:30"`)           |
 | `timeToMinutes(time)`     | `"HH:MM"` string → integer minutes, or `null` for invalid input    |
 | `hoursWorked(start, end)` | Duration string (e.g. `"7h 30m"`) from two nullable minute offsets |
+
+## Task Comments
+
+Task comments are threaded discussions attached to a task definition. Any member whose org is in the same franchise network as the task's owning org can comment.
+
+### Permission model
+
+```
+franchiseRoot(org) = org.parentId ?? org.id
+canComment         = franchiseRoot(taskOrg) === franchiseRoot(userOrg)
+```
+
+Org members with `MANAGE_TASKS` can additionally pin and delete any comment.
+
+### Features
+
+- **Threaded replies** — one level deep (top-level comments + inline replies)
+- **Voting** — up/down votes per comment; one vote per user enforced by composite PK
+- **Pinning** — managers can pin a top-level comment to the top of the thread
+- **Inline editing** — authors can edit their own comment content; `editedAt` is set
+- **Soft delete** — deleted comments show a "[deleted]" tombstone; replies are preserved
+- **Author snapshot** — `authorName` and `authorImage` are captured at post time so comments display correctly even if the author's account is later deleted
+
+### Service layer (`lib/services/task-comments.ts`)
+
+| Function                                          | Description                                           |
+| ------------------------------------------------- | ----------------------------------------------------- |
+| `canUserCommentOnTask(taskId, userOrgId)`          | Franchise root check — returns `true` if allowed      |
+| `getTaskComments(taskId)`                         | All top-level comments + one level of replies (asc)   |
+| `createComment(taskId, orgId, authorId, input)`   | Insert a new comment or reply                         |
+| `editComment(commentId, authorId, input)`         | Update content and set `editedAt`; author-only guard  |
+| `softDeleteComment(commentId)`                    | Sets `isDeleted = true`; content replaced at render   |
+| `voteOnComment(commentId, userId, type)`          | Upserts a `TaskCommentVote`; removes vote if same type toggled |
+| `setPinComment(commentId, isPinned)`              | Toggles `isPinned` and `pinnedAt`                     |
+
+### Server actions (`app/actions/task-comments.ts`)
+
+| Action                | Auth requirement      | Description                                      |
+| --------------------- | --------------------- | ------------------------------------------------ |
+| `addCommentAction`    | Franchise member      | Post a new comment or reply                      |
+| `editCommentAction`   | Comment author        | Edit content of own comment                      |
+| `deleteCommentAction` | Author or `MANAGE_TASKS` | Soft-delete a comment                         |
+| `voteCommentAction`   | Franchise member      | Cast or toggle an up/down vote                   |
+| `pinCommentAction`    | `MANAGE_TASKS`        | Pin or unpin a top-level comment                 |
+
+### UI components (`app/(app)/orgs/[orgId]/tasks/[taskId]/comments/`)
+
+| File                   | Type   | Description                                                                     |
+| ---------------------- | ------ | ------------------------------------------------------------------------------- |
+| `index.tsx`            | Server | Async gate + hydration — parallel-fetches comments, canComment, canManage       |
+| `comment-section.tsx`  | Client | Stateful shell — owns reply/edit open state; calls `router.refresh()` on change |
+| `comment-item.tsx`     | Client | One comment row — votes (optimistic), pin, edit, delete, reply                  |
+| `comment-input.tsx`    | Client | Controlled textarea for new comments or replies                                 |
+| `types.ts`             | —      | `CommentFE` type (ISO string dates, aggregated vote counts, one-level replies)  |
 
 ## Server Actions vs API Routes
 
@@ -876,6 +943,7 @@ A parent org can spawn franchisee orgs using a one-time invite token flow:
 
 ## UI Notes
 
+- **Org color accents** — both the hub page (`/`) org cards and the org overview page (`/orgs/[orgId]`) derive a deterministic accent color from the org name via a seeded palette (`orgColor(name)` hashes the character codes mod 9). The hub card uses the color for the initials badge background and a top color bar; the overview page renders a `h-1.5` color bar at the top of the card. No extra DB field is required.
 - **Sidebar architecture** — Three context layers work together:
   - `MobileSidebarContext` — boolean open/close state for the global app sidebar overlay on mobile.
   - `AppSidebar` — desktop hover-expand strip (`w-12` → `w-52`); mobile fixed overlay. Uses `SidebarNavItem variant="app"`.
@@ -890,6 +958,8 @@ A parent org can spawn franchisee orgs using a one-time invite token flow:
 - **Role picker** — Searchable text input with a dropdown. Selecting a role auto-adds it; no `+` button. The owner role is never shown in the picker (filtered in the edit page query and enforced in the service layer).
 - **Owner role guard** — Three layers: (1) DB query filters it from `allRoles` on the edit page, (2) `updateMembership` rejects any `roleId` whose key is `"owner"`, (3) the new-member query uses `NOT: { key: "owner" }`.
 - **Clicking tasks in timetable** — In Calendar view the task title inside each block is a `<Link>` to the task detail page. In Simple (table) view the task name cell is a `<Link>`; clicking elsewhere in the row still opens the edit popup.
+- **Timetable simple view** — Replaced the `<table>` layout with flex rows. Each row has a colored accent bar (`w-1 self-stretch rounded-full`, color from `inst.taskColor`), a monospace time column, the task name (linked, truncated, line-through when done/skipped), assignee initials chips (max 3 + "+N" overflow, hidden on mobile), a compact duration label (`formatDuration` — e.g. `"45m"`, `"1h 30m"`), and a status badge pill. A small status dot replaces the badge on mobile (`sm:hidden`). The edit button fades out on hover focus for desktop.
+- **Mobile page sidebar X close button** — The mobile overlay for the page sidebar (`PageSidebarSlot`) includes an `absolute` positioned X button (top-right corner) to close the panel. It is positioned in the outer `fixed` container (not the scrollable inner div) so it stays visible while the user scrolls the sidebar content.
 - **Form validation** — server-action errors rendered inline with `aria-invalid`/`aria-describedby` plus a Sonner toast summary.
 - **Timetable** — Calendar and Simple mode toggle, week navigation via `?week=` and `?mode=` params. Calendar view uses absolute positioning for task blocks; overlapping tasks get side-by-side columns. Status colours: gray = TODO, amber = IN_PROGRESS, green = DONE, red = SKIPPED.
 - **Fixed toolbar / scroll containment** — `h-dvh` on `SidebarProvider` + `overflow-hidden` on `SidebarInset` keep the body from scrolling so toolbars can stay visually fixed. The `<main>` element is the actual scroll container. Child pages that need a pinned toolbar use `flex flex-col h-full` on their root, a static `<Toolbar>` at the top, and a `flex-1 overflow-auto` div below it for the scrollable list. Negative horizontal margins on the scrollable div cancel `<main>`'s padding so the list extends edge-to-edge.
@@ -898,7 +968,7 @@ A parent org can spawn franchisee orgs using a one-time invite token flow:
 - **Roster templates** — Reusable multi-week staffing patterns. A template has a `cycleWeeks` (1–12); the editor shows a 7-row × cycleWeeks-column grid. Clicking a cell opens an `ActionSidebar` panel to assign members and shift times. The +/− stepper adds/removes week columns — removing a column is blocked when entries exist in the last week. Applying a template (via the Apply Template panel on the live roster page) stamps the pattern starting from a selected Monday, repeating it `N` times; a conflict check prevents overwriting existing entries unless the force checkbox is ticked.
 - **Template list management** — MANAGE_TASKS holders see a ··· dropdown on each template (card and list view) with Rename (inline Dialog), Duplicate ("Copy of …" with collision suffix), and Delete (AlertDialog confirmation). Mutations call `revalidatePath` so the list refreshes without a full reload.
 - **Task descriptions** — Task descriptions are stored as GFM markdown and rendered via `react-markdown` + `remark-gfm` on the task detail page. The task list (card and table views) strips markdown via a lightweight `stripMd()` helper for plain-text previews.
-- **Task table** — `TaskTable` client component: search, sort (name/duration/people), role filter, row `···` menu (Edit / Duplicate / Delete with confirm). Clicking the row navigates to the task detail page.
+- **Task table** — `TaskTable` client component: search, sort (name/duration/people), role filter, row `···` menu (Edit / Duplicate / Delete with confirm). Clicking the row navigates to the task detail page (keyboard accessible — `role="button"` + `tabIndex=0`). In "All" and "Shared" modes each task row shows an ownership badge: **Mine** (org owns it), **Franchise** (inherited from parent), or **Available** (franchise global, not yet added).
 - **Roles page** — System roles show a `system` badge and cannot be deleted; Owner also cannot be edited. "+ Create Role" in the page sidebar opens an `ActionSidebar` panel with the full role form (name, color, permissions, task eligibility). The row `···` menu's "Edit" item opens the same form pre-filled in the action sidebar — no standalone `/new` or `/[roleId]/edit` pages. On success the panel closes and `router.refresh()` updates the table in place.
 - **Role security** — `createRole` and `updateRole` validate `taskIds` against tasks scoped to `orgId` inside a transaction. Cross-tenant IDs abort the transaction with an `INVALID` error.
 
@@ -1048,7 +1118,7 @@ SENTRY_AUTH_TOKEN=   # Required whenever source maps are uploaded at build time 
 
 ## Status
 
-Work in progress. Fully implemented: service layer (all 10 services with 93 integration tests), REST API, auth, member management (list, view, edit, restrict, delete), task management (list, view, create, edit with color), timetable view (calendar + simple, task links), timetable templates (create, rename, duplicate, delete, calendar/simple editor, cycle-length controls, apply to timetable), org settings, role management (list, create, edit, delete, task eligibility, color — all via action sidebar panels; no standalone create/edit pages), franchise management, required colors on tasks and roles, async breadcrumbs with name resolution, fixed-toolbar scroll containment on members and tasks pages, audit log (DB table + Zod-validated service layer, all significant mutations instrumented — UI pending), tasks/members/roles page sidebar redesign (shell + sub-content pattern matching timetable architecture, URL-param-driven filters, ActionSidebar panels for Invite Member + Add Bot + Create Role + Edit Role with mobile Dialog fallback).
+Work in progress. Fully implemented: service layer (all 10 services with 93 integration tests), REST API, auth, member management (list, view, edit, restrict, delete, convert-to-bot), task management (list, view, create, edit with color; ownership badges; card keyboard navigation), timetable view (calendar + simple, task links; simple view redesigned as flex rows with color accent bars, assignee chips, duration labels, status badge pills, and mobile status dots), timetable templates (create, rename, duplicate, delete, calendar/simple editor, cycle-length controls, apply to timetable), org settings, role management (list, create, edit, delete, task eligibility, color — all via action sidebar panels; no standalone create/edit pages), franchise management, required colors on tasks and roles, async breadcrumbs with name resolution, fixed-toolbar scroll containment on members and tasks pages, audit log (DB table + Zod-validated service layer, all significant mutations instrumented — UI pending), tasks/members/roles page sidebar redesign (shell + sub-content pattern matching timetable architecture, URL-param-driven filters, ActionSidebar panels for Invite Member + Add Bot + Create Role + Edit Role with mobile Dialog fallback), task comments (threaded comments with replies, voting, pinning, soft delete, inline edit — franchise-scoped permission model), mobile page sidebar X close button, org color accent bars (hub + overview), task filter/sort/view preferences persisted to both localStorage and cookies (server-side redirect on first load, no client round-trip), roster tool permissions corrected to MANAGE_MEMBERS.
 
 Not yet started: schedule generation (automatic cycle-based rotation), worker "Today" checklist, completion stats, timetable/notification settings pages, real-time notification refresh, audit log UI (activity feed page).
 

--- a/__tests__/e2e/tasks.spec.ts
+++ b/__tests__/e2e/tasks.spec.ts
@@ -126,7 +126,7 @@ test("edit task → updated title visible in task list and detail", async ({
 
   // Navigate to task detail
   await searchTasks(page, taskTitle);
-  await page.getByRole("cell", { name: taskTitle }).click();
+  await page.getByRole("button").filter({ hasText: taskTitle }).click();
   await expect(page).toHaveURL(/\/orgs\/.+\/tasks\/.+/);
   await expect(page.getByRole("heading", { name: taskTitle })).toBeVisible();
 
@@ -159,7 +159,7 @@ test("delete task from detail → removed from task list", async ({ page }) => {
 
   // Navigate to detail
   await searchTasks(page, taskTitle);
-  await page.getByRole("cell", { name: taskTitle }).click();
+  await page.getByRole("button").filter({ hasText: taskTitle }).click();
   await expect(page.getByRole("heading", { name: taskTitle })).toBeVisible();
 
   // Delete via task-actions toolbar
@@ -177,7 +177,7 @@ test("delete task from detail → removed from task list", async ({ page }) => {
   await expect(page).toHaveURL(`/orgs/${orgId}/tasks`, { timeout: 15000 });
 
   await searchTasks(page, taskTitle);
-  await expect(page.getByRole("cell", { name: taskTitle })).not.toBeVisible();
+  await expect(page.getByRole("button").filter({ hasText: taskTitle })).not.toBeVisible();
 });
 
 test("delete task from table row menu → removed from task list", async ({
@@ -195,7 +195,7 @@ test("delete task from table row menu → removed from task list", async ({
   // Open the row menu and click Delete
   await searchTasks(page, taskTitle);
   await page
-    .getByRole("row")
+    .getByRole("button")
     .filter({ hasText: taskTitle })
     .getByRole("button", { name: /task actions/i })
     .click();
@@ -209,7 +209,7 @@ test("delete task from table row menu → removed from task list", async ({
     .click();
 
   // Table refreshes in place (router.refresh), task is gone
-  await expect(page.getByRole("cell", { name: taskTitle })).not.toBeVisible();
+  await expect(page.getByRole("button").filter({ hasText: taskTitle })).not.toBeVisible();
 });
 
 test("create task without title → stays on page, does not submit", async ({
@@ -239,7 +239,7 @@ test("edit task without title → stays on edit page, does not submit", async ({
 
   // Navigate to edit
   await searchTasks(page, taskTitle);
-  await page.getByRole("cell", { name: taskTitle }).click();
+  await page.getByRole("button").filter({ hasText: taskTitle }).click();
   await expect(page.getByRole("heading", { name: taskTitle })).toBeVisible();
   await page
     .getByTestId("task-actions")
@@ -278,7 +278,7 @@ test("create task with role → role badge visible in task list", async ({
 
   await searchTasks(page, taskTitle);
   await expect(
-    page.getByRole("row").filter({ hasText: taskTitle }).getByText(roleName),
+    page.getByRole("button").filter({ hasText: taskTitle }).getByText(roleName),
   ).toBeVisible();
 });
 
@@ -299,7 +299,7 @@ test("edit task to add role → role badge visible in task list", async ({
 
   // Navigate to edit
   await searchTasks(page, taskTitle);
-  await page.getByRole("cell", { name: taskTitle }).click();
+  await page.getByRole("button").filter({ hasText: taskTitle }).click();
   await expect(page.getByRole("heading", { name: taskTitle })).toBeVisible();
   await page
     .getByTestId("task-actions")
@@ -323,7 +323,7 @@ test("edit task to add role → role badge visible in task list", async ({
   await page.waitForLoadState("networkidle");
   await searchTasks(page, taskTitle);
   await expect(
-    page.getByRole("row").filter({ hasText: taskTitle }).getByText(roleName),
+    page.getByRole("button").filter({ hasText: taskTitle }).getByText(roleName),
   ).toBeVisible();
 });
 
@@ -347,7 +347,7 @@ test("edit task to remove role → role badge no longer visible in task list", a
 
   // Navigate to edit
   await searchTasks(page, taskTitle);
-  await page.getByRole("cell", { name: taskTitle }).click();
+  await page.getByRole("button").filter({ hasText: taskTitle }).click();
   await expect(page.getByRole("heading", { name: taskTitle })).toBeVisible();
   await page
     .getByTestId("task-actions")
@@ -367,7 +367,7 @@ test("edit task to remove role → role badge no longer visible in task list", a
   await page.goto(`/orgs/${orgId}/tasks`);
   await searchTasks(page, taskTitle);
   await expect(
-    page.getByRole("row").filter({ hasText: taskTitle }).getByText(roleName),
+    page.getByRole("button").filter({ hasText: taskTitle }).getByText(roleName),
   ).not.toBeVisible();
 });
 
@@ -386,9 +386,9 @@ test("search filter → only matching tasks visible", async ({ page }) => {
   }
 
   await searchTasks(page, matchTitle);
-  await expect(page.getByRole("cell", { name: matchTitle })).toBeVisible();
+  await expect(page.getByRole("button").filter({ hasText: matchTitle })).toBeVisible();
   await expect(
-    page.getByRole("cell", { name: noMatchTitle }),
+    page.getByRole("button").filter({ hasText: noMatchTitle }),
   ).not.toBeVisible();
 });
 
@@ -420,9 +420,9 @@ test("role filter → only tasks with that role visible", async ({ page }) => {
   await page.getByRole("button", { name: /filter by role/i }).click();
   await page.getByRole("menuitem", { name: roleName }).click();
 
-  await expect(page.getByRole("cell", { name: taskWithRole })).toBeVisible();
+  await expect(page.getByRole("button").filter({ hasText: taskWithRole })).toBeVisible();
   await expect(
-    page.getByRole("cell", { name: taskWithoutRole }),
+    page.getByRole("button").filter({ hasText: taskWithoutRole }),
   ).not.toBeVisible();
 });
 
@@ -447,17 +447,18 @@ test("task detail → shows correct fields after create", async ({ page }) => {
 
   // Navigate to detail
   await searchTasks(page, taskTitle);
-  await page.getByRole("cell", { name: taskTitle }).click();
+  await page.getByRole("button").filter({ hasText: taskTitle }).click();
   await expect(page.getByRole("heading", { name: taskTitle })).toBeVisible();
 
   await expect(page.getByText("1 h 30 min")).toBeVisible();
-  await expect(page.getByText("2 – 5 days")).toBeVisible();
+  await expect(page.getByText("2–5 days")).toBeVisible();
   await expect(page.getByText(description)).toBeVisible();
+  // "People" label is a <p>, followed immediately by the value <p>
   await expect(
     page
-      .locator("dt")
-      .filter({ hasText: /people required/i })
-      .locator("+ dd"),
+      .locator("p")
+      .filter({ hasText: /^people$/i })
+      .locator("+ p"),
   ).toHaveText("3");
 });
 
@@ -479,7 +480,7 @@ test("task detail → shows updated values after edit", async ({ page }) => {
 
   // Navigate to edit
   await searchTasks(page, taskTitle);
-  await page.getByRole("cell", { name: taskTitle }).click();
+  await page.getByRole("button").filter({ hasText: taskTitle }).click();
   await expect(page.getByRole("heading", { name: taskTitle })).toBeVisible();
   await page
     .getByTestId("task-actions")
@@ -500,7 +501,7 @@ test("task detail → shows updated values after edit", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: updatedTitle })).toBeVisible();
   await expect(page.getByText("2 h 15 min")).toBeVisible();
-  await expect(page.getByText("3 – 7 days")).toBeVisible();
+  await expect(page.getByText("3–7 days")).toBeVisible();
   await expect(page.getByText(updatedDescription)).toBeVisible();
 });
 

--- a/app/(app)/orgs/[orgId]/memberships/_components/member-form.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/member-form.tsx
@@ -1,5 +1,18 @@
 "use client";
 
+/**
+ * MemberForm — shared create/edit form for org members and bot slots.
+ *
+ * Modes:
+ *  - `create`   — adds a new human member (email + working days + roles) or
+ *                 creates a bot placeholder (empty email path).
+ *  - `edit`     — updates working days and roles for an existing member.
+ *  - `bot-edit` — updates the display name and roles of a bot membership.
+ *
+ * Also exposes a "Convert to Bot" section (edit mode, non-bot human member)
+ * that calls `memberToBotAction` to strip the linked user account and turn the
+ * membership into a named placeholder.
+ */
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
@@ -15,6 +28,7 @@ import {
 import {
   createBotAction,
   inviteBotSlotAction,
+  memberToBotAction,
   updateBotAction,
 } from "@/app/actions/bots";
 
@@ -73,6 +87,11 @@ export function MemberForm({
   const [roleIds, setRoleIds] = useState<string[]>(initialRoleIds);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [inviteErrors, setInviteErrors] = useState<Record<string, string>>({});
+  const [convertBotName, setConvertBotName] = useState(name ?? "");
+  const [convertErrors, setConvertErrors] = useState<Record<string, string>>(
+    {},
+  );
+  const [isConvertPending, startConvertTransition] = useTransition();
 
   // In create mode: empty email = creating a new bot
   const isBot = mode === "create" && email.trim() === "";
@@ -166,6 +185,31 @@ export function MemberForm({
         onSuccess();
       } else {
         router.push(`/orgs/${orgId}/memberships/${membershipId}`);
+      }
+    });
+  }
+
+  function handleConvertToBot() {
+    if (!convertBotName.trim()) {
+      setConvertErrors({ name: "Bot name is required" });
+      return;
+    }
+    setConvertErrors({});
+    startConvertTransition(async () => {
+      const result = await memberToBotAction(orgId, {
+        membershipId: membershipId!,
+        overrideName: convertBotName.trim(),
+      });
+      if (!result.ok) {
+        setConvertErrors({ _: result.error });
+        return;
+      }
+      toast.success(`${name ?? "Member"} converted to bot.`);
+      if (onSuccess) {
+        router.refresh();
+        onSuccess();
+      } else {
+        router.push(`/orgs/${orgId}/memberships`);
       }
     });
   }
@@ -436,6 +480,45 @@ export function MemberForm({
               : "Invite"
             : "Save"}
       </Button>
+
+      {mode === "edit" && !isCurrentlyBot && (
+        <div className="flex flex-col gap-3 pt-4 border-t border-border">
+          <div>
+            <p className="text-sm font-semibold text-foreground">
+              Convert to Bot
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Detaches this user account and turns the slot into a bot
+              placeholder. Their timetable assignments are preserved.
+            </p>
+          </div>
+          {convertErrors._ && (
+            <p className="text-sm text-destructive">{convertErrors._}</p>
+          )}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Bot Name</label>
+            <Input
+              type="text"
+              placeholder="e.g. Open Slot"
+              value={convertBotName}
+              onChange={(e) => setConvertBotName(e.target.value)}
+            />
+            {convertErrors.name && (
+              <p className="text-xs text-destructive">{convertErrors.name}</p>
+            )}
+          </div>
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            className="self-start"
+            disabled={isConvertPending}
+            onClick={handleConvertToBot}
+          >
+            {isConvertPending ? "Converting…" : "Convert to Bot"}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
@@ -275,6 +275,14 @@ function CardGrid({
             key={m.id}
             className="group relative cursor-pointer"
             onClick={() => onView(m)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+                if (e.key === ' ' || e.key === 'Spacebar') e.preventDefault();
+                onView(m);
+              }
+            }}
           >
             <Card className="h-full items-center text-center transition-all group-hover:shadow-md group-hover:border-primary/20 cursor-pointer overflow-hidden">
               <div className="pt-5 flex justify-center">

--- a/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
+++ b/app/(app)/orgs/[orgId]/memberships/_components/members-view.tsx
@@ -14,7 +14,8 @@
  *   - `Avatar`      — shows the member's profile photo or a two-letter
  *                     initial fallback at three sizes (sm / md / lg).
  *   - `StatusBadge` — shown only when a member's status is RESTRICTED.
- *   - `RolesBadge`  — comma-separated list of role names, or "No role".
+ *   - `RolesBadge`  — pill list of role names; `align` prop controls
+ *                     left-align (list view) vs center-align (card view).
  *   - `CardGrid`    — responsive grid of shadcn Cards (card view).
  *   - `MemberList`  — bordered list of rows (list view).
  *
@@ -110,14 +111,17 @@ function StatusBadge({ status }: { status: "ACTIVE" | "RESTRICTED" }) {
 
 function RolesBadge({
   roles,
+  align = "center",
 }: {
   roles: { id: string; name: string; color: string }[];
+  align?: "center" | "start";
 }) {
+  const justifyClass = align === "start" ? "justify-start" : "justify-center";
   if (roles.length === 0)
     return <span className="text-xs text-muted-foreground">No role</span>;
   if (roles.length > 2) {
     return (
-      <div className="flex flex-wrap gap-1 justify-center">
+      <div className={cn("flex flex-wrap gap-1", justifyClass)}>
         {roles.map((r) => (
           <span
             key={r.id}
@@ -132,7 +136,7 @@ function RolesBadge({
     );
   }
   return (
-    <div className="flex flex-wrap gap-1 justify-center">
+    <div className={cn("flex flex-wrap gap-1", justifyClass)}>
       {roles.map((r) => (
         <span
           key={r.id}
@@ -245,15 +249,6 @@ export function MembersView({
   );
 }
 
-function abbreviateName(name: string, maxLen = 12): string {
-  if (name.length <= maxLen) return name;
-  const parts = name.trim().split(/\s+/);
-  if (parts.length === 1) return parts[0].slice(0, maxLen);
-  const first = parts[0].slice(0, 4);
-  const last = parts[parts.length - 1].slice(0, 4);
-  return `${first}. ${last}.`;
-}
-
 function CardGrid({
   members,
   orgId,
@@ -268,7 +263,7 @@ function CardGrid({
   onView: (m: Member) => void;
 }) {
   return (
-    <div className="flex flex-wrap gap-4 justify-center">
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
       {members.map((m) => {
         const roles = m.memberRoles.map(({ role }) => ({
           id: role.id,
@@ -278,11 +273,11 @@ function CardGrid({
         return (
           <div
             key={m.id}
-            className="group relative cursor-pointer w-44 h-56 shrink-0"
+            className="group relative cursor-pointer"
             onClick={() => onView(m)}
           >
             <Card className="h-full items-center text-center transition-all group-hover:shadow-md group-hover:border-primary/20 cursor-pointer overflow-hidden">
-              <div className="pt-4 flex justify-center">
+              <div className="pt-5 flex justify-center">
                 <Avatar
                   name={m.user?.name ?? m.botName}
                   image={m.user?.image ?? null}
@@ -290,11 +285,13 @@ function CardGrid({
                 />
               </div>
               <CardContent className="flex flex-col items-center gap-1.5 pb-4 pt-3">
-                <CardTitle className="text-sm leading-tight flex items-center gap-1.5">
-                  {abbreviateName(m.user?.name ?? m.botName ?? "Unnamed")}
+                <CardTitle className="text-sm leading-tight w-full flex items-center justify-center gap-1.5 flex-wrap">
+                  <span className="truncate">
+                    {m.user?.name ?? m.botName ?? "Unnamed"}
+                  </span>
                   {m.userId === null && (
-                    <span className="text-xs font-bold font-mono text-red-500 tracking-tight">
-                      [Bot]
+                    <span className="inline-flex items-center rounded-full bg-violet-500/10 text-violet-600 dark:text-violet-400 px-1.5 py-0.5 text-[10px] font-medium shrink-0">
+                      Bot
                     </span>
                   )}
                 </CardTitle>
@@ -304,7 +301,7 @@ function CardGrid({
             </Card>
             {canManage && (
               <div
-                className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                className="absolute top-1 right-1"
                 onClick={(e) => e.stopPropagation()}
               >
                 <MemberActions
@@ -360,20 +357,31 @@ function MemberList({
               <Avatar
                 name={m.user?.name ?? m.botName}
                 image={m.user?.image ?? null}
-                size="sm"
+                size="md"
               />
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium truncate flex items-center gap-1.5">
-                  {m.user?.name ?? m.botName ?? "Unnamed"}
+                <div className="flex items-center gap-1.5 mb-0.5">
+                  <p className="text-sm font-medium truncate">
+                    {m.user?.name ?? m.botName ?? "Unnamed"}
+                  </p>
                   {m.userId === null && (
-                    <span className="text-xs font-bold font-mono text-red-500 tracking-tight">
-                      [Bot]
+                    <span className="inline-flex items-center rounded-full bg-violet-500/10 text-violet-600 dark:text-violet-400 px-1.5 py-0.5 text-[10px] font-medium shrink-0">
+                      Bot
                     </span>
                   )}
-                </p>
-                <RolesBadge roles={roles} />
+                </div>
+                <RolesBadge roles={roles} align="start" />
               </div>
-              <StatusBadge status={m.status} />
+              <div className="flex flex-col items-end gap-1 shrink-0">
+                <StatusBadge status={m.status} />
+                <span className="text-xs text-muted-foreground hidden sm:block">
+                  Joined{" "}
+                  {m.joinedAt.toLocaleDateString(undefined, {
+                    month: "short",
+                    year: "numeric",
+                  })}
+                </span>
+              </div>
             </button>
             {canManage && (
               <div className="pr-3 shrink-0">

--- a/app/(app)/orgs/[orgId]/page.tsx
+++ b/app/(app)/orgs/[orgId]/page.tsx
@@ -8,9 +8,22 @@ import {
   Settings,
   MapPin,
   Clock,
+  Globe,
   ArrowRight,
   ArrowLeftRight,
 } from "lucide-react";
+
+// ─── org color ────────────────────────────────────────────────────────────────
+
+const ORG_COLOR_PALETTE = [
+  "#6366f1", "#8b5cf6", "#ec4899", "#f43f5e",
+  "#f97316", "#22c55e", "#14b8a6", "#06b6d4", "#3b82f6",
+];
+
+function orgColor(name: string): string {
+  const sum = [...name].reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  return ORG_COLOR_PALETTE[sum % ORG_COLOR_PALETTE.length];
+}
 import { requireOrgMemberPage } from "@/lib/authz";
 import { getAuthUserId } from "@/lib/authz/_shared";
 import { prisma } from "@/lib/prisma";
@@ -127,11 +140,24 @@ const Page = async ({ params }: { params: Promise<{ orgId: string }> }) => {
 
   return (
     <>
-      <div className="max-w-3xl mx-auto w-full rounded-2xl border bg-card shadow-sm p-6 sm:p-8">
+      <div className="max-w-3xl mx-auto w-full rounded-2xl border bg-card shadow-sm">
+        {/* Color accent bar */}
+        <div
+          className="h-1.5 rounded-t-2xl"
+          style={{ backgroundColor: orgColor(org.name) }}
+        />
+        <div className="p-6 sm:p-8">
         {/* Org header */}
         <div className="flex items-start justify-between gap-4 mb-8">
           <div>
-            <h1 className="font-heading text-2xl tracking-tight">{org.name}</h1>
+            <div className="flex items-center gap-2.5 flex-wrap">
+              <h1 className="font-heading text-2xl tracking-tight">{org.name}</h1>
+              {isOwner && (
+                <span className="inline-flex items-center rounded-full bg-primary/10 text-primary px-2 py-0.5 text-xs font-medium">
+                  Owner
+                </span>
+              )}
+            </div>
             <div className="flex flex-wrap items-center gap-3 mt-1.5 text-sm text-muted-foreground">
               {org.address && (
                 <span className="flex items-center gap-1">
@@ -140,9 +166,15 @@ const Page = async ({ params }: { params: Promise<{ orgId: string }> }) => {
                 </span>
               )}
               <span className="flex items-center gap-1">
-                <Clock className="h-3.5 w-3.5" />
+                <Globe className="h-3.5 w-3.5" />
                 {org.timezone.replace(/_/g, " ")}
               </span>
+              {org.openTimeMin != null && org.closeTimeMin != null && (
+                <span className="flex items-center gap-1">
+                  <Clock className="h-3.5 w-3.5" />
+                  {minTo12h(org.openTimeMin)} – {minTo12h(org.closeTimeMin)}
+                </span>
+              )}
             </div>
           </div>
           {isOwner && (
@@ -203,7 +235,7 @@ const Page = async ({ params }: { params: Promise<{ orgId: string }> }) => {
                 All tools →
               </Link>
             </div>
-            <div className="max-h-46 overflow-y-auto rounded-xl border divide-y">
+            <div className="max-h-44 overflow-y-auto rounded-xl border divide-y">
               {recentSets.map((s) => (
                 <Link
                   key={s.id}
@@ -245,7 +277,20 @@ const Page = async ({ params }: { params: Promise<{ orgId: string }> }) => {
               </p>
             </div>
           ) : (
-            <div className="rounded-xl border divide-y overflow-hidden">
+            <>
+              <div className="mb-3">
+                <div className="flex items-center justify-between text-xs text-muted-foreground mb-1.5">
+                  <span>{doneToday} of {todayInstances.length} done</span>
+                  <span>{Math.round((doneToday / todayInstances.length) * 100)}%</span>
+                </div>
+                <div className="w-full h-1.5 bg-muted rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-green-500 rounded-full transition-all"
+                    style={{ width: `${(doneToday / todayInstances.length) * 100}%` }}
+                  />
+                </div>
+              </div>
+              <div className="rounded-xl border divide-y overflow-hidden">
               {todayInstances
                 .slice()
                 .sort((a, b) => a.startTimeMin - b.startTimeMin)
@@ -280,21 +325,32 @@ const Page = async ({ params }: { params: Promise<{ orgId: string }> }) => {
                     </span>
 
                     {/* Status */}
-                    <div className="flex items-center gap-1.5 shrink-0">
-                      <span
-                        className={cn(
-                          "w-1.5 h-1.5 rounded-full",
-                          statusDotClass(inst.status),
-                        )}
-                      />
-                      <span className="text-xs text-muted-foreground hidden sm:inline">
-                        {statusLabel(inst.status)}
-                      </span>
-                    </div>
+                    <span
+                      className={cn(
+                        "hidden sm:inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium shrink-0",
+                        inst.status === "IN_PROGRESS"
+                          ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                          : inst.status === "DONE"
+                          ? "bg-green-500/10 text-green-600 dark:text-green-400"
+                          : inst.status === "SKIPPED"
+                          ? "bg-red-500/10 text-red-500"
+                          : "bg-muted text-muted-foreground",
+                      )}
+                    >
+                      {statusLabel(inst.status)}
+                    </span>
+                    <span
+                      className={cn(
+                        "w-1.5 h-1.5 rounded-full shrink-0 sm:hidden",
+                        statusDotClass(inst.status),
+                      )}
+                    />
                   </div>
                 ))}
-            </div>
+              </div>
+            </>
           )}
+        </div>
         </div>
       </div>
     </>

--- a/app/(app)/orgs/[orgId]/page.tsx
+++ b/app/(app)/orgs/[orgId]/page.tsx
@@ -344,6 +344,7 @@ const Page = async ({ params }: { params: Promise<{ orgId: string }> }) => {
                         "w-1.5 h-1.5 rounded-full shrink-0 sm:hidden",
                         statusDotClass(inst.status),
                       )}
+                      aria-label={statusLabel(inst.status)}
                     />
                   </div>
                 ))}

--- a/app/(app)/orgs/[orgId]/tasks/[taskId]/comments/comment-input.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/[taskId]/comments/comment-input.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+/**
+ * CommentInput — controlled textarea + submit button for posting comments.
+ *
+ * Used for both top-level comments and replies. Pass `parentId` to create a
+ * threaded reply. `onSuccess` is called after a successful post (e.g. to close
+ * the reply input). `onCancel` is called when the user dismisses the input
+ * without submitting.
+ *
+ * Calls `addCommentAction` — a server action that validates the content,
+ * checks franchise membership, and writes to the DB.
+ */
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { addCommentAction } from "@/app/actions/task-comments";
+
+interface CommentInputProps {
+  orgId: string;
+  taskId: string;
+  parentId?: string;
+  placeholder?: string;
+  onSuccess?: () => void;
+  onCancel?: () => void;
+}
+
+export function CommentInput({
+  orgId,
+  taskId,
+  parentId,
+  placeholder = "Write a comment…",
+  onSuccess,
+  onCancel,
+}: CommentInputProps) {
+  const [content, setContent] = useState("");
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = content.trim();
+    if (!trimmed) return;
+    setError(null);
+
+    startTransition(async () => {
+      const result = await addCommentAction(orgId, taskId, {
+        content: trimmed,
+        parentId,
+      });
+      if (result.ok) {
+        setContent("");
+        onSuccess?.();
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <textarea
+        className="w-full min-h-18 resize-none rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+        placeholder={placeholder}
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        disabled={isPending}
+        onKeyDown={(e) => {
+          // Cmd/Ctrl+Enter submits
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            handleSubmit(e as unknown as React.FormEvent);
+          }
+        }}
+      />
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      <div className="flex items-center justify-end gap-2">
+        {onCancel && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onCancel}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+        )}
+        <Button
+          type="submit"
+          size="sm"
+          disabled={!content.trim() || isPending}
+        >
+          {isPending ? "Posting…" : parentId ? "Reply" : "Comment"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tasks/[taskId]/comments/comment-item.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/[taskId]/comments/comment-item.tsx
@@ -341,7 +341,10 @@ export function CommentItem({
               {!comment.isDeleted && (isOwn || canManage) && (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <button className="inline-flex items-center rounded px-1 py-0.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">
+                    <button
+                      className="inline-flex items-center rounded px-1 py-0.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                      aria-label="Comment actions"
+                    >
                       <MoreHorizontal className="w-3.5 h-3.5" />
                     </button>
                   </DropdownMenuTrigger>

--- a/app/(app)/orgs/[orgId]/tasks/[taskId]/comments/comment-item.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/[taskId]/comments/comment-item.tsx
@@ -1,0 +1,430 @@
+"use client";
+
+/**
+ * CommentItem — renders one comment (top-level or reply) with all its actions.
+ *
+ * Features:
+ *  - Soft-deleted comments show a "[deleted]" tombstone instead of content.
+ *  - Inline edit mode replaces the content with a `CommentInput` pre-filled
+ *    with the current text.
+ *  - Pinned indicator and Pin / Unpin toggle for MANAGE_TASKS holders.
+ *  - Up/down vote buttons with optimistic UI (useOptimistic); actual vote is
+ *    persisted via `voteCommentAction`.
+ *  - Reply expansion — clicking "Reply" opens a nested `CommentInput`.
+ *  - ··· dropdown menu for Edit, Delete (own comments) or Delete (canManage).
+ *
+ * Sub-component `Avatar` renders a profile image or a two-letter initial
+ * fallback at two sizes (sm / md).
+ */
+import { useState, useTransition, useOptimistic } from "react";
+import { useRouter } from "next/navigation";
+import { ThumbsUp, ThumbsDown, Pin, PinOff, Pencil, Trash2, CornerDownRight, MoreHorizontal } from "lucide-react";
+import { VoteType } from "@prisma/client";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import {
+  voteCommentAction,
+  deleteCommentAction,
+  editCommentAction,
+  pinCommentAction,
+} from "@/app/actions/task-comments";
+import { CommentInput } from "./comment-input";
+import type { CommentFE } from "./types";
+
+// ─── Avatar ───────────────────────────────────────────────────────────────────
+
+function Avatar({
+  name,
+  image,
+  size = "sm",
+}: {
+  name: string;
+  image: string | null;
+  size?: "sm" | "xs";
+}) {
+  const dim = size === "xs" ? "w-6 h-6 text-[10px]" : "w-8 h-8 text-xs";
+  // Derive a hue from the name for a consistent color
+  const hue = name
+    .split("")
+    .reduce((acc, ch) => acc + ch.charCodeAt(0), 0) % 360;
+
+  if (image) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={image}
+        alt={name}
+        className={cn("rounded-full object-cover shrink-0", dim)}
+      />
+    );
+  }
+  return (
+    <div
+      className={cn(
+        "rounded-full flex items-center justify-center font-medium text-white shrink-0",
+        dim,
+      )}
+      style={{ backgroundColor: `hsl(${hue}, 55%, 52%)` }}
+    >
+      {name.charAt(0).toUpperCase()}
+    </div>
+  );
+}
+
+// ─── Relative time ────────────────────────────────────────────────────────────
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(months / 12)}y ago`;
+}
+
+// ─── Inline edit form ─────────────────────────────────────────────────────────
+
+function InlineEdit({
+  orgId,
+  taskId,
+  commentId,
+  defaultContent,
+  onSuccess,
+  onCancel,
+}: {
+  orgId: string;
+  taskId: string;
+  commentId: string;
+  defaultContent: string;
+  onSuccess: () => void;
+  onCancel: () => void;
+}) {
+  const [content, setContent] = useState(defaultContent);
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = content.trim();
+    if (!trimmed || trimmed === defaultContent) { onCancel(); return; }
+    startTransition(async () => {
+      const result = await editCommentAction(orgId, taskId, commentId, { content: trimmed });
+      if (result.ok) onSuccess();
+      else setError(result.error);
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 mt-2">
+      <textarea
+        className="w-full min-h-18 resize-none rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        disabled={isPending}
+        autoFocus
+      />
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      <div className="flex items-center justify-end gap-2">
+        <Button type="button" variant="ghost" size="sm" onClick={onCancel} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button type="submit" size="sm" disabled={!content.trim() || isPending}>
+          {isPending ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+// ─── CommentItem ──────────────────────────────────────────────────────────────
+
+interface CommentItemProps {
+  comment: CommentFE | Omit<CommentFE, "replies">;
+  orgId: string;
+  taskId: string;
+  currentUserId: string | null;
+  canComment: boolean;
+  canManage: boolean;
+  isReply?: boolean;
+  /** id of the comment whose reply input is currently open (top-level orchestration) */
+  replyOpenId: string | null;
+  editingId: string | null;
+  onToggleReply: (id: string) => void;
+  onToggleEdit: (id: string) => void;
+  onRefresh: () => void;
+  onError: (msg: string) => void;
+  className?: string;
+}
+
+export function CommentItem({
+  comment,
+  orgId,
+  taskId,
+  currentUserId,
+  canComment,
+  canManage,
+  isReply = false,
+  replyOpenId,
+  editingId,
+  onToggleReply,
+  onToggleEdit,
+  onRefresh,
+  onError,
+  className,
+}: CommentItemProps) {
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+
+  const isEditing = editingId === comment.id;
+  const isReplyOpen = replyOpenId === comment.id;
+  const isOwn = currentUserId != null && comment.authorId === currentUserId;
+
+  // ── Optimistic vote state ────────────────────────────────────────────────
+  const [optimistic, dispatchVote] = useOptimistic(
+    { userVote: comment.userVote, upvotes: comment.upvotes, downvotes: comment.downvotes },
+    (
+      _,
+      newVote: VoteType | null,
+    ) => {
+      const prev = comment.userVote;
+      let up = comment.upvotes;
+      let down = comment.downvotes;
+      if (prev === "UPVOTE") up--;
+      if (prev === "DOWNVOTE") down--;
+      if (newVote === "UPVOTE") up++;
+      if (newVote === "DOWNVOTE") down++;
+      return { userVote: newVote, upvotes: up, downvotes: down };
+    },
+  );
+
+  function handleVote(type: VoteType) {
+    if (!currentUserId) return;
+    // Toggle: clicking same vote removes it
+    const newType = optimistic.userVote === type ? null : type;
+    startTransition(async () => {
+      dispatchVote(newType);
+      const result = await voteCommentAction(orgId, taskId, comment.id, newType);
+      if (result.ok) router.refresh();
+      else onError(result.error);
+    });
+  }
+
+  function handleDelete() {
+    startTransition(async () => {
+      const result = await deleteCommentAction(orgId, taskId, comment.id);
+      if (result.ok) onRefresh();
+      else onError(result.error);
+    });
+  }
+
+  function handlePin(pin: boolean) {
+    startTransition(async () => {
+      const result = await pinCommentAction(orgId, taskId, comment.id, pin);
+      if (result.ok) onRefresh();
+      else onError(result.error);
+    });
+  }
+
+  const replies = "replies" in comment ? comment.replies : [];
+
+  return (
+    <div className={className}>
+      {/* Main comment row */}
+      <div className="flex gap-3">
+        <Avatar
+          name={comment.authorName}
+          image={comment.authorImage}
+          size={isReply ? "xs" : "sm"}
+        />
+
+        <div className="flex-1 min-w-0">
+          {/* Header */}
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className="text-sm font-medium">{comment.authorName}</span>
+            <span className="text-xs text-muted-foreground">
+              {timeAgo(comment.createdAt)}
+            </span>
+            {comment.editedAt && (
+              <span className="text-xs text-muted-foreground">(edited)</span>
+            )}
+            {"isPinned" in comment && comment.isPinned && (
+              <span className="inline-flex items-center gap-0.5 text-xs font-medium text-amber-600">
+                <Pin className="w-3 h-3" />
+                Pinned
+              </span>
+            )}
+          </div>
+
+          {/* Content or edit form */}
+          {isEditing ? (
+            <InlineEdit
+              orgId={orgId}
+              taskId={taskId}
+              commentId={comment.id}
+              defaultContent={comment.content}
+              onSuccess={() => { onToggleEdit(comment.id); onRefresh(); }}
+              onCancel={() => onToggleEdit(comment.id)}
+            />
+          ) : comment.isDeleted ? (
+            <p className="text-sm text-muted-foreground italic mt-1">
+              This comment was deleted.
+            </p>
+          ) : (
+            <p className="text-sm mt-1 whitespace-pre-wrap wrap-break-word">
+              {comment.content}
+            </p>
+          )}
+
+          {/* Actions row */}
+          {!isEditing && (
+            <div className="flex items-center gap-1 mt-2 -ml-1">
+              {/* Upvote */}
+              <button
+                onClick={() => handleVote("UPVOTE")}
+                disabled={!currentUserId}
+                className={cn(
+                  "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs transition-colors",
+                  optimistic.userVote === "UPVOTE"
+                    ? "text-blue-600 bg-blue-50 dark:bg-blue-950"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted",
+                  !currentUserId && "cursor-default",
+                )}
+              >
+                <ThumbsUp className="w-3.5 h-3.5" />
+                {optimistic.upvotes > 0 && optimistic.upvotes}
+              </button>
+
+              {/* Downvote */}
+              <button
+                onClick={() => handleVote("DOWNVOTE")}
+                disabled={!currentUserId}
+                className={cn(
+                  "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs transition-colors",
+                  optimistic.userVote === "DOWNVOTE"
+                    ? "text-red-600 bg-red-50 dark:bg-red-950"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted",
+                  !currentUserId && "cursor-default",
+                )}
+              >
+                <ThumbsDown className="w-3.5 h-3.5" />
+                {optimistic.downvotes > 0 && optimistic.downvotes}
+              </button>
+
+              {/* Reply button — only on top-level, not deleted, canComment */}
+              {!isReply && !comment.isDeleted && canComment && (
+                <button
+                  onClick={() => onToggleReply(comment.id)}
+                  className={cn(
+                    "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs transition-colors",
+                    isReplyOpen
+                      ? "text-foreground bg-muted"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted",
+                  )}
+                >
+                  <CornerDownRight className="w-3.5 h-3.5" />
+                  Reply
+                </button>
+              )}
+
+              {/* Edit / Delete / Pin — own comment or manager */}
+              {!comment.isDeleted && (isOwn || canManage) && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button className="inline-flex items-center rounded px-1 py-0.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">
+                      <MoreHorizontal className="w-3.5 h-3.5" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-36">
+                    {isOwn && (
+                      <DropdownMenuItem onClick={() => onToggleEdit(comment.id)}>
+                        <Pencil className="w-3.5 h-3.5 mr-2" />
+                        Edit
+                      </DropdownMenuItem>
+                    )}
+                    {canManage && !isReply && (
+                      <DropdownMenuItem
+                        onClick={() =>
+                          handlePin(!("isPinned" in comment && comment.isPinned))
+                        }
+                      >
+                        {"isPinned" in comment && comment.isPinned ? (
+                          <>
+                            <PinOff className="w-3.5 h-3.5 mr-2" />
+                            Unpin
+                          </>
+                        ) : (
+                          <>
+                            <Pin className="w-3.5 h-3.5 mr-2" />
+                            Pin
+                          </>
+                        )}
+                      </DropdownMenuItem>
+                    )}
+                    {(isOwn || canManage) && (
+                      <DropdownMenuItem
+                        onClick={handleDelete}
+                        className="text-destructive focus:text-destructive"
+                      >
+                        <Trash2 className="w-3.5 h-3.5 mr-2" />
+                        Delete
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+            </div>
+          )}
+
+          {/* Inline reply input */}
+          {isReplyOpen && !isReply && (
+            <div className="mt-3">
+              <CommentInput
+                orgId={orgId}
+                taskId={taskId}
+                parentId={comment.id}
+                placeholder="Write a reply…"
+                onSuccess={() => { onToggleReply(comment.id); onRefresh(); }}
+                onCancel={() => onToggleReply(comment.id)}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Replies */}
+      {replies.length > 0 && (
+        <div className="ml-11 mt-3 flex flex-col gap-3">
+          {replies.map((reply) => (
+            <CommentItem
+              key={reply.id}
+              comment={reply}
+              orgId={orgId}
+              taskId={taskId}
+              currentUserId={currentUserId}
+              canComment={canComment}
+              canManage={canManage}
+              isReply
+              replyOpenId={replyOpenId}
+              editingId={editingId}
+              onToggleReply={onToggleReply}
+              onToggleEdit={onToggleEdit}
+              onRefresh={onRefresh}
+              onError={onError}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tasks/[taskId]/comments/comment-section.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/[taskId]/comments/comment-section.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+/**
+ * CommentSection — stateful client shell for the task comment thread.
+ *
+ * Owns:
+ *  - `replyOpenId`  — which top-level comment has its reply input expanded
+ *  - `editingId`    — which comment is in inline-edit mode
+ *
+ * After any mutation (add / edit / delete / vote / pin) it calls
+ * `router.refresh()` inside `startTransition` so the server re-fetches updated
+ * data without a hard navigation.
+ *
+ * Renders a flat list of `CommentItem` components (each handles its own
+ * replies and vote/pin/edit/delete actions), followed by the top-level
+ * `CommentInput` for adding new comments.
+ */
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import type { CommentFE } from "./types";
+import { CommentItem } from "./comment-item";
+import { CommentInput } from "./comment-input";
+
+interface CommentSectionProps {
+  orgId: string;
+  taskId: string;
+  currentUserId: string | null;
+  canComment: boolean;
+  canManage: boolean;
+  initialComments: CommentFE[];
+}
+
+export function CommentSection({
+  orgId,
+  taskId,
+  currentUserId,
+  canComment,
+  canManage,
+  initialComments,
+}: CommentSectionProps) {
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+  const [replyOpenId, setReplyOpenId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  function refresh() {
+    startTransition(() => router.refresh());
+  }
+
+  function handleToggleReply(id: string) {
+    setReplyOpenId((prev) => (prev === id ? null : id));
+    setEditingId(null);
+  }
+
+  function handleToggleEdit(id: string) {
+    setEditingId((prev) => (prev === id ? null : id));
+    setReplyOpenId(null);
+  }
+
+  const total = initialComments.reduce(
+    (n, c) => n + 1 + (c.replies?.length ?? 0),
+    0,
+  );
+
+  return (
+    <div className="rounded-lg border bg-card">
+      {/* Header */}
+      <div className="px-5 py-3 border-b border-border">
+        <h2 className="text-sm font-medium">
+          Comments{total > 0 ? ` (${total})` : ""}
+        </h2>
+      </div>
+
+      {/* Comment list */}
+      <div className="divide-y divide-border">
+        {initialComments.length === 0 && (
+          <p className="px-5 py-6 text-sm text-muted-foreground text-center">
+            No comments yet.{" "}
+            {canComment ? "Be the first to comment below." : ""}
+          </p>
+        )}
+        {initialComments.map((comment) => (
+          <CommentItem
+            key={comment.id}
+            comment={comment}
+            orgId={orgId}
+            taskId={taskId}
+            currentUserId={currentUserId}
+            canComment={canComment}
+            canManage={canManage}
+            replyOpenId={replyOpenId}
+            editingId={editingId}
+            onToggleReply={handleToggleReply}
+            onToggleEdit={handleToggleEdit}
+            onRefresh={refresh}
+            onError={(msg: string) => toast.error(msg)}
+            className="px-5 py-4"
+          />
+        ))}
+      </div>
+
+      {/* New comment input */}
+      {canComment && (
+        <div className="px-5 py-4 border-t border-border">
+          <CommentInput
+            orgId={orgId}
+            taskId={taskId}
+            onSuccess={refresh}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tasks/[taskId]/comments/index.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/[taskId]/comments/index.tsx
@@ -1,0 +1,92 @@
+/**
+ * TaskComments — async server component that gates and hydrates the comment section.
+ *
+ * Fetches in parallel:
+ *  - all top-level comments + one level of replies for the task
+ *  - whether the current user's org is in the same franchise (canComment)
+ *  - the current user's membership (to derive canManage)
+ *
+ * Converts DB rows to `CommentFE` (ISO string dates, aggregated vote counts)
+ * then passes them to the `CommentSection` client component as initial data.
+ * A Suspense boundary around `<TaskComments>` in the parent page provides the
+ * loading fallback.
+ */
+import { PermissionAction } from "@prisma/client";
+import { getAuthUserId } from "@/lib/authz/_shared";
+import { getOrgMembership, memberHasPermission } from "@/lib/authz/_shared";
+import { getTaskComments, canUserCommentOnTask } from "@/lib/services/task-comments";
+import type { CommentRow } from "@/lib/services/task-comments";
+import type { CommentFE } from "./types";
+import { CommentSection } from "./comment-section";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function toCommentFE(
+  row: CommentRow,
+  currentUserId: string | null,
+): CommentFE {
+  const votes = row.votes ?? [];
+  const upvotes = votes.filter((v) => v.type === "UPVOTE").length;
+  const downvotes = votes.filter((v) => v.type === "DOWNVOTE").length;
+  const userVote = currentUserId
+    ? (votes.find((v) => v.userId === currentUserId)?.type ?? null)
+    : null;
+
+  return {
+    id: row.id,
+    authorId: row.authorId,
+    authorName: row.authorName,
+    authorImage: row.authorImage,
+    content: row.content,
+    parentId: row.parentId,
+    isDeleted: row.isDeleted,
+    isPinned: row.isPinned,
+    pinnedAt: row.pinnedAt?.toISOString() ?? null,
+    editedAt: row.editedAt?.toISOString() ?? null,
+    createdAt: row.createdAt.toISOString(),
+    upvotes,
+    downvotes,
+    userVote,
+    replies: (row.replies ?? []).map(
+      (r) => toCommentFE(r, currentUserId) as Omit<CommentFE, "replies">,
+    ),
+  };
+}
+
+// ─── Server component ─────────────────────────────────────────────────────────
+
+interface TaskCommentsProps {
+  orgId: string;
+  taskId: string;
+}
+
+export async function TaskComments({ orgId, taskId }: TaskCommentsProps) {
+  const userId = await getAuthUserId();
+
+  const [commentRows, canComment, membership] = await Promise.all([
+    getTaskComments(taskId),
+    userId ? canUserCommentOnTask(taskId, orgId) : Promise.resolve(false),
+    userId ? getOrgMembership(orgId, userId) : Promise.resolve(null),
+  ]);
+
+  const canManage = membership
+    ? await memberHasPermission(
+        membership.id,
+        orgId,
+        PermissionAction.MANAGE_TASKS,
+      )
+    : false;
+
+  const comments = commentRows.map((row) => toCommentFE(row, userId));
+
+  return (
+    <CommentSection
+      orgId={orgId}
+      taskId={taskId}
+      currentUserId={userId}
+      canComment={canComment}
+      canManage={canManage}
+      initialComments={comments}
+    />
+  );
+}

--- a/app/(app)/orgs/[orgId]/tasks/[taskId]/comments/types.ts
+++ b/app/(app)/orgs/[orgId]/tasks/[taskId]/comments/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Client-facing comment shape used throughout the comments UI.
+ *
+ * Dates are serialized to ISO strings (vs Date objects) so this type can cross
+ * the server→client boundary safely. `votes` are aggregated into `upvotes`,
+ * `downvotes`, and `userVote` by the `toCommentFE` helper in `index.tsx`.
+ */
+import type { VoteType } from "@prisma/client";
+
+export type CommentFE = {
+  id: string;
+  authorId: string | null;
+  authorName: string;
+  authorImage: string | null;
+  content: string;
+  parentId: string | null;
+  isDeleted: boolean;
+  isPinned: boolean;
+  pinnedAt: string | null;
+  editedAt: string | null;
+  createdAt: string;
+  upvotes: number;
+  downvotes: number;
+  userVote: VoteType | null;
+  replies: Omit<CommentFE, "replies">[];
+};

--- a/app/(app)/orgs/[orgId]/tasks/[taskId]/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/[taskId]/page.tsx
@@ -26,8 +26,10 @@ import { createSignedReadUrl } from "@/lib/supabase-storage";
 import { RegisterPageSidebarSubContent } from "@/components/layout/page-sidebar-context";
 import { Toolbar } from "@/components/layout/toolbar";
 import { BackButton } from "@/components/layout/back-button";
+import { Clock, Users, AlarmClock, RefreshCw, Globe, Lock } from "lucide-react";
 import { TaskDescription } from "./task-description";
 import { TaskDetailSidebar } from "./task-detail-sidebar";
+import { TaskComments } from "./comments/index";
 import { formatDate } from "@/lib/utils";
 
 function formatDuration(min: number): string {
@@ -121,127 +123,204 @@ const ViewTaskPage = async ({ params, searchParams }: Props) => {
       </Toolbar>
 
       <div className="w-full max-w-3xl mx-auto flex flex-col gap-6">
-        <h1 className="text-2xl font-semibold">{task.name}</h1>
-
-        {/* Detail card */}
-        <div className="w-full rounded-lg border bg-card p-6 grid grid-cols-1 md:grid-cols-[1fr_200px] gap-8">
-          {/* Left: task fields */}
-          <dl className="flex flex-col gap-4">
-            <div>
-              <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">
-                Duration
-              </dt>
-              <dd className="text-sm">{formatDuration(task.durationMin)}</dd>
+        {/* Page header */}
+        <div className="flex items-start gap-3">
+          <span
+            className="w-3 h-3 rounded-full shrink-0 mt-2"
+            style={{ backgroundColor: task.color }}
+          />
+          <div className="min-w-0">
+            <h1 className="text-2xl font-semibold leading-tight">
+              {task.name}
+            </h1>
+            <div className="flex flex-wrap items-center gap-x-1.5 mt-1">
+              {createdByName && (
+                <span className="text-sm text-muted-foreground">
+                  By {createdByName}
+                </span>
+              )}
+              {createdByName && (
+                <span className="text-muted-foreground/40 select-none">·</span>
+              )}
+              <span className="text-sm text-muted-foreground">
+                {formatDate(task.createdAt)}
+              </span>
+              {sharedBy && (
+                <>
+                  <span className="text-muted-foreground/40 select-none">·</span>
+                  <span className="text-sm text-muted-foreground">
+                    Shared from {sharedBy}
+                  </span>
+                </>
+              )}
             </div>
-
-            {task.preferredStartTimeMin != null && (
-              <div>
-                <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">
-                  Preferred start time
-                </dt>
-                <dd className="text-sm">
-                  {formatTime(task.preferredStartTimeMin)}
-                </dd>
-              </div>
-            )}
-
-            <div>
-              <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">
-                People required
-              </dt>
-              <dd className="text-sm">{task.minPeople}</dd>
-            </div>
-
-            {(task.minWaitDays != null || task.maxWaitDays != null) && (
-              <div>
-                <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">
-                  Wait days
-                </dt>
-                <dd className="text-sm">
-                  {task.minWaitDays != null && task.maxWaitDays != null
-                    ? `${task.minWaitDays} – ${task.maxWaitDays} days`
-                    : task.minWaitDays != null
-                      ? `Min ${task.minWaitDays} days`
-                      : `Max ${task.maxWaitDays} days`}
-                </dd>
-              </div>
-            )}
-
-            {task.description && (
-              <div>
-                <dt className="text-xs text-muted-foreground uppercase tracking-wide mb-0.5">
-                  Description
-                </dt>
-                <dd>
-                  <TaskDescription description={task.description} />
-                </dd>
-              </div>
-            )}
-          </dl>
-
-          {/* Right: photo placeholder + created date */}
-          <div className="flex flex-col gap-4 order-first md:order-last">
-            {imageSignedUrl ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={imageSignedUrl}
-                alt={`Photo for ${task.name}`}
-                className="rounded-md aspect-square w-full object-cover"
-              />
-            ) : (
-              <div className="rounded-md bg-muted aspect-square w-full flex items-center justify-center text-xs text-muted-foreground">
-                No photo
-              </div>
-            )}
-            <p className="text-xs text-muted-foreground">
-              Created {formatDate(task.createdAt)}
-            </p>
           </div>
         </div>
 
-        {/* Tags */}
-        {taskTags.length > 0 && (
-          <div className="rounded-lg border bg-card p-6">
-            <h2 className="text-sm font-medium mb-3">Tags</h2>
-            <div className="flex flex-wrap gap-2">
-              {taskTags.map((tag) => (
-                <span
-                  key={tag.id}
-                  className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs"
+        {/* Main unified card */}
+        <div className="rounded-lg border bg-card overflow-hidden">
+          {/* Color accent bar */}
+          <div className="h-1.5" style={{ backgroundColor: task.color }} />
+
+          {/* Image + structured fields */}
+          <div className="p-6 grid grid-cols-1 sm:grid-cols-[200px_1fr] gap-6">
+            {/* Left: cover image or colored initial block */}
+            <div>
+              {imageSignedUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={imageSignedUrl}
+                  alt={`Photo for ${task.name}`}
+                  className="rounded-md aspect-square w-full object-cover"
+                />
+              ) : (
+                <div
+                  className="rounded-md aspect-square w-full flex items-center justify-center text-3xl font-bold select-none"
+                  style={{
+                    backgroundColor: task.color + "20",
+                    color: task.color,
+                  }}
                 >
-                  <span
-                    className="inline-block w-2 h-2 rounded-full shrink-0"
-                    style={{ backgroundColor: tag.color }}
-                  />
-                  {tag.name}
-                </span>
-              ))}
+                  {task.name.charAt(0).toUpperCase()}
+                </div>
+              )}
+            </div>
+
+            {/* Right: key fields */}
+            <div className="flex flex-col gap-4">
+              <div className="grid grid-cols-2 gap-x-4 gap-y-3">
+                {/* Duration */}
+                <div className="flex items-start gap-2">
+                  <Clock className="w-4 h-4 text-muted-foreground shrink-0 mt-0.5" />
+                  <div>
+                    <p className="text-xs text-muted-foreground">Duration</p>
+                    <p className="text-sm font-medium">
+                      {formatDuration(task.durationMin)}
+                    </p>
+                  </div>
+                </div>
+
+                {/* People */}
+                <div className="flex items-start gap-2">
+                  <Users className="w-4 h-4 text-muted-foreground shrink-0 mt-0.5" />
+                  <div>
+                    <p className="text-xs text-muted-foreground">People</p>
+                    <p className="text-sm font-medium">{task.minPeople}</p>
+                  </div>
+                </div>
+
+                {/* Start time */}
+                {task.preferredStartTimeMin != null && (
+                  <div className="flex items-start gap-2">
+                    <AlarmClock className="w-4 h-4 text-muted-foreground shrink-0 mt-0.5" />
+                    <div>
+                      <p className="text-xs text-muted-foreground">Start time</p>
+                      <p className="text-sm font-medium">
+                        {formatTime(task.preferredStartTimeMin)}
+                      </p>
+                    </div>
+                  </div>
+                )}
+
+                {/* Wait days */}
+                {(task.minWaitDays != null || task.maxWaitDays != null) && (
+                  <div className="flex items-start gap-2">
+                    <RefreshCw className="w-4 h-4 text-muted-foreground shrink-0 mt-0.5" />
+                    <div>
+                      <p className="text-xs text-muted-foreground">Wait days</p>
+                      <p className="text-sm font-medium">
+                        {task.minWaitDays != null && task.maxWaitDays != null
+                          ? `${task.minWaitDays}–${task.maxWaitDays} days`
+                          : task.minWaitDays != null
+                            ? `Min ${task.minWaitDays} days`
+                            : `Max ${task.maxWaitDays} days`}
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Scope badge */}
+              <div className="mt-auto">
+                {task.scope === "GLOBAL" ? (
+                  <span className="inline-flex items-center gap-1.5 text-xs font-medium text-emerald-700 bg-emerald-50 dark:text-emerald-400 dark:bg-emerald-950 rounded-full px-2.5 py-1 border border-emerald-200 dark:border-emerald-800">
+                    <Globe className="w-3 h-3" />
+                    Shared with franchise
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground bg-muted rounded-full px-2.5 py-1 border border-border">
+                    <Lock className="w-3 h-3" />
+                    Private
+                  </span>
+                )}
+              </div>
             </div>
           </div>
-        )}
 
-        {/* Eligible roles */}
-        <div className="rounded-lg border bg-card p-6">
-          <h2 className="text-sm font-medium mb-3">Eligible roles</h2>
-          {eligibleRoles.length === 0 ? (
-            <p className="text-sm text-muted-foreground">All roles eligible</p>
-          ) : (
-            <div className="flex flex-wrap gap-2">
-              {eligibleRoles.map((role) => (
-                <span
-                  key={role.id}
-                  className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs"
-                >
-                  <span
-                    className="inline-block w-2 h-2 rounded-full shrink-0"
-                    style={{ backgroundColor: role.color }}
-                  />
-                  {role.name}
-                </span>
-              ))}
+          {/* Description */}
+          {task.description && (
+            <div className="border-t border-border px-6 py-5">
+              <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+                Description
+              </h2>
+              <TaskDescription description={task.description} />
             </div>
           )}
+
+          {/* Tags + Eligible roles */}
+          <div className="border-t border-border px-6 py-5 flex flex-col gap-5">
+            {taskTags.length > 0 && (
+              <div>
+                <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                  Tags
+                </h2>
+                <div className="flex flex-wrap gap-1.5">
+                  {taskTags.map((tag) => (
+                    <span
+                      key={tag.id}
+                      className="inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium"
+                    >
+                      <span
+                        className="inline-block w-2 h-2 rounded-full shrink-0"
+                        style={{ backgroundColor: tag.color }}
+                      />
+                      {tag.name}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div>
+              <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                Eligible roles
+              </h2>
+              {eligibleRoles.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  All roles eligible
+                </p>
+              ) : (
+                <div className="flex flex-wrap gap-1.5">
+                  {eligibleRoles.map((role) => (
+                    <span
+                      key={role.id}
+                      className="inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium"
+                    >
+                      <span
+                        className="inline-block w-2 h-2 rounded-full shrink-0"
+                        style={{ backgroundColor: role.color }}
+                      />
+                      {role.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
         </div>
+
+        {/* Comments */}
+        <TaskComments orgId={orgId} taskId={taskId} />
       </div>
     </>
   );

--- a/app/(app)/orgs/[orgId]/tasks/[taskId]/task-detail-sidebar.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/[taskId]/task-detail-sidebar.tsx
@@ -324,10 +324,10 @@ export function TaskDetailSidebar({
             Layout
           </p>
           <Button
-            variant={activeTitle === SECTIONS_TITLE ? "secondary" : "outline"}
+            variant="outline"
             size="sm"
             className="w-full justify-start gap-2"
-            onClick={handleSectionsOpen}
+            disabled
           >
             <LayoutList className="h-3.5 w-3.5" />
             Edit Sections

--- a/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/_components/task-table.tsx
@@ -51,6 +51,35 @@ import {
 } from "@/app/actions/tasks";
 import type { SortOption } from "./tasks-config";
 
+function formatDuration(min: number): string {
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+function ownershipBadge(task: Task, orgId: string) {
+  if (task._available) {
+    return (
+      <span className="inline-flex items-center rounded-full bg-emerald-50 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-800 px-2 py-0.5 text-xs font-medium whitespace-nowrap">
+        Available
+      </span>
+    );
+  }
+  if (task.orgId !== orgId) {
+    return (
+      <span className="inline-flex items-center rounded-full bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-400 border border-blue-200 dark:border-blue-800 px-2 py-0.5 text-xs font-medium whitespace-nowrap">
+        Franchise
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded-full bg-muted text-muted-foreground border border-border px-2 py-0.5 text-xs font-medium whitespace-nowrap">
+      Mine
+    </span>
+  );
+}
+
 // Strip markdown syntax for plain-text previews
 function stripMd(text: string): string {
   return text
@@ -223,9 +252,18 @@ export function TaskTable({
             {visible.map((task) => (
               <div
                 key={task.id}
-                className="rounded-xl border bg-card shadow-sm hover:shadow-md transition-all overflow-hidden relative group"
+                tabIndex={0}
+                role="button"
+                className="rounded-xl border bg-card shadow-sm hover:shadow-md transition-all overflow-hidden relative group cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                onClick={() => router.push(`/orgs/${orgId}/tasks/${task.id}`)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    router.push(`/orgs/${orgId}/tasks/${task.id}`);
+                  }
+                }}
               >
-                {/* Cover image or color accent bar */}
+                {/* Cover image or colored initial block */}
                 {task.imageSignedUrl ? (
                   // eslint-disable-next-line @next/next/no-img-element
                   <img
@@ -235,57 +273,31 @@ export function TaskTable({
                   />
                 ) : (
                   <div
-                    className="h-1.5 w-full"
-                    style={{ backgroundColor: task.color }}
-                  />
+                    className="h-36 w-full flex items-center justify-center text-5xl font-bold select-none"
+                    style={{
+                      backgroundColor: task.color + "25",
+                      color: task.color,
+                    }}
+                  >
+                    {task.name.charAt(0).toUpperCase()}
+                  </div>
                 )}
-                <div
-                  className={`block p-4${!task._available ? " cursor-pointer" : ""}`}
-                  tabIndex={!task._available ? 0 : undefined}
-                  role={!task._available ? "button" : undefined}
-                  onClick={() => {
-                    if (!task._available)
-                      router.push(`/orgs/${orgId}/tasks/${task.id}`);
-                  }}
-                  onKeyDown={(e) => {
-                    if (
-                      !task._available &&
-                      (e.key === "Enter" || e.key === " ")
-                    ) {
-                      e.preventDefault();
-                      router.push(`/orgs/${orgId}/tasks/${task.id}`);
-                    }
-                  }}
-                >
+                <div className="p-4">
                   <div className="flex flex-col gap-3">
-                    <div className="flex items-start gap-2">
-                      <span
-                        className="w-2.5 h-2.5 rounded-full shrink-0 mt-0.5"
-                        style={{ backgroundColor: task.color }}
-                      />
-                      <div className="font-semibold text-sm leading-snug">
-                        {task.name}
-                      </div>
+                    <div className="font-semibold text-sm leading-snug">
+                      {task.name}
                     </div>
                     {task.description && (
                       <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed">
                         {stripMd(task.description)}
                       </p>
                     )}
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                        {task.durationMin} min
-                      </span>
-                      <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                        {task.minPeople}+ people
-                      </span>
-                    </div>
                     {task.eligibility.length > 0 && (
                       <div className="flex flex-wrap gap-1">
                         {task.eligibility.map((e) => (
                           <span
                             key={e.role.id}
-                            className="inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium"
+                            className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium"
                           >
                             {e.role.color && (
                               <span
@@ -298,22 +310,221 @@ export function TaskTable({
                         ))}
                       </div>
                     )}
+                    {task.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-1">
+                        {task.tags.map((tt) => (
+                          <span
+                            key={tt.tag.id}
+                            className="inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium"
+                          >
+                            <span
+                              className="inline-block w-1.5 h-1.5 rounded-full shrink-0"
+                              style={{ backgroundColor: tt.tag.color }}
+                            />
+                            {tt.tag.name}
+                          </span>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 </div>
+                <div
+                  className="flex items-center justify-between px-3 py-2 border-t"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <div className="flex items-center gap-2">
+                    {ownershipBadge(task, orgId)}
+                    <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                      {formatDuration(task.durationMin)}
+                    </span>
+                    <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                      {task.minPeople}+ ppl
+                    </span>
+                  </div>
+                  {canManageTasks && task._available && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8"
+                      disabled={isPending}
+                      title="Add to my list"
+                      onClick={() => handleAddToList(task)}
+                    >
+                      <Plus className="h-4 w-4" />
+                      <span className="sr-only">Add to list</span>
+                    </Button>
+                  )}
+                  {canManageTasks && !task._available && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8"
+                          disabled={isPending}
+                        >
+                          <MoreHorizontal className="h-4 w-4" />
+                          <span className="sr-only">Task actions</span>
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent
+                        align="end"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <DropdownMenuItem
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            router.push(
+                              `/orgs/${orgId}/tasks/${task.id}/edit`,
+                            );
+                          }}
+                        >
+                          Edit
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          disabled
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            router.push(
+                              `/orgs/${orgId}/tasks/new?duplicateFrom=${task.id}`,
+                            );
+                          }}
+                        >
+                          Duplicate
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          className="text-destructive focus:text-destructive"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleDeleteClick(task);
+                          }}
+                        >
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border bg-card overflow-hidden shadow-sm divide-y divide-border">
+            {visible.map((task) => (
+              <div
+                key={task.id}
+                tabIndex={0}
+                role="button"
+                className="flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors cursor-pointer group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                onClick={() => router.push(`/orgs/${orgId}/tasks/${task.id}`)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    router.push(`/orgs/${orgId}/tasks/${task.id}`);
+                  }
+                }}
+              >
+                {/* Color accent bar */}
+                <div
+                  className="w-1 self-stretch rounded-full shrink-0"
+                  style={{ backgroundColor: task.color }}
+                />
+
+                {/* Thumbnail */}
+                {task.imageSignedUrl && (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={task.imageSignedUrl}
+                    alt=""
+                    className="w-9 h-9 rounded-md object-cover shrink-0 hidden sm:block"
+                  />
+                )}
+
+                {/* Main content */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm truncate">
+                      {task.name}
+                    </span>
+                    {task.tags.length > 0 && (
+                      <div className="hidden md:flex items-center gap-1 shrink-0">
+                        {task.tags.slice(0, 5).map((tt) => (
+                          <span
+                            key={tt.tag.id}
+                            className="w-2 h-2 rounded-full shrink-0"
+                            style={{ backgroundColor: tt.tag.color }}
+                            title={tt.tag.name}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  {task.description && (
+                    <p className="text-xs text-muted-foreground truncate mt-0.5 leading-relaxed">
+                      {stripMd(task.description)}
+                    </p>
+                  )}
+                  {/* Mobile-only metadata row */}
+                  <div className="flex sm:hidden items-center gap-2 mt-1.5 flex-wrap">
+                    {ownershipBadge(task, orgId)}
+                    <span className="text-xs text-muted-foreground tabular-nums">
+                      {formatDuration(task.durationMin)}
+                    </span>
+                    <span className="text-muted-foreground/40 text-xs select-none">·</span>
+                    <span className="text-xs text-muted-foreground tabular-nums">
+                      {task.minPeople}+ ppl
+                    </span>
+                  </div>
+                </div>
+
+                {/* Metadata */}
+                <div className="hidden sm:flex items-center gap-4 shrink-0 text-xs text-muted-foreground">
+                  {ownershipBadge(task, orgId)}
+                  <span className="tabular-nums">
+                    {formatDuration(task.durationMin)}
+                  </span>
+                  <span className="tabular-nums">{task.minPeople}+ ppl</span>
+                  <div className="hidden md:flex items-center gap-1">
+                    {task.eligibility.length === 0 ? (
+                      <span className="text-muted-foreground/40">—</span>
+                    ) : (
+                      <>
+                        {task.eligibility.slice(0, 2).map((e) => (
+                          <span
+                            key={e.role.id}
+                            className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium whitespace-nowrap"
+                          >
+                            {e.role.color && (
+                              <span
+                                className="h-1.5 w-1.5 rounded-full shrink-0"
+                                style={{ backgroundColor: e.role.color }}
+                              />
+                            )}
+                            {e.role.name}
+                          </span>
+                        ))}
+                        {task.eligibility.length > 2 && (
+                          <span>+{task.eligibility.length - 2}</span>
+                        )}
+                      </>
+                    )}
+                  </div>
+                </div>
+
+                {/* Actions — hidden until hover */}
                 {canManageTasks && (
-                  <div className="absolute top-3 right-3">
+                  <div
+                    className="shrink-0 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100 transition-opacity"
+                    onClick={(e) => e.stopPropagation()}
+                  >
                     {task._available ? (
                       <Button
                         variant="ghost"
                         size="icon"
-                        className="h-7 w-7 opacity-100 transition-opacity sm:opacity-0 sm:pointer-events-none sm:group-hover:opacity-100 sm:group-hover:pointer-events-auto sm:focus-visible:opacity-100 sm:focus-visible:pointer-events-auto"
+                        className="h-8 w-8"
                         disabled={isPending}
                         title="Add to my list"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          handleAddToList(task);
-                        }}
+                        onClick={() => handleAddToList(task)}
                       >
                         <Plus className="h-4 w-4" />
                         <span className="sr-only">Add to list</span>
@@ -324,48 +535,36 @@ export function TaskTable({
                           <Button
                             variant="ghost"
                             size="icon"
-                            className="h-7 w-7 opacity-100 transition-opacity sm:opacity-0 sm:pointer-events-none sm:group-hover:opacity-100 sm:group-hover:pointer-events-auto sm:focus-visible:opacity-100 sm:focus-visible:pointer-events-auto"
+                            className="h-8 w-8"
                             disabled={isPending}
-                            onClick={(e) => {
-                              e.preventDefault();
-                              e.stopPropagation();
-                            }}
                           >
                             <MoreHorizontal className="h-4 w-4" />
                             <span className="sr-only">Task actions</span>
                           </Button>
                         </DropdownMenuTrigger>
-                        <DropdownMenuContent
-                          align="end"
-                          onClick={(e) => e.stopPropagation()}
-                        >
+                        <DropdownMenuContent align="end">
                           <DropdownMenuItem
-                            onClick={(e) => {
-                              e.stopPropagation();
+                            onClick={() =>
                               router.push(
                                 `/orgs/${orgId}/tasks/${task.id}/edit`,
-                              );
-                            }}
+                              )
+                            }
                           >
                             Edit
                           </DropdownMenuItem>
                           <DropdownMenuItem
                             disabled
-                            onClick={(e) => {
-                              e.stopPropagation();
+                            onClick={() =>
                               router.push(
                                 `/orgs/${orgId}/tasks/new?duplicateFrom=${task.id}`,
-                              );
-                            }}
+                              )
+                            }
                           >
                             Duplicate
                           </DropdownMenuItem>
                           <DropdownMenuItem
                             className="text-destructive focus:text-destructive"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleDeleteClick(task);
-                            }}
+                            onClick={() => handleDeleteClick(task)}
                           >
                             Delete
                           </DropdownMenuItem>
@@ -376,152 +575,6 @@ export function TaskTable({
                 )}
               </div>
             ))}
-          </div>
-        ) : (
-          <div className="rounded-lg border bg-card overflow-hidden shadow-sm overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b bg-muted/40">
-                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                    Title
-                  </th>
-                  <th className="hidden sm:table-cell text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                    Description
-                  </th>
-                  <th className="hidden sm:table-cell text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                    Duration
-                  </th>
-                  <th className="hidden sm:table-cell text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                    People
-                  </th>
-                  <th className="hidden sm:table-cell text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                    Role
-                  </th>
-                  {canManageTasks && <th className="w-10" />}
-                </tr>
-              </thead>
-              <tbody>
-                {visible.map((task) => (
-                  <tr
-                    key={task.id}
-                    tabIndex={0}
-                    onClick={() => {
-                      if (!task._available)
-                        router.push(`/orgs/${orgId}/tasks/${task.id}`);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key !== "Enter") return;
-                      if (e.target !== e.currentTarget) return;
-                      if (!task._available)
-                        router.push(`/orgs/${orgId}/tasks/${task.id}`);
-                    }}
-                    className={`border-b last:border-0 hover:bg-primary/5 active:bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset${!task._available ? " cursor-pointer" : ""}`}
-                  >
-                    <td className="px-4 py-3 font-medium">
-                      <div className="flex items-center gap-2">
-                        <span
-                          className="w-2 h-2 rounded-full shrink-0"
-                          style={{ backgroundColor: task.color }}
-                        />
-                        {task.name}
-                      </div>
-                    </td>
-                    <td className="hidden sm:table-cell px-4 py-3 text-muted-foreground max-w-60 truncate">
-                      {task.description ? stripMd(task.description) : "—"}
-                    </td>
-                    <td className="hidden sm:table-cell px-4 py-3 tabular-nums">
-                      {task.durationMin} min
-                    </td>
-                    <td className="hidden sm:table-cell px-4 py-3 tabular-nums">
-                      {task.minPeople}
-                    </td>
-                    <td className="hidden sm:table-cell px-4 py-3">
-                      {task.eligibility.length === 0 ? (
-                        <span className="text-muted-foreground">—</span>
-                      ) : (
-                        <div className="flex flex-wrap gap-1">
-                          {task.eligibility.map((e) => (
-                            <span
-                              key={e.role.id}
-                              className="inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium"
-                            >
-                              {e.role.color && (
-                                <span
-                                  className="h-1.5 w-1.5 rounded-full shrink-0"
-                                  style={{ backgroundColor: e.role.color }}
-                                />
-                              )}
-                              {e.role.name}
-                            </span>
-                          ))}
-                        </div>
-                      )}
-                    </td>
-                    {canManageTasks && (
-                      <td
-                        className="px-2 py-3 text-right"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        {task._available ? (
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-7 w-7"
-                            disabled={isPending}
-                            title="Add to my list"
-                            onClick={() => handleAddToList(task)}
-                          >
-                            <Plus className="h-4 w-4" />
-                            <span className="sr-only">Add to list</span>
-                          </Button>
-                        ) : (
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-7 w-7"
-                                disabled={isPending}
-                              >
-                                <MoreHorizontal className="h-4 w-4" />
-                                <span className="sr-only">Task actions</span>
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  router.push(
-                                    `/orgs/${orgId}/tasks/${task.id}/edit`,
-                                  )
-                                }
-                              >
-                                Edit
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                disabled
-                                onClick={() =>
-                                  router.push(
-                                    `/orgs/${orgId}/tasks/new?duplicateFrom=${task.id}`,
-                                  )
-                                }
-                              >
-                                Duplicate
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                className="text-destructive focus:text-destructive"
-                                onClick={() => handleDeleteClick(task)}
-                              >
-                                Delete
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        )}
-                      </td>
-                    )}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
           </div>
         )}
       </div>

--- a/app/(app)/orgs/[orgId]/tasks/_components/tasks-sidebar-content.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/_components/tasks-sidebar-content.tsx
@@ -12,8 +12,10 @@
  *  - Actions — Create Task link (canManageTasks only)
  *
  * All mode/filter/sort/view state is URL-driven: each control pushes a new URL
- * so the server page re-renders with updated params. The last-used mode is also
- * persisted to localStorage so it survives navigation away and back.
+ * so the server page re-renders with updated params. The last-used mode and prefs
+ * are persisted to both localStorage and cookies. Cookies allow the server page to
+ * perform a redirect before render (no client round-trip); localStorage keeps prefs
+ * alive across browser sessions when cookies have not yet been set.
  */
 import { useRouter } from "next/navigation";
 import Link from "next/link";
@@ -75,6 +77,12 @@ export function TasksSidebarContent({
   const TASKS_PREFS_KEY = `tasks-prefs-${orgId}`;
   const isFirstRender = useRef(true);
 
+  function setTasksCookie(key: string, value: string) {
+    try {
+      document.cookie = `${key}=${encodeURIComponent(value)}; path=/; max-age=31536000; SameSite=Lax`;
+    } catch { /* ignore */ }
+  }
+
   // On mount: restore saved mode and/or filter prefs if URL has no explicit params
   useEffect(() => {
     const overrides: Parameters<typeof buildHref>[0] = {};
@@ -130,6 +138,18 @@ export function TasksSidebarContent({
     if (Object.keys(overrides).length > 0) {
       router.replace(buildHref(overrides));
     }
+    // Seed cookies so the server can restore prefs without a client-side round-trip
+    // on the next bare navigation (no URL params). This is a one-time migration for
+    // users who have localStorage data but no cookie yet.
+    const resolvedMode = (overrides.mode ?? mode) as string;
+    const resolvedPrefs = JSON.stringify({
+      sort: overrides.sort ?? sort,
+      roleId: overrides.roleId !== undefined ? overrides.roleId : roleId,
+      tagId: overrides.tagId !== undefined ? overrides.tagId : tagId,
+      view: overrides.view ?? view,
+    });
+    setTasksCookie(TASKS_MODE_KEY, resolvedMode);
+    setTasksCookie(TASKS_PREFS_KEY, resolvedPrefs);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -139,14 +159,11 @@ export function TasksSidebarContent({
       isFirstRender.current = false;
       return;
     }
+    const prefsJson = JSON.stringify({ sort, roleId, tagId, view });
     try {
-      localStorage.setItem(
-        `tasks-prefs-${orgId}`,
-        JSON.stringify({ sort, roleId, tagId, view }),
-      );
-    } catch {
-      // Ignore localStorage errors
-    }
+      localStorage.setItem(`tasks-prefs-${orgId}`, prefsJson);
+    } catch { /* ignore */ }
+    setTasksCookie(TASKS_PREFS_KEY, prefsJson);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sort, roleId, tagId, view]);
 
@@ -186,21 +203,30 @@ export function TasksSidebarContent({
           url={buildHref({ mode: "shared" })}
           icon={Globe}
           isActive={mode === "shared"}
-          onClick={() => localStorage.setItem(TASKS_MODE_KEY, "shared")}
+          onClick={() => {
+            localStorage.setItem(TASKS_MODE_KEY, "shared");
+            setTasksCookie(TASKS_MODE_KEY, "shared");
+          }}
         />
         <SidebarNavItem
           title="My Tasks"
           url={buildHref({ mode: "list" })}
           icon={ListTodo}
           isActive={mode === "list"}
-          onClick={() => localStorage.setItem(TASKS_MODE_KEY, "list")}
+          onClick={() => {
+            localStorage.setItem(TASKS_MODE_KEY, "list");
+            setTasksCookie(TASKS_MODE_KEY, "list");
+          }}
         />
         <SidebarNavItem
           title="Shared"
           url={buildHref({ mode: "available" })}
           icon={Share2}
           isActive={mode === "available"}
-          onClick={() => localStorage.setItem(TASKS_MODE_KEY, "available")}
+          onClick={() => {
+            localStorage.setItem(TASKS_MODE_KEY, "available");
+            setTasksCookie(TASKS_MODE_KEY, "available");
+          }}
         />
       </div>
 
@@ -291,9 +317,15 @@ export function TasksSidebarContent({
             size="sm"
             className="w-fit"
             value={view}
-            onChange={(v) =>
-              router.push(buildHref({ view: v as "list" | "card" }))
-            }
+            onChange={(v) => {
+              const newView = v as "list" | "card";
+              // Update cookie before navigating so the server-side redirect
+              // doesn't restore the old view when the URL has no ?view param
+              const newPrefs = JSON.stringify({ sort, roleId, tagId, view: newView });
+              try { localStorage.setItem(TASKS_PREFS_KEY, newPrefs); } catch { /* ignore */ }
+              setTasksCookie(TASKS_PREFS_KEY, newPrefs);
+              router.push(buildHref({ view: newView }));
+            }}
             options={[
               { value: "list", label: <List className="h-4 w-4" /> },
               { value: "card", label: <LayoutGrid className="h-4 w-4" /> },

--- a/app/(app)/orgs/[orgId]/tasks/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/page.tsx
@@ -9,6 +9,8 @@ import {
   getAuthUserId,
 } from "@/lib/authz/_shared";
 import { PermissionAction } from "@prisma/client";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import { RegisterPageSidebarSubContent } from "@/components/layout/page-sidebar-context";
 import { TaskTable } from "./_components/task-table";
 import { TasksSidebarContent } from "./_components/tasks-sidebar-content";
@@ -29,7 +31,9 @@ import { SORT_OPTIONS, type SortOption } from "./_components/tasks-config";
  *
  * Sort, role filter, tag filter, and view (list/card) are additional URL params
  * so the sidebar controls and the table stay in sync without client state sharing.
- * The last-used mode is also persisted to localStorage so it survives page refreshes.
+ * The last-used mode/prefs are persisted to cookies (server-readable) so they can
+ * be restored via a server-side redirect before the page renders, avoiding the
+ * client-side localStorage round-trip on first load.
  */
 const VALID_SORT_VALUES = SORT_OPTIONS.map((o) => o.value);
 
@@ -56,8 +60,55 @@ const TasksPage = async ({
       : sp.mode === "available"
         ? "available"
         : "shared";
+  const isFiltersExplicit = !!(sp.sort || sp.roleId || sp.view || sp.tagId);
 
   await requireOrgMemberPage(orgId);
+
+  // ── Restore prefs from cookies before any data fetch ──────────────────────
+  // Cookies are readable server-side, so we can redirect to the correct URL
+  // immediately instead of letting the client read localStorage and re-render.
+  if (!isModeExplicit || !isFiltersExplicit) {
+    const cookieStore = await cookies();
+    const urlParams = new URLSearchParams();
+    let needsRedirect = false;
+
+    // Keep any params that are already explicit in the URL
+    if (isModeExplicit && sp.mode) urlParams.set("mode", sp.mode);
+    if (sp.sort) urlParams.set("sort", sp.sort);
+    if (sp.roleId) urlParams.set("roleId", sp.roleId);
+    if (sp.tagId) urlParams.set("tagId", sp.tagId);
+    if (sp.view) urlParams.set("view", sp.view);
+
+    if (!isModeExplicit) {
+      const saved = cookieStore.get(`tasks-mode-${orgId}`)?.value;
+      if (saved === "list" || saved === "available") {
+        urlParams.set("mode", saved);
+        needsRedirect = true;
+      }
+    }
+
+    if (!isFiltersExplicit) {
+      try {
+        const raw = cookieStore.get(`tasks-prefs-${orgId}`)?.value;
+        const prefs = raw ? (JSON.parse(raw) as Record<string, string>) : null;
+        if (prefs) {
+          if (prefs.sort && VALID_SORT_VALUES.includes(prefs.sort as SortOption) && prefs.sort !== "name-asc") {
+            urlParams.set("sort", prefs.sort);
+            needsRedirect = true;
+          }
+          if (prefs.roleId) { urlParams.set("roleId", prefs.roleId); needsRedirect = true; }
+          if (prefs.tagId) { urlParams.set("tagId", prefs.tagId); needsRedirect = true; }
+          if (prefs.view === "card") { urlParams.set("view", prefs.view); needsRedirect = true; }
+        }
+      } catch { /* ignore malformed cookie */ }
+    }
+
+    if (needsRedirect) {
+      const qs = urlParams.toString();
+      redirect(`/orgs/${orgId}/tasks${qs ? `?${qs}` : ""}`);
+    }
+  }
+  // ──────────────────────────────────────────────────────────────────────────
 
   const userId = await getAuthUserId();
   const membership = userId ? await getOrgMembership(orgId, userId) : null;
@@ -115,7 +166,6 @@ const TasksPage = async ({
     typeof sp.tagId === "string" && tags.some((t) => t.id === sp.tagId)
       ? sp.tagId
       : null;
-  const isFiltersExplicit = !!(sp.sort || sp.roleId || sp.view || sp.tagId);
 
   return (
     <>

--- a/app/(app)/orgs/[orgId]/tasks/page.tsx
+++ b/app/(app)/orgs/[orgId]/tasks/page.tsx
@@ -90,7 +90,7 @@ const TasksPage = async ({
     if (!isFiltersExplicit) {
       try {
         const raw = cookieStore.get(`tasks-prefs-${orgId}`)?.value;
-        const prefs = raw ? (JSON.parse(raw) as Record<string, string>) : null;
+        const prefs = raw ? (JSON.parse(decodeURIComponent(raw)) as Record<string, string>) : null;
         if (prefs) {
           if (prefs.sort && VALID_SORT_VALUES.includes(prefs.sort as SortOption) && prefs.sort !== "name-asc") {
             urlParams.set("sort", prefs.sort);

--- a/app/(app)/orgs/[orgId]/timetable/_components/timetable-pref-redirect.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/_components/timetable-pref-redirect.tsx
@@ -1,23 +1,44 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 
 /**
- * Reads timetable mode/span preferences from localStorage and redirects to
- * include them in the URL if the user navigated to the page without explicit
- * params (e.g. clicking the sidebar link).
+ * TimetablePrefRedirect — syncs timetable view preferences to cookies so the
+ * server can restore them on the next bare navigation before any data fetch,
+ * eliminating the client-side round-trip flash.
  *
- * Runs only once on mount — does nothing if mode/span are already in the URL.
+ * Two jobs:
+ *  1. On mount: seeds the `timetable-prefs-{orgId}` cookie from the current
+ *     URL params. If the URL has no mode/span (bare navigation, server hasn't
+ *     redirected yet), falls back to localStorage for one-time migration of
+ *     existing users. The server will redirect on the NEXT bare navigation.
+ *
+ *  2. On URL param changes (mode, span, roleId, tagId): updates the cookie so
+ *     the server can restore all prefs — including filters — on re-entry.
+ *     `anchor` is intentionally excluded; it is navigation state, not a pref.
  */
 export function TimetablePrefRedirect({ orgId }: { orgId: string }) {
-  const router = useRouter();
   const searchParams = useSearchParams();
 
-  useEffect(() => {
-    const hasMode = searchParams.has("mode");
-    const hasSpan = searchParams.has("span");
+  const mode = searchParams.get("mode");
+  const span = searchParams.get("span");
+  const roleId = searchParams.get("roleId");
+  const tagId = searchParams.get("tagId");
 
+  function writePrefCookie(value: string) {
+    try {
+      document.cookie = `timetable-prefs-${orgId}=${encodeURIComponent(value)}; path=/; max-age=31536000; SameSite=Lax`;
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // On mount: seed the cookie. When mode is in the URL (server already
+  // redirected), use the URL values directly. When mode is absent (bare URL,
+  // first visit), read localStorage for the one-time migration so the server
+  // can redirect correctly on the next visit. anchor is not persisted.
+  useEffect(() => {
     let storedMode: string | null = null;
     let storedSpan: string | null = null;
     try {
@@ -27,24 +48,38 @@ export function TimetablePrefRedirect({ orgId }: { orgId: string }) {
       /* ignore */
     }
 
-    const params = new URLSearchParams(searchParams.toString());
-    let changed = false;
+    const resolvedMode =
+      mode === "simple" || mode === "calendar"
+        ? mode
+        : storedMode === "simple"
+          ? "simple"
+          : "calendar";
+    const resolvedSpan =
+      span === "day" || span === "week"
+        ? span
+        : storedSpan === "day"
+          ? "day"
+          : "week";
 
-    if (!hasMode && (storedMode === "simple" || storedMode === "calendar")) {
-      params.set("mode", storedMode);
-      changed = true;
-    }
-
-    if (!hasSpan && (storedSpan === "day" || storedSpan === "week")) {
-      params.set("span", storedSpan);
-      changed = true;
-    }
-
-    if (changed) {
-      router.replace(`/orgs/${orgId}/timetable?${params.toString()}`);
-    }
+    writePrefCookie(
+      JSON.stringify({
+        mode: resolvedMode,
+        span: resolvedSpan,
+        roleId: roleId ?? null,
+        tagId: tagId ?? null,
+      }),
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Keep cookie up-to-date on every URL param change (mode, span, roleId,
+  // tagId). Guard on `mode` being present so a bare navigation never
+  // overwrites a valid cookie with null values before the server redirects.
+  useEffect(() => {
+    if (!mode) return;
+    writePrefCookie(JSON.stringify({ mode, span, roleId, tagId }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, span, roleId, tagId, orgId]);
 
   return null;
 }

--- a/app/(app)/orgs/[orgId]/timetable/page.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/page.tsx
@@ -3,6 +3,8 @@
  * Timetable week-view server component.
  */
 import { PermissionAction } from "@prisma/client";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import { requireOrgMemberPage } from "@/lib/authz";
 import { getOrgMembership, memberHasPermission } from "@/lib/authz/_shared";
 import { getRangeTimetableInstances } from "@/lib/services/timetable-entries";
@@ -43,6 +45,77 @@ export default async function TimetablePage({
   const rawTagId = first(rawSearchParams.tagId) ?? null;
 
   const { userId } = await requireOrgMemberPage(orgId);
+
+  // ── Cookie-based pref restore ───────────────────────────────────────────────
+  // Restore mode/span/roleId/tagId from the `timetable-prefs-{orgId}` cookie
+  // when the user navigates to the page without explicit URL params (e.g. the
+  // sidebar link). This happens server-side before any data fetch so there is
+  // no client-side flash or round-trip.
+  //
+  // The cookie is written by TimetablePrefRedirect on every URL param change,
+  // so it always reflects the user's last explicit state.
+  //
+  // We only enter this block when mode OR span are absent — within the timetable
+  // both are always set explicitly (by week navigation, view picker, and filter
+  // buttons), so a missing mode/span reliably signals a bare navigation from
+  // outside the page (e.g. sidebar link → `/orgs/[orgId]/timetable`).
+  const isModeExplicit = modeParam === "simple" || modeParam === "calendar";
+  const isSpanExplicit = spanParam === "day" || spanParam === "week";
+
+  if (!isModeExplicit || !isSpanExplicit) {
+    const cookieStore = await cookies();
+    const raw = cookieStore.get(`timetable-prefs-${orgId}`)?.value;
+    if (raw) {
+      try {
+        const saved = JSON.parse(decodeURIComponent(raw)) as {
+          mode?: string;
+          span?: string;
+          roleId?: string | null;
+          tagId?: string | null;
+        };
+        const urlParams = new URLSearchParams();
+        if (anchorParam) urlParams.set("anchor", anchorParam);
+        let needsRedirect = false;
+
+        if (isModeExplicit && modeParam) {
+          urlParams.set("mode", modeParam);
+        } else if (saved.mode === "simple" || saved.mode === "calendar") {
+          urlParams.set("mode", saved.mode);
+          needsRedirect = true;
+        }
+
+        if (isSpanExplicit && spanParam) {
+          urlParams.set("span", spanParam);
+        } else if (saved.span === "day" || saved.span === "week") {
+          urlParams.set("span", saved.span);
+          needsRedirect = true;
+        }
+
+        // Only restore roleId/tagId if not already in the URL
+        if (rawRoleId) {
+          urlParams.set("roleId", rawRoleId);
+        } else if (saved.roleId) {
+          urlParams.set("roleId", saved.roleId);
+          needsRedirect = true;
+        }
+
+        if (rawTagId) {
+          urlParams.set("tagId", rawTagId);
+        } else if (saved.tagId) {
+          urlParams.set("tagId", saved.tagId);
+          needsRedirect = true;
+        }
+
+        if (needsRedirect) {
+          const qs = urlParams.toString();
+          redirect(`/orgs/${orgId}/timetable${qs ? `?${qs}` : ""}`);
+        }
+      } catch {
+        /* ignore malformed cookie */
+      }
+    }
+  }
+  // ──────────────────────────────────────────────────────────────────────────
 
   const orgMeta = await getOrgTimetableMeta(orgId);
   const orgTz = orgMeta?.timezone ?? "UTC";

--- a/app/(app)/orgs/[orgId]/timetable/timetable-client/simple-view.tsx
+++ b/app/(app)/orgs/[orgId]/timetable/timetable-client/simple-view.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { CalendarDays, MoreHorizontal } from "lucide-react";
+import { cn } from "@/lib/utils";
 import {
   addDays,
   getDayName,
@@ -12,11 +13,16 @@ import {
   minTo12h,
 } from "../_shared/grid-utils";
 import {
-  STATUS_LABELS,
   statusDotClass,
-  statusRowClass,
   getMondayOf,
 } from "./helpers";
+
+function formatDuration(min: number): string {
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
 import { CalendarEditPopup } from "./calendar-edit-popup";
 import type { ClientTimetableInstance, ClientMembership } from "./types";
 
@@ -69,10 +75,10 @@ export function SimpleView({
 
   if (visibleInstances.length === 0) {
     return (
-      <div className="flex items-center justify-center border py-24">
+      <div className="flex items-center justify-center rounded-xl border border-dashed bg-muted/20 py-16">
         <div className="flex flex-col items-center gap-3 text-center">
           <CalendarDays className="h-10 w-10 text-muted-foreground/40" />
-          <p className="text-2xl font-semibold text-foreground">
+          <p className="text-xl font-semibold text-foreground">
             {span === "day" ? "No tasks today" : "No tasks this week"}
           </p>
         </div>
@@ -95,7 +101,12 @@ export function SimpleView({
               className={`rounded-xl border shadow-sm overflow-hidden ${today ? "border-primary/40 bg-card ring-1 ring-primary/20" : "bg-card"}`}
             >
               <div
-                className={`px-4 py-2.5 flex items-center gap-2 font-semibold text-sm border-b ${today ? "bg-primary/8 text-primary border-primary/20" : "bg-muted/20"}`}
+                className={cn(
+                "px-4 py-2.5 flex items-center gap-2 font-semibold text-sm border-b",
+                today
+                  ? "bg-primary/10 text-primary border-primary/20"
+                  : "bg-muted/20",
+              )}
               >
                 {dayLabel}
                 {today && (
@@ -110,100 +121,141 @@ export function SimpleView({
                   No tasks scheduled
                 </div>
               ) : (
-                <table className="w-full text-sm">
-                  <thead className="border-b bg-muted/20">
-                    <tr className="text-xs text-muted-foreground uppercase tracking-wide">
-                      <th className="px-3 py-1.5 text-left font-medium w-8">
-                        #
-                      </th>
-                      <th className="px-3 py-1.5 text-left font-medium">
-                        Time
-                      </th>
-                      <th className="px-3 py-1.5 text-left font-medium">
-                        Status
-                      </th>
-                      <th className="px-3 py-1.5 text-left font-medium">
-                        Task
-                      </th>
-                      <th className="px-3 py-1.5 text-left font-medium">
-                        Duration
-                      </th>
-                      <th className="px-3 py-1.5 text-left font-medium">
-                        Assigned To
-                      </th>
-                      {memberships && <th className="px-3 py-1.5 w-8" />}
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y">
-                    {dayInstances.map((inst, idx) => {
-                      const assigneeNames =
-                        inst.assignees
-                          .map(
-                            (a) =>
-                              a.membership.user?.name ??
-                              a.membership.botName ??
-                              "Bot",
-                          )
-                          .join(", ") || "—";
-                      const isSkipped = effStatus(inst) === "SKIPPED";
-                      return (
-                        <tr
-                          key={inst.id}
-                          onClick={() =>
-                            memberships && setEditingInstance(inst)
-                          }
-                          className={`hover:bg-primary/5 active:bg-primary/10 transition-colors ${memberships ? "cursor-pointer" : ""} ${statusRowClass(effStatus(inst))}`}
-                        >
-                          <td className="px-3 py-2 text-muted-foreground">
-                            {idx + 1}
-                          </td>
-                          <td className="px-3 py-2 text-muted-foreground text-xs font-mono">
-                            {minTo12h(inst.startTimeMin)}
-                          </td>
-                          <td className="px-3 py-2">
-                            <span className="inline-flex items-center gap-1.5 text-xs font-medium text-foreground">
-                              <span
-                                className={`w-2 h-2 rounded-full ${statusDotClass(effStatus(inst))}`}
-                              />
-                              {STATUS_LABELS[effStatus(inst)]}
-                            </span>
-                          </td>
-                          <td
-                            className={`px-3 py-2 font-medium ${isSkipped ? "line-through text-muted-foreground" : ""}`}
+                <div className="divide-y">
+                  {dayInstances.map((inst) => {
+                    const effectiveStatus = effStatus(inst);
+                    const isSkipped = effectiveStatus === "SKIPPED";
+                    const isDone = effectiveStatus === "DONE";
+                    return (
+                      <div
+                        key={inst.id}
+                        className={cn(
+                          "group flex items-center gap-3 px-4 py-3 transition-colors",
+                          memberships
+                            ? "cursor-pointer hover:bg-primary/5 active:bg-primary/10"
+                            : "",
+                        )}
+                        onClick={() => memberships && setEditingInstance(inst)}
+                      >
+                        {/* Task color accent */}
+                        <div
+                          className="w-1 self-stretch rounded-full shrink-0"
+                          style={{
+                            backgroundColor: inst.taskColor ?? "#94a3b8",
+                          }}
+                        />
+
+                        {/* Time */}
+                        <span className="text-xs text-muted-foreground font-mono w-14 shrink-0 tabular-nums">
+                          {minTo12h(inst.startTimeMin)}
+                        </span>
+
+                        {/* Task name */}
+                        <div className="flex-1 min-w-0">
+                          <Link
+                            href={`/orgs/${orgId}/tasks/${inst.taskId}?ref=timetable`}
+                            onClick={(e) => e.stopPropagation()}
+                            className={cn(
+                              "text-sm font-medium hover:underline block truncate",
+                              isSkipped || isDone
+                                ? "text-muted-foreground"
+                                : "",
+                              isSkipped ? "line-through" : "",
+                            )}
                           >
-                            <Link
-                              href={`/orgs/${orgId}/tasks/${inst.taskId}?ref=timetable`}
-                              onClick={(e) => e.stopPropagation()}
-                              className="hover:underline"
-                            >
-                              {inst.task.title}
-                            </Link>
-                          </td>
-                          <td className="px-3 py-2 text-muted-foreground text-xs">
-                            {inst.task.durationMin} min
-                          </td>
-                          <td className="px-3 py-2 text-muted-foreground text-xs">
-                            {assigneeNames}
-                          </td>
-                          {memberships && (
-                            <td className="px-2 py-2">
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  setEditingInstance(inst);
-                                }}
-                                className="flex items-center justify-center w-6 h-6 rounded hover:bg-muted transition-colors cursor-pointer text-muted-foreground"
-                                aria-label="Edit"
-                              >
-                                <MoreHorizontal className="h-3.5 w-3.5" />
-                              </button>
-                            </td>
+                            {inst.task.title}
+                          </Link>
+                        </div>
+
+                        {/* Assignee initials */}
+                        <div className="hidden sm:flex items-center gap-0.5 shrink-0">
+                          {inst.assignees.length === 0 ? (
+                            <span className="text-xs text-muted-foreground/50">
+                              —
+                            </span>
+                          ) : (
+                            <>
+                              {inst.assignees.slice(0, 3).map((a) => {
+                                const name =
+                                  a.membership.user?.name ??
+                                  a.membership.botName ??
+                                  "?";
+                                const initials = name
+                                  .trim()
+                                  .split(/\s+/)
+                                  .map((w) => w[0])
+                                  .slice(0, 2)
+                                  .join("")
+                                  .toUpperCase();
+                                return (
+                                  <span
+                                    key={a.id}
+                                    title={name}
+                                    className="w-6 h-6 rounded-full bg-muted text-muted-foreground text-[10px] font-semibold flex items-center justify-center"
+                                  >
+                                    {initials}
+                                  </span>
+                                );
+                              })}
+                              {inst.assignees.length > 3 && (
+                                <span className="w-6 h-6 rounded-full bg-muted text-muted-foreground text-[10px] font-semibold flex items-center justify-center">
+                                  +{inst.assignees.length - 3}
+                                </span>
+                              )}
+                            </>
                           )}
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
+                        </div>
+
+                        {/* Duration */}
+                        <span className="text-xs text-muted-foreground shrink-0 hidden sm:block">
+                          {formatDuration(inst.task.durationMin)}
+                        </span>
+
+                        {/* Status badge (sm+) / dot (mobile) */}
+                        <span
+                          className={cn(
+                            "hidden sm:inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium shrink-0",
+                            effectiveStatus === "IN_PROGRESS"
+                              ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                              : effectiveStatus === "DONE"
+                                ? "bg-green-500/10 text-green-600 dark:text-green-400"
+                                : effectiveStatus === "SKIPPED"
+                                  ? "bg-red-500/10 text-red-500"
+                                  : "bg-muted text-muted-foreground",
+                          )}
+                        >
+                          {effectiveStatus === "IN_PROGRESS"
+                            ? "In progress"
+                            : effectiveStatus === "DONE"
+                              ? "Done"
+                              : effectiveStatus === "SKIPPED"
+                                ? "Skipped"
+                                : "To do"}
+                        </span>
+                        <span
+                          className={cn(
+                            "w-2 h-2 rounded-full shrink-0 sm:hidden",
+                            statusDotClass(effectiveStatus),
+                          )}
+                        />
+
+                        {/* Edit button */}
+                        {memberships && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setEditingInstance(inst);
+                            }}
+                            className="flex items-center justify-center w-6 h-6 rounded hover:bg-muted transition-colors shrink-0 text-muted-foreground sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100"
+                            aria-label="Edit"
+                          >
+                            <MoreHorizontal className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
               )}
             </div>
           );

--- a/app/(app)/orgs/[orgId]/tools/roster/page.tsx
+++ b/app/(app)/orgs/[orgId]/tools/roster/page.tsx
@@ -65,7 +65,7 @@ export default async function RosterPage({
     ? await memberHasPermission(
         membership.id,
         orgId,
-        PermissionAction.MANAGE_TIMETABLE,
+        PermissionAction.MANAGE_MEMBERS,
       )
     : false;
 

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -4,7 +4,19 @@ import Image from "next/image";
 import { requireUserPage } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { getPublicUrl } from "@/lib/supabase-storage";
-import { Building2, Plus, Network, Users, Globe } from "lucide-react";
+import { Building2, Plus, Network, Users, Globe, ChevronRight } from "lucide-react";
+
+// ─── Org color ────────────────────────────────────────────────────────────────
+
+const ORG_COLOR_PALETTE = [
+  "#6366f1", "#8b5cf6", "#ec4899", "#f43f5e",
+  "#f97316", "#22c55e", "#14b8a6", "#06b6d4", "#3b82f6",
+];
+
+function orgColor(name: string): string {
+  const sum = [...name].reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  return ORG_COLOR_PALETTE[sum % ORG_COLOR_PALETTE.length];
+}
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { OrgNotFoundToast } from "./org-not-found-toast";
@@ -14,12 +26,15 @@ import { getInvitesForUser } from "@/lib/services/invites";
 
 // ─── Org card ─────────────────────────────────────────────────────────────────
 
-function OrgInitials({ name }: { name: string }) {
+function OrgInitials({ name, color }: { name: string; color: string }) {
   const words = name.trim().split(/\s+/);
   const initials =
     words.length >= 2 ? words[0][0] + words[1][0] : name.slice(0, 2);
   return (
-    <div className="w-11 h-11 rounded-xl bg-primary/10 text-primary flex items-center justify-center text-sm font-semibold shrink-0 uppercase">
+    <div
+      className="w-11 h-11 rounded-xl flex items-center justify-center text-sm font-semibold shrink-0 uppercase"
+      style={{ backgroundColor: color + "25", color }}
+    >
       {initials}
     </div>
   );
@@ -36,56 +51,88 @@ type OrgEntry = {
 };
 
 function OrgCard({ org }: { org: OrgEntry }) {
+  const color = orgColor(org.name);
   return (
     <Link
       href={`/orgs/${org.id}`}
       className={cn(
-        "group flex flex-col gap-4 rounded-xl border bg-card p-5 shadow-sm",
+        "group flex flex-col rounded-xl border bg-card shadow-sm overflow-hidden",
         "hover:border-primary/40 hover:shadow-md transition-all duration-150",
       )}
     >
-      <div className="flex items-start gap-3">
-        {org.image ? (
-          <Image
-            src={org.image}
-            alt={org.name}
-            width={44}
-            height={44}
-            className="rounded-xl object-cover shrink-0"
-          />
-        ) : (
-          <OrgInitials name={org.name} />
-        )}
-        <div className="flex-1 min-w-0">
-          <p className="font-semibold text-sm truncate leading-tight">
-            {org.name}
-          </p>
-          <div className="flex items-center gap-1.5 mt-1 flex-wrap">
-            {org.isOwner && (
-              <span className="inline-flex items-center rounded-full bg-primary/10 text-primary px-2 py-0.5 text-xs font-medium">
-                Owner
-              </span>
-            )}
-            {org.isParent && (
-              <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400 px-2 py-0.5 text-xs font-medium">
-                <Network className="h-3 w-3" />
-                Franchisor
-              </span>
-            )}
+      {/* Color accent bar */}
+      <div className="h-1.5" style={{ backgroundColor: color }} />
+
+      <div className="flex flex-col gap-4 p-5 flex-1">
+        <div className="flex items-start gap-3">
+          {org.image ? (
+            <Image
+              src={org.image}
+              alt={org.name}
+              width={44}
+              height={44}
+              className="rounded-xl object-cover shrink-0"
+            />
+          ) : (
+            <OrgInitials name={org.name} color={color} />
+          )}
+          <div className="flex-1 min-w-0">
+            <p className="font-semibold text-sm truncate leading-tight">
+              {org.name}
+            </p>
+            <div className="flex items-center gap-1.5 mt-1 flex-wrap">
+              {org.isOwner && (
+                <span className="inline-flex items-center rounded-full bg-primary/10 text-primary px-2 py-0.5 text-xs font-medium">
+                  Owner
+                </span>
+              )}
+              {org.isParent && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400 px-2 py-0.5 text-xs font-medium">
+                  <Network className="h-3 w-3" />
+                  Franchisor
+                </span>
+              )}
+              {!org.isOwner && !org.isParent && (
+                <span className="inline-flex items-center rounded-full bg-muted text-muted-foreground px-2 py-0.5 text-xs font-medium">
+                  Member
+                </span>
+              )}
+            </div>
           </div>
+          <ChevronRight className="h-4 w-4 text-muted-foreground/40 group-hover:text-muted-foreground group-hover:translate-x-0.5 transition-all shrink-0 mt-0.5" />
+        </div>
+
+        <div className="flex items-center gap-4 text-xs text-muted-foreground mt-auto">
+          <span className="flex items-center gap-1.5">
+            <Users className="h-3.5 w-3.5" />
+            {org.memberCount}{" "}
+            {org.memberCount === 1 ? "member" : "members"}
+          </span>
+          <span className="flex items-center gap-1.5 truncate">
+            <Globe className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{org.timezone.replace(/_/g, " ")}</span>
+          </span>
         </div>
       </div>
+    </Link>
+  );
+}
 
-      <div className="flex items-center gap-4 text-xs text-muted-foreground border-t border-border pt-3">
-        <span className="flex items-center gap-1.5">
-          <Users className="h-3.5 w-3.5" />
-          {org.memberCount} {org.memberCount === 1 ? "member" : "members"}
-        </span>
-        <span className="flex items-center gap-1.5 truncate">
-          <Globe className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">{org.timezone.replace(/_/g, " ")}</span>
-        </span>
+// ─── New org tile ─────────────────────────────────────────────────────────────
+
+function NewOrgTile() {
+  return (
+    <Link
+      href="/orgs/new"
+      className={cn(
+        "group flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed p-5 transition-all duration-150 min-h-[120px]",
+        "border-border hover:border-primary/40 hover:bg-primary/5 text-muted-foreground hover:text-primary",
+      )}
+    >
+      <div className="w-10 h-10 rounded-xl bg-muted group-hover:bg-primary/10 flex items-center justify-center transition-colors">
+        <Plus className="h-5 w-5" />
       </div>
+      <p className="text-sm font-medium">New Organization</p>
     </Link>
   );
 }
@@ -185,9 +232,16 @@ export default async function HubPage({
       {/* Header */}
       <div className="flex items-start justify-between gap-4 mb-8">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">
-            Organizations
-          </h1>
+          <div className="flex items-center gap-2.5">
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Organizations
+            </h1>
+            {orgs.length > 0 && (
+              <span className="inline-flex items-center rounded-full bg-muted text-muted-foreground px-2.5 py-0.5 text-xs font-medium">
+                {orgs.length}
+              </span>
+            )}
+          </div>
           <p className="text-sm text-muted-foreground mt-1">
             {orgs.length === 0
               ? "You're not part of any organization yet."
@@ -224,6 +278,7 @@ export default async function HubPage({
           {orgs.map((org) => (
             <OrgCard key={org.id} org={org} />
           ))}
+          <NewOrgTile />
         </div>
       ) : (
         <div className="grid sm:grid-cols-2 gap-4">

--- a/app/actions/roster.ts
+++ b/app/actions/roster.ts
@@ -1,7 +1,7 @@
 /**
  * @file app/actions/roster.ts
  * Server actions for the Roster tool.
- * All write actions require MANAGE_TIMETABLE permission.
+ * All write actions require MANAGE_MEMBERS permission.
  * Thin wrappers: validate auth → delegate to lib/services/roster → revalidatePath.
  */
 "use server";
@@ -42,7 +42,7 @@ export async function setRosterCellMembersAction(
 ): Promise<{ ok: boolean; error?: string; entries?: SavedRosterEntry[] }> {
   const authz = await requireOrgPermissionAction(
     orgId,
-    PermissionAction.MANAGE_TIMETABLE,
+    PermissionAction.MANAGE_MEMBERS,
   );
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
@@ -69,7 +69,7 @@ export async function upsertRosterDayConfigAction(
 ): Promise<{ ok: boolean; error?: string }> {
   const authz = await requireOrgPermissionAction(
     orgId,
-    PermissionAction.MANAGE_TIMETABLE,
+    PermissionAction.MANAGE_MEMBERS,
   );
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
@@ -89,7 +89,7 @@ export async function createRosterTemplateAction(
 ): Promise<{ ok: boolean; error?: string; templateId?: string }> {
   const authz = await requireOrgPermissionAction(
     orgId,
-    PermissionAction.MANAGE_TIMETABLE,
+    PermissionAction.MANAGE_MEMBERS,
   );
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
@@ -106,7 +106,7 @@ export async function deleteRosterTemplateAction(
 ): Promise<{ ok: boolean; error?: string }> {
   const authz = await requireOrgPermissionAction(
     orgId,
-    PermissionAction.MANAGE_TIMETABLE,
+    PermissionAction.MANAGE_MEMBERS,
   );
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
@@ -124,7 +124,7 @@ export async function renameRosterTemplateAction(
 ): Promise<{ ok: boolean; error?: string }> {
   const authz = await requireOrgPermissionAction(
     orgId,
-    PermissionAction.MANAGE_TIMETABLE,
+    PermissionAction.MANAGE_MEMBERS,
   );
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
@@ -144,7 +144,7 @@ export async function setRosterTemplateCellMembersAction(
 ): Promise<{ ok: boolean; error?: string }> {
   const authz = await requireOrgPermissionAction(
     orgId,
-    PermissionAction.MANAGE_TIMETABLE,
+    PermissionAction.MANAGE_MEMBERS,
   );
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
@@ -168,7 +168,7 @@ export async function updateRosterTemplateCycleWeeksAction(
 ): Promise<{ ok: boolean; error?: string }> {
   const authz = await requireOrgPermissionAction(
     orgId,
-    PermissionAction.MANAGE_TIMETABLE,
+    PermissionAction.MANAGE_MEMBERS,
   );
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
@@ -190,7 +190,7 @@ export async function clearRosterTemplateWeekAction(
 ): Promise<{ ok: boolean; error?: string }> {
   const authz = await requireOrgPermissionAction(
     orgId,
-    PermissionAction.MANAGE_TIMETABLE,
+    PermissionAction.MANAGE_MEMBERS,
   );
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 
@@ -210,7 +210,7 @@ export async function applyRosterTemplateAction(
 ): Promise<{ ok: boolean; error?: string; conflict?: boolean }> {
   const authz = await requireOrgPermissionAction(
     orgId,
-    PermissionAction.MANAGE_TIMETABLE,
+    PermissionAction.MANAGE_MEMBERS,
   );
   if (!authz.ok) return { ok: false, error: "Unauthorized" };
 

--- a/app/actions/task-comments.ts
+++ b/app/actions/task-comments.ts
@@ -81,7 +81,7 @@ export async function editCommentAction(
   if (!parsed.success)
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
 
-  const result = await editComment(commentId, authz.userId, parsed.data);
+  const result = await editComment(taskId, commentId, authz.userId, parsed.data);
   if (!result.ok) return { ok: false, error: result.error };
 
   revalidatePath(`/orgs/${orgId}/tasks/${taskId}`);
@@ -104,7 +104,7 @@ export async function deleteCommentAction(
     PermissionAction.MANAGE_TASKS,
   );
 
-  const result = await softDeleteComment(commentId, authz.userId, canManage);
+  const result = await softDeleteComment(taskId, commentId, authz.userId, canManage);
   if (!result.ok) return { ok: false, error: result.error };
 
   revalidatePath(`/orgs/${orgId}/tasks/${taskId}`);
@@ -125,7 +125,7 @@ export async function voteCommentAction(
   const allowed = await canUserCommentOnTask(taskId, orgId);
   if (!allowed) return { ok: false, error: "Unauthorized" };
 
-  const result = await voteOnComment(commentId, authz.userId, type);
+  const result = await voteOnComment(taskId, commentId, authz.userId, type);
   if (!result.ok) return { ok: false, error: result.error };
 
   revalidatePath(`/orgs/${orgId}/tasks/${taskId}`);
@@ -150,7 +150,7 @@ export async function pinCommentAction(
   );
   if (!canManage) return { ok: false, error: "Insufficient permissions" };
 
-  const result = await setPinComment(commentId, isPinned);
+  const result = await setPinComment(taskId, commentId, isPinned);
   if (!result.ok) return { ok: false, error: result.error };
 
   revalidatePath(`/orgs/${orgId}/tasks/${taskId}`);

--- a/app/actions/task-comments.ts
+++ b/app/actions/task-comments.ts
@@ -1,0 +1,158 @@
+"use server";
+
+/**
+ * Server actions for task comments.
+ *
+ * addCommentAction    — post a new top-level comment or reply (franchise member only).
+ * editCommentAction   — edit own comment content.
+ * deleteCommentAction — soft-delete own comment, or any comment with MANAGE_TASKS.
+ * voteCommentAction   — upvote / downvote / remove vote (franchise member only).
+ * pinCommentAction    — pin / unpin a top-level comment (MANAGE_TASKS required).
+ */
+
+import { PermissionAction, VoteType } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireOrgMemberAction } from "@/lib/authz";
+import { memberHasPermission } from "@/lib/authz/_shared";
+import {
+  canUserCommentOnTask,
+  createComment,
+  editComment,
+  softDeleteComment,
+  voteOnComment,
+  setPinComment,
+} from "@/lib/services/task-comments";
+import {
+  addCommentSchema,
+  editCommentSchema,
+} from "@/lib/validators/task-comment";
+import { revalidatePath } from "next/cache";
+
+type CommentActionResult = { ok: true } | { ok: false; error: string };
+
+// ─── Add comment ──────────────────────────────────────────────────────────────
+
+export async function addCommentAction(
+  orgId: string,
+  taskId: string,
+  input: { content: string; parentId?: string },
+): Promise<CommentActionResult> {
+  const authz = await requireOrgMemberAction(orgId);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const parsed = addCommentSchema.safeParse(input);
+  if (!parsed.success)
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
+
+  const allowed = await canUserCommentOnTask(taskId, orgId);
+  if (!allowed) return { ok: false, error: "You are not in this franchise" };
+
+  const user = await prisma.user.findUnique({
+    where: { id: authz.userId },
+    select: { name: true, image: true },
+  });
+
+  const result = await createComment(
+    taskId,
+    orgId,
+    authz.userId,
+    user?.name ?? "Unknown",
+    user?.image ?? null,
+    parsed.data,
+  );
+  if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(`/orgs/${orgId}/tasks/${taskId}`);
+  return { ok: true };
+}
+
+// ─── Edit comment ─────────────────────────────────────────────────────────────
+
+export async function editCommentAction(
+  orgId: string,
+  taskId: string,
+  commentId: string,
+  input: { content: string },
+): Promise<CommentActionResult> {
+  const authz = await requireOrgMemberAction(orgId);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const parsed = editCommentSchema.safeParse(input);
+  if (!parsed.success)
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input" };
+
+  const result = await editComment(commentId, authz.userId, parsed.data);
+  if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(`/orgs/${orgId}/tasks/${taskId}`);
+  return { ok: true };
+}
+
+// ─── Delete comment ───────────────────────────────────────────────────────────
+
+export async function deleteCommentAction(
+  orgId: string,
+  taskId: string,
+  commentId: string,
+): Promise<CommentActionResult> {
+  const authz = await requireOrgMemberAction(orgId);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const canManage = await memberHasPermission(
+    authz.membership.id,
+    orgId,
+    PermissionAction.MANAGE_TASKS,
+  );
+
+  const result = await softDeleteComment(commentId, authz.userId, canManage);
+  if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(`/orgs/${orgId}/tasks/${taskId}`);
+  return { ok: true };
+}
+
+// ─── Vote ─────────────────────────────────────────────────────────────────────
+
+export async function voteCommentAction(
+  orgId: string,
+  taskId: string,
+  commentId: string,
+  type: VoteType | null,
+): Promise<CommentActionResult> {
+  const authz = await requireOrgMemberAction(orgId);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const allowed = await canUserCommentOnTask(taskId, orgId);
+  if (!allowed) return { ok: false, error: "Unauthorized" };
+
+  const result = await voteOnComment(commentId, authz.userId, type);
+  if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(`/orgs/${orgId}/tasks/${taskId}`);
+  return { ok: true };
+}
+
+// ─── Pin ──────────────────────────────────────────────────────────────────────
+
+export async function pinCommentAction(
+  orgId: string,
+  taskId: string,
+  commentId: string,
+  isPinned: boolean,
+): Promise<CommentActionResult> {
+  const authz = await requireOrgMemberAction(orgId);
+  if (!authz.ok) return { ok: false, error: "Unauthorized" };
+
+  const canManage = await memberHasPermission(
+    authz.membership.id,
+    orgId,
+    PermissionAction.MANAGE_TASKS,
+  );
+  if (!canManage) return { ok: false, error: "Insufficient permissions" };
+
+  const result = await setPinComment(commentId, isPinned);
+  if (!result.ok) return { ok: false, error: result.error };
+
+  revalidatePath(`/orgs/${orgId}/tasks/${taskId}`);
+  return { ok: true };
+}

--- a/components/layout/page-sidebar-context.tsx
+++ b/components/layout/page-sidebar-context.tsx
@@ -25,7 +25,7 @@ import {
   useEffect,
   type ReactNode,
 } from "react";
-import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { PanelLeftClose, PanelLeftOpen, X } from "lucide-react";
 import { useMobileSidebar } from "@/components/layout/mobile-sidebar-context";
 import { usePersistedState } from "@/hooks/use-persisted-state";
 
@@ -88,7 +88,7 @@ export function usePageSidebarCollapsed() {
  */
 export function PageSidebarSlot() {
   const { sidebar, collapsed, setCollapsed } = useContext(PageSidebarCtx);
-  const { open } = useMobileSidebar();
+  const { open, setOpen } = useMobileSidebar();
 
   if (!sidebar) return null;
 
@@ -124,8 +124,17 @@ export function PageSidebarSlot() {
 
       {/* Mobile: overlay anchored right of the AppSidebar icon strip */}
       {open && (
-        <div className="md:hidden fixed inset-y-0 left-12 z-50 flex flex-col w-65 bg-sidebar border-r border-border overflow-y-auto max-h-screen">
-          {sidebar}
+        <div className="md:hidden fixed inset-y-0 left-12 z-50 flex flex-col w-65 bg-sidebar border-r border-border">
+          <button
+            onClick={() => setOpen(false)}
+            className="absolute top-2 right-2 z-10 flex items-center justify-center w-8 h-8 rounded-md text-muted-foreground hover:bg-muted transition-colors"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+          <div className="flex-1 overflow-y-auto flex flex-col">
+            {sidebar}
+          </div>
         </div>
       )}
     </>

--- a/lib/services/task-comments.ts
+++ b/lib/services/task-comments.ts
@@ -126,12 +126,13 @@ export async function createComment(
 }
 
 export async function editComment(
+  taskId: string,
   commentId: string,
   authorId: string,
   data: EditCommentInput,
 ): Promise<ServiceResult<CommentRow>> {
-  const existing = await prisma.taskComment.findUnique({
-    where: { id: commentId },
+  const existing = await prisma.taskComment.findFirst({
+    where: { id: commentId, taskId },
     select: { authorId: true, isDeleted: true },
   });
   if (!existing)
@@ -142,7 +143,7 @@ export async function editComment(
     return { ok: false, error: "Not the author", code: "FORBIDDEN" };
 
   const updated = await prisma.taskComment.update({
-    where: { id: commentId },
+    where: { id: commentId, taskId },
     data: { content: data.content, editedAt: new Date() },
     include: commentInclude,
   });
@@ -150,12 +151,13 @@ export async function editComment(
 }
 
 export async function softDeleteComment(
+  taskId: string,
   commentId: string,
   userId: string,
   canManage: boolean,
 ): Promise<ServiceResult<null>> {
-  const existing = await prisma.taskComment.findUnique({
-    where: { id: commentId },
+  const existing = await prisma.taskComment.findFirst({
+    where: { id: commentId, taskId },
     select: { authorId: true, isDeleted: true },
   });
   if (!existing)
@@ -165,17 +167,25 @@ export async function softDeleteComment(
     return { ok: false, error: "Not the author", code: "FORBIDDEN" };
 
   await prisma.taskComment.update({
-    where: { id: commentId },
+    where: { id: commentId, taskId },
     data: { isDeleted: true, content: "" },
   });
   return { ok: true, data: null };
 }
 
 export async function voteOnComment(
+  taskId: string,
   commentId: string,
   userId: string,
   type: VoteType | null,
 ): Promise<ServiceResult<null>> {
+  const comment = await prisma.taskComment.findFirst({
+    where: { id: commentId, taskId },
+    select: { id: true },
+  });
+  if (!comment)
+    return { ok: false, error: "Comment not found", code: "NOT_FOUND" };
+
   if (type === null) {
     await prisma.taskCommentVote.deleteMany({ where: { commentId, userId } });
   } else {
@@ -189,11 +199,12 @@ export async function voteOnComment(
 }
 
 export async function setPinComment(
+  taskId: string,
   commentId: string,
   isPinned: boolean,
 ): Promise<ServiceResult<null>> {
-  const existing = await prisma.taskComment.findUnique({
-    where: { id: commentId },
+  const existing = await prisma.taskComment.findFirst({
+    where: { id: commentId, taskId },
     select: { parentId: true },
   });
   if (!existing)
@@ -202,7 +213,7 @@ export async function setPinComment(
     return { ok: false, error: "Cannot pin a reply", code: "INVALID" };
 
   await prisma.taskComment.update({
-    where: { id: commentId },
+    where: { id: commentId, taskId },
     data: { isPinned, pinnedAt: isPinned ? new Date() : null },
   });
   return { ok: true, data: null };

--- a/lib/services/task-comments.ts
+++ b/lib/services/task-comments.ts
@@ -1,0 +1,209 @@
+/**
+ * Task comment service — CRUD, voting, pinning, and franchise permission checks.
+ *
+ * Permission model (as requested):
+ *   franchiseRoot(org) = org.parentId ?? org.id
+ *   canComment = franchiseRoot(taskOrg) === franchiseRoot(userOrg)
+ *
+ * This means any org in the same franchise network (parent or sibling) can
+ * comment on a task, regardless of which specific org owns it.
+ */
+import { VoteType } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import type { ServiceResult } from "./types";
+import type { AddCommentInput, EditCommentInput } from "@/lib/validators/task-comment";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type VoteRow = { userId: string; type: VoteType };
+
+export type CommentRow = {
+  id: string;
+  taskId: string;
+  orgId: string;
+  authorId: string | null;
+  authorName: string;
+  authorImage: string | null;
+  content: string;
+  parentId: string | null;
+  isDeleted: boolean;
+  isPinned: boolean;
+  pinnedAt: Date | null;
+  editedAt: Date | null;
+  createdAt: Date;
+  votes: VoteRow[];
+  replies?: CommentRow[];
+};
+
+// ─── Prisma include shape ─────────────────────────────────────────────────────
+
+const replyInclude = {
+  votes: { select: { userId: true, type: true } },
+} as const;
+
+const commentInclude = {
+  votes: { select: { userId: true, type: true } },
+  replies: {
+    orderBy: { createdAt: "asc" as const },
+    include: replyInclude,
+  },
+} as const;
+
+// ─── Permission check ─────────────────────────────────────────────────────────
+
+/**
+ * Returns true if the user's org is in the same franchise as the task's org.
+ *
+ * Rule: compare franchise roots (parentId ?? own id).
+ * If parentId is null (org IS the root), use the org's own id as the root.
+ */
+export async function canUserCommentOnTask(
+  taskId: string,
+  userOrgId: string,
+): Promise<boolean> {
+  const [task, userOrg] = await Promise.all([
+    prisma.task.findUnique({
+      where: { id: taskId },
+      select: { organization: { select: { id: true, parentId: true } } },
+    }),
+    prisma.organization.findUnique({
+      where: { id: userOrgId },
+      select: { id: true, parentId: true },
+    }),
+  ]);
+  if (!task || !userOrg) return false;
+
+  const taskRoot = task.organization.parentId ?? task.organization.id;
+  const userRoot = userOrg.parentId ?? userOrg.id;
+  return taskRoot === userRoot;
+}
+
+// ─── Queries ──────────────────────────────────────────────────────────────────
+
+/** Fetch all top-level comments for a task with replies and votes. Pinned first, then oldest. */
+export async function getTaskComments(taskId: string): Promise<CommentRow[]> {
+  const rows = await prisma.taskComment.findMany({
+    where: { taskId, parentId: null },
+    orderBy: [{ isPinned: "desc" }, { createdAt: "asc" }],
+    include: commentInclude,
+  });
+  return rows as unknown as CommentRow[];
+}
+
+// ─── Mutations ────────────────────────────────────────────────────────────────
+
+export async function createComment(
+  taskId: string,
+  orgId: string,
+  authorId: string,
+  authorName: string,
+  authorImage: string | null,
+  data: AddCommentInput,
+): Promise<ServiceResult<CommentRow>> {
+  // Validate parent exists, is top-level, and belongs to this task
+  if (data.parentId) {
+    const parent = await prisma.taskComment.findFirst({
+      where: { id: data.parentId, taskId, parentId: null },
+      select: { id: true },
+    });
+    if (!parent)
+      return { ok: false, error: "Parent comment not found", code: "NOT_FOUND" };
+  }
+
+  const comment = await prisma.taskComment.create({
+    data: {
+      taskId,
+      orgId,
+      authorId,
+      authorName,
+      authorImage,
+      content: data.content,
+      parentId: data.parentId ?? null,
+    },
+    include: commentInclude,
+  });
+  return { ok: true, data: comment as unknown as CommentRow };
+}
+
+export async function editComment(
+  commentId: string,
+  authorId: string,
+  data: EditCommentInput,
+): Promise<ServiceResult<CommentRow>> {
+  const existing = await prisma.taskComment.findUnique({
+    where: { id: commentId },
+    select: { authorId: true, isDeleted: true },
+  });
+  if (!existing)
+    return { ok: false, error: "Comment not found", code: "NOT_FOUND" };
+  if (existing.isDeleted)
+    return { ok: false, error: "Cannot edit a deleted comment", code: "INVALID" };
+  if (existing.authorId !== authorId)
+    return { ok: false, error: "Not the author", code: "FORBIDDEN" };
+
+  const updated = await prisma.taskComment.update({
+    where: { id: commentId },
+    data: { content: data.content, editedAt: new Date() },
+    include: commentInclude,
+  });
+  return { ok: true, data: updated as unknown as CommentRow };
+}
+
+export async function softDeleteComment(
+  commentId: string,
+  userId: string,
+  canManage: boolean,
+): Promise<ServiceResult<null>> {
+  const existing = await prisma.taskComment.findUnique({
+    where: { id: commentId },
+    select: { authorId: true, isDeleted: true },
+  });
+  if (!existing)
+    return { ok: false, error: "Comment not found", code: "NOT_FOUND" };
+  if (existing.isDeleted) return { ok: true, data: null };
+  if (!canManage && existing.authorId !== userId)
+    return { ok: false, error: "Not the author", code: "FORBIDDEN" };
+
+  await prisma.taskComment.update({
+    where: { id: commentId },
+    data: { isDeleted: true, content: "" },
+  });
+  return { ok: true, data: null };
+}
+
+export async function voteOnComment(
+  commentId: string,
+  userId: string,
+  type: VoteType | null,
+): Promise<ServiceResult<null>> {
+  if (type === null) {
+    await prisma.taskCommentVote.deleteMany({ where: { commentId, userId } });
+  } else {
+    await prisma.taskCommentVote.upsert({
+      where: { commentId_userId: { commentId, userId } },
+      create: { commentId, userId, type },
+      update: { type },
+    });
+  }
+  return { ok: true, data: null };
+}
+
+export async function setPinComment(
+  commentId: string,
+  isPinned: boolean,
+): Promise<ServiceResult<null>> {
+  const existing = await prisma.taskComment.findUnique({
+    where: { id: commentId },
+    select: { parentId: true },
+  });
+  if (!existing)
+    return { ok: false, error: "Comment not found", code: "NOT_FOUND" };
+  if (existing.parentId !== null)
+    return { ok: false, error: "Cannot pin a reply", code: "INVALID" };
+
+  await prisma.taskComment.update({
+    where: { id: commentId },
+    data: { isPinned, pinnedAt: isPinned ? new Date() : null },
+  });
+  return { ok: true, data: null };
+}

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -233,7 +233,7 @@ export async function getAccessibleTaskById(orgId: string, taskId: string) {
   if (ownedTask) return { task: ownedTask, isOwner: true as const };
 
   // Check for explicit inheritance first, then fall back to GLOBAL visibility
-  const [inheritance, sharedTask] = await Promise.all([
+  const [inheritance, sharedTask, viewerOrg] = await Promise.all([
     prisma.taskInheritance.findUnique({
       where: { taskId_orgId: { taskId, orgId } },
     }),
@@ -241,14 +241,35 @@ export async function getAccessibleTaskById(orgId: string, taskId: string) {
       where: { id: taskId },
       include: taskInclude,
     }),
+    prisma.organization.findUnique({
+      where: { id: orgId },
+      select: { id: true, parentId: true },
+    }),
   ]);
 
-  if (!sharedTask) return null;
+  if (!sharedTask || !viewerOrg) return null;
 
-  // Allow viewing if the org has inherited it OR if the task is published (GLOBAL)
-  if (!inheritance && sharedTask.scope !== "GLOBAL") return null;
+  // Allow viewing if the org has inherited it
+  if (inheritance) return { task: sharedTask, isOwner: false as const };
 
-  return { task: sharedTask, isOwner: false as const };
+  // For GLOBAL tasks, check franchise scoping
+  if (sharedTask.scope === "GLOBAL") {
+    const taskOrg = await prisma.organization.findUnique({
+      where: { id: sharedTask.orgId },
+      select: { id: true, parentId: true },
+    });
+    if (!taskOrg) return null;
+
+    // Compare franchise roots
+    const taskRoot = taskOrg.parentId ?? taskOrg.id;
+    const viewerRoot = viewerOrg.parentId ?? viewerOrg.id;
+
+    if (taskRoot === viewerRoot) {
+      return { task: sharedTask, isOwner: false as const };
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -217,10 +217,13 @@ export async function getTaskById(orgId: string, taskId: string) {
 }
 
 /**
- * Returns a task the org can access — either because it owns the task or
- * because it has an active TaskInheritance row. Returns null if neither.
- * The `isOwner` flag distinguishes between the two cases so callers can
- * conditionally render publish controls, edit buttons, etc.
+ * Returns a task the org can access — either because it owns the task,
+ * because it has an active TaskInheritance row, or because the task is
+ * GLOBAL (viewable by any org even without inheriting it). Returns null
+ * only if the task doesn't exist or isn't accessible.
+ *
+ * `isOwner: true`  — org owns the task (can edit, delete, publish)
+ * `isOwner: false` — org has inherited or is viewing a shared GLOBAL task
  */
 export async function getAccessibleTaskById(orgId: string, taskId: string) {
   const ownedTask = await prisma.task.findFirst({
@@ -229,18 +232,23 @@ export async function getAccessibleTaskById(orgId: string, taskId: string) {
   });
   if (ownedTask) return { task: ownedTask, isOwner: true as const };
 
-  const inheritance = await prisma.taskInheritance.findUnique({
-    where: { taskId_orgId: { taskId, orgId } },
-  });
-  if (!inheritance) return null;
+  // Check for explicit inheritance first, then fall back to GLOBAL visibility
+  const [inheritance, sharedTask] = await Promise.all([
+    prisma.taskInheritance.findUnique({
+      where: { taskId_orgId: { taskId, orgId } },
+    }),
+    prisma.task.findUnique({
+      where: { id: taskId },
+      include: taskInclude,
+    }),
+  ]);
 
-  const inheritedTask = await prisma.task.findUnique({
-    where: { id: taskId },
-    include: taskInclude,
-  });
-  if (!inheritedTask) return null;
+  if (!sharedTask) return null;
 
-  return { task: inheritedTask, isOwner: false as const };
+  // Allow viewing if the org has inherited it OR if the task is published (GLOBAL)
+  if (!inheritance && sharedTask.scope !== "GLOBAL") return null;
+
+  return { task: sharedTask, isOwner: false as const };
 }
 
 /**

--- a/lib/validators/task-comment.ts
+++ b/lib/validators/task-comment.ts
@@ -9,12 +9,12 @@
 import { z } from "zod";
 
 export const addCommentSchema = z.object({
-  content: z.string().min(1, "Comment cannot be empty").max(2000),
+  content: z.string().trim().min(1, "Comment cannot be empty").max(2000),
   parentId: z.string().cuid().optional(),
 });
 
 export const editCommentSchema = z.object({
-  content: z.string().min(1, "Comment cannot be empty").max(2000),
+  content: z.string().trim().min(1, "Comment cannot be empty").max(2000),
 });
 
 export type AddCommentInput = z.infer<typeof addCommentSchema>;

--- a/lib/validators/task-comment.ts
+++ b/lib/validators/task-comment.ts
@@ -1,0 +1,21 @@
+/**
+ * Zod schemas for task comment mutations.
+ *
+ * addCommentSchema  — validates content (1–2000 chars) and an optional parentId
+ *                     (CUID) for threaded replies.
+ * editCommentSchema — validates content only; parentId cannot be changed post-
+ *                     creation.
+ */
+import { z } from "zod";
+
+export const addCommentSchema = z.object({
+  content: z.string().min(1, "Comment cannot be empty").max(2000),
+  parentId: z.string().cuid().optional(),
+});
+
+export const editCommentSchema = z.object({
+  content: z.string().min(1, "Comment cannot be empty").max(2000),
+});
+
+export type AddCommentInput = z.infer<typeof addCommentSchema>;
+export type EditCommentInput = z.infer<typeof editCommentSchema>;

--- a/prisma/migrations/20260526000000_add_task_comments/migration.sql
+++ b/prisma/migrations/20260526000000_add_task_comments/migration.sql
@@ -1,0 +1,62 @@
+-- CreateEnum
+CREATE TYPE "VoteType" AS ENUM ('UPVOTE', 'DOWNVOTE');
+
+-- CreateTable
+CREATE TABLE "TaskComment" (
+    "id" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "authorId" TEXT,
+    "authorName" TEXT NOT NULL,
+    "authorImage" TEXT,
+    "content" TEXT NOT NULL,
+    "parentId" TEXT,
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "isPinned" BOOLEAN NOT NULL DEFAULT false,
+    "pinnedAt" TIMESTAMP(3),
+    "editedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TaskComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TaskCommentVote" (
+    "commentId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" "VoteType" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TaskCommentVote_pkey" PRIMARY KEY ("commentId","userId")
+);
+
+-- CreateIndex
+CREATE INDEX "TaskComment_taskId_orgId_idx" ON "TaskComment"("taskId", "orgId");
+
+-- CreateIndex
+CREATE INDEX "TaskComment_parentId_idx" ON "TaskComment"("parentId");
+
+-- CreateIndex
+CREATE INDEX "TaskComment_authorId_idx" ON "TaskComment"("authorId");
+
+-- CreateIndex
+CREATE INDEX "TaskCommentVote_userId_idx" ON "TaskCommentVote"("userId");
+
+-- AddForeignKey
+ALTER TABLE "TaskComment" ADD CONSTRAINT "TaskComment_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskComment" ADD CONSTRAINT "TaskComment_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskComment" ADD CONSTRAINT "TaskComment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskComment" ADD CONSTRAINT "TaskComment_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "TaskComment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskCommentVote" ADD CONSTRAINT "TaskCommentVote_commentId_fkey" FOREIGN KEY ("commentId") REFERENCES "TaskComment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskCommentVote" ADD CONSTRAINT "TaskCommentVote_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,6 +63,11 @@ enum ViewType {
   WEEKLY
 }
 
+enum VoteType {
+  UPVOTE
+  DOWNVOTE
+}
+
 // ─────────────────────────────────────
 // AUTH (NextAuth)
 // ─────────────────────────────────────
@@ -125,8 +130,10 @@ model User {
   receivedNotifications     Notification[] @relation("ReceivedNotifications")
   auditLogs                 AuditLog[]
 
-  feedback      Feedback[]
-  createdTasks  Task[]     @relation("CreatedTasks")
+  feedback            Feedback[]
+  createdTasks        Task[]              @relation("CreatedTasks")
+  taskComments        TaskComment[]
+  taskCommentVotes    TaskCommentVote[]
 
   accounts      Account[]
   sessions      Session[]
@@ -179,6 +186,7 @@ model Organization {
   feedback            Feedback[]
   taskInheritances    TaskInheritance[]
   sectionLayouts      TaskSectionLayout[]
+  taskComments        TaskComment[]
 
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
@@ -321,6 +329,7 @@ model Task {
   timetableTemplateEntries TimetableTemplateEntry[]
   inheritedBy           TaskInheritance[]
   sectionLayouts        TaskSectionLayout[]
+  comments              TaskComment[]
 
   scope                 TaskScope @default(ORG)
 
@@ -912,4 +921,66 @@ model TaskSectionLayout {
 
   @@unique([taskId, orgId, type])
   @@index([taskId, orgId])
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TASK COMMENT
+// One-level threading: top-level comments have parentId = null;
+// replies point to a top-level comment. Replies cannot themselves be replied to.
+// ─────────────────────────────────────────────────────────────────────────────
+
+model TaskComment {
+  id          String   @id @default(cuid())
+
+  taskId      String
+  task        Task         @relation(fields: [taskId], references: [id], onDelete: Cascade)
+
+  orgId       String
+  org         Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  // Nullable — preserved as a tombstone when the author deletes their account
+  authorId    String?
+  author      User?        @relation(fields: [authorId], references: [id], onDelete: SetNull)
+  authorName  String       // snapshot at post time
+  authorImage String?      // snapshot at post time
+
+  content     String
+
+  // One-level reply: null = top-level, non-null = reply to a top-level comment
+  parentId    String?
+  parent      TaskComment?  @relation("TaskCommentReplies", fields: [parentId], references: [id], onDelete: Cascade)
+  replies     TaskComment[] @relation("TaskCommentReplies")
+
+  isDeleted   Boolean  @default(false)
+  isPinned    Boolean  @default(false)
+  pinnedAt    DateTime?
+  editedAt    DateTime?
+
+  votes       TaskCommentVote[]
+
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([taskId, orgId])
+  @@index([parentId])
+  @@index([authorId])
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TASK COMMENT VOTE
+// One row per (comment, user) pair. Composite PK prevents double-voting.
+// ─────────────────────────────────────────────────────────────────────────────
+
+model TaskCommentVote {
+  commentId String
+  userId    String
+  type      VoteType
+
+  comment   TaskComment @relation(fields: [commentId], references: [id], onDelete: Cascade)
+  user      User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@id([commentId, userId])
+  @@index([userId])
 }


### PR DESCRIPTION
## What Changed

Full task comment system + several UI/UX improvements across the app.

**Task comments** — threaded discussions on task detail pages, scoped to franchise networks. Any org in the same franchise can comment; managers (MANAGE_TASKS) can pin and delete any comment.

**UI improvements** — org color accents on hub + overview, timetable simple view redesign (flex rows with color bars, assignee chips, duration, status badges), mobile page sidebar X close button, task table ownership badges and keyboard navigation, member form convert-to-bot action.

**Cookie-based pref restoration** — task filter/sort/view prefs now persist to both localStorage and cookies so the server can redirect to the correct URL immediately without a client round-trip.

**Docs** — JSDoc added to all new files; README fully updated with new models, enums, migration history, Task Comments section, and UI notes.

## Why

Closes #

## Type

- [ ] 🐛 Bug fix
- [x] ✨ Enhancement / Feature
- [ ] 🔧 Refactor
- [x] 📝 Documentation
- [x] 🎨 UI / Styling

## How to Test

1. Run `pnpm prisma db push` to apply `TaskComment` + `TaskCommentVote` schema changes
2. Navigate to any task detail page (`/orgs/[orgId]/tasks/[taskId]`) — a comment section should appear at the bottom
3. Post a top-level comment, reply to it, upvote/downvote, pin (as a manager), and soft-delete
4. Verify only franchise-network members can comment (try from an unrelated org — section should show read-only)
5. Visit `/` (hub) — org cards should show a colored accent bar and colored initials badge
6. Visit `/orgs/[orgId]` (overview) — color bar at top of card; Owner badge next to org name
7. Open the timetable in Simple mode — rows should have color bars, assignee chips, duration, status badges
8. On mobile, open the page sidebar — an X button should appear in the top-right corner to close it
9. Navigate to tasks, set a filter/sort — refresh the page — prefs should restore via server-side redirect without flash

## Screenshots / Recordings

<!-- Before & after if UI changed -->

## Checklist

- [ ] Tested on desktop (Chrome)
- [ ] Tested on mobile (iPhone Safari)
- [ ] No lint errors (`pnpm lint`)
- [ ] Build passes (`pnpm build`)
- [ ] Smoke test updated (if applicable)

## Smoke Test Issues Resolved

<!-- List any smoke test issues this PR fixes -->

- [ ] #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task comments: threaded replies, voting, pinning, inline post/edit and comment counts on task pages
  * Convert member to bot from membership edit
  * Deterministic org color accents and a “New Organization” tile

* **Improvements**
  * Redesigned task detail, task cards, timetable simple view and roster layouts (ownership badges, mobile status dots)
  * Preferences persist/restore via cookies across sessions
  * Mobile sidebar now has an explicit close button

* **Bug Fixes**
  * Roster write permission corrected to Manage Members

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IvanTran-2001/FriendChise/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->