### PR TITLE
feat(item-list): unify placement and movement UI

### DIFF
--- a/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/add-item-to-list-panel.tsx
+++ b/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/add-item-to-list-panel.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState, useTransition, useEffect } from "react";
-import { GripVertical, Search, MapPin, Loader2 } from "lucide-react";
+import { GripVertical, Search, MapPin, Loader2, LayoutGrid, SlidersHorizontal } from "lucide-react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 
 import { cn } from "@/lib/utils";
 import { addToolItemListEntryAtPositionAction } from "@/app/actions/tools";
+import { usePersistedState } from "@/hooks/use-persisted-state";
 
 export type PickableItem = {
   id: string;
@@ -26,11 +27,13 @@ interface AddItemToListPanelProps {
   defaultRow?: number;
   gridCols?: number;
   gridRows?: number;
+  onModeChange?: (mode: "grid" | "manual") => void;
   onAdded: (entry: unknown) => void;
   onClose: () => void;
-  /** Fired whenever the computed target position changes (Page/Col/Row inputs).
-   * Parent uses this to highlight the corresponding cell in the grid. */
+  /** Fired in manual mode whenever the computed target position changes. */
   onPositionChange?: (position: number) => void;
+  /** Grid mode: called when user picks an item; parent handles cell selection. */
+  onItemPicked?: (item: PickableItem) => void;
 }
 
 export function AddItemToListPanel({
@@ -42,56 +45,74 @@ export function AddItemToListPanel({
   defaultRow = 1,
   gridCols = 4,
   gridRows = 4,
+  onModeChange,
   onAdded,
   onClose,
   onPositionChange,
+  onItemPicked,
 }: AddItemToListPanelProps) {
   const [search, setSearch] = useState("");
   const [selectedItem, setSelectedItem] = useState<PickableItem | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [mode, setMode] = usePersistedState<"grid" | "manual">(
+    `item-list-add-item-mode-${orgId}-${listId}`,
+    "grid",
+  );
+
+  const pageSize = gridCols * gridRows;
+
+  // ── Manual mode state ────────────────────────────────────────────────────
   const [page, setPage] = useState(String(defaultPage));
   const [col, setCol] = useState(String(defaultCol));
   const [row, setRow] = useState(String(defaultRow));
-  const [isPending, startTransition] = useTransition();
 
   const filtered = availableItems.filter((i) =>
     i.name.toLowerCase().includes(search.toLowerCase()),
   );
 
-  const pageSize = gridCols * gridRows;
+  // ── Manual position derived value ────────────────────────────────────────────
   const parsedPage = parseInt(page);
   const parsedCol = parseInt(col);
   const parsedRow = parseInt(row);
   const maxRows = Math.ceil(pageSize / gridCols);
-  // Derived 0-indexed absolute position from the Page/Col/Row inputs
-  const position =
-    !isNaN(parsedPage) &&
-    !isNaN(parsedCol) &&
-    !isNaN(parsedRow) &&
-    parsedCol >= 1 &&
-    parsedCol <= gridCols &&
-    parsedRow >= 1 &&
-    parsedRow <= maxRows
+  const manualPosition =
+    !isNaN(parsedPage) && !isNaN(parsedCol) && !isNaN(parsedRow) &&
+    parsedCol >= 1 && parsedCol <= gridCols &&
+    parsedRow >= 1 && parsedRow <= maxRows
       ? (parsedPage - 1) * pageSize + (parsedRow - 1) * gridCols + (parsedCol - 1)
       : -1;
-  // Notify parent whenever the target position changes so the grid can highlight it
+
   useEffect(() => {
-    if (position >= 0) onPositionChange?.(position);
-  }, [position]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (mode === "manual" && manualPosition >= 0) onPositionChange?.(manualPosition);
+  }, [mode, manualPosition]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function setAddItemMode(nextMode: "grid" | "manual") {
+    setMode(nextMode);
+    onModeChange?.(nextMode);
+  }
 
   function handleSelectItem(item: PickableItem) {
     if (isPending) return;
+
+    if (mode === "grid") {
+      // Grid mode: notify parent to handle cell selection.
+      onItemPicked?.(item);
+      return;
+    }
+
+    // Manual mode: place immediately using the typed position
     if (selectedItem?.id === item.id) {
       setSelectedItem(null);
       return;
     }
     setSelectedItem(item);
-    if (position < 0) return;
+    if (manualPosition < 0) return;
     startTransition(async () => {
       const result = await addToolItemListEntryAtPositionAction(
         orgId,
         listId,
         item.id,
-        position,
+        manualPosition,
       );
       if (!result.ok) {
         toast.error("error" in result ? result.error : "Failed to add item.");
@@ -105,46 +126,61 @@ export function AddItemToListPanel({
 
   return (
     <div className="flex flex-col h-full">
-      {/* Top section: position + selected item + button */}
-      <div className="px-4 pt-4 pb-3 border-b border-border flex flex-col gap-2">
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
-          <MapPin className="h-3 w-3 shrink-0" />
-          <span>Position</span>
+      {/* Mode toggle + position */}
+      <div className="px-4 pt-4 pb-3 border-b border-border flex flex-col gap-3">
+        <div className="flex items-center gap-1 bg-muted rounded-md p-0.5 w-fit">
+          <button
+            onClick={() => setAddItemMode("grid")}
+            className={cn(
+              "flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium transition-colors",
+              mode === "grid"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <LayoutGrid className="h-3 w-3" />
+            Select Cell
+          </button>
+          <button
+            onClick={() => setAddItemMode("manual")}
+            className={cn(
+              "flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium transition-colors",
+              mode === "manual"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <SlidersHorizontal className="h-3 w-3" />
+            Manual
+          </button>
         </div>
-        <div className="grid grid-cols-3 gap-2">
-          <div className="flex flex-col gap-1">
-            <label className="text-xs text-muted-foreground">Page</label>
-            <Input
-              type="number"
-              min="1"
-              value={page}
-              onChange={(e) => setPage(e.target.value)}
-              className="h-8 text-sm"
-            />
+
+        {mode === "grid" ? (
+          <p className="text-xs text-muted-foreground">
+            Pick an item below — then tap a cell in the grid to place it.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <MapPin className="h-3 w-3 shrink-0" />
+              <span>Position</span>
+            </div>
+            <div className="grid grid-cols-3 gap-2">
+              <div className="flex flex-col gap-1">
+                <label className="text-xs text-muted-foreground">Page</label>
+                <Input type="number" min="1" value={page} onChange={(e) => setPage(e.target.value)} className="h-8 text-sm" />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-xs text-muted-foreground">Col</label>
+                <Input type="number" min="1" max={gridCols} value={col} onChange={(e) => setCol(e.target.value)} className="h-8 text-sm" />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-xs text-muted-foreground">Row</label>
+                <Input type="number" min="1" max={gridRows} value={row} onChange={(e) => setRow(e.target.value)} className="h-8 text-sm" />
+              </div>
+            </div>
           </div>
-          <div className="flex flex-col gap-1">
-            <label className="text-xs text-muted-foreground">Col</label>
-            <Input
-              type="number"
-              min="1"
-              max={gridCols}
-              value={col}
-              onChange={(e) => setCol(e.target.value)}
-              className="h-8 text-sm"
-            />
-          </div>
-          <div className="flex flex-col gap-1">
-            <label className="text-xs text-muted-foreground">Row</label>
-            <Input
-              type="number"
-              min="1"
-              max={gridRows}
-              value={row}
-              onChange={(e) => setRow(e.target.value)}
-              className="h-8 text-sm"
-            />
-          </div>
-        </div>
+        )}
 
         {isPending && (
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">

--- a/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/add-item-to-list-panel.tsx
+++ b/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/add-item-to-list-panel.tsx
@@ -101,7 +101,7 @@ export function AddItemToListPanel({
     }
 
     // Manual mode: place immediately using the typed position
-    if (selectedItem?.id === item.id) {
+    if (selectedItem?.id === item.id && manualPosition >= 0) {
       setSelectedItem(null);
       return;
     }

--- a/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/blue-action-button.tsx
+++ b/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/blue-action-button.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface BlueActionButtonProps {
+  children: ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  icon?: ReactNode;
+  className?: string;
+  type?: "button" | "submit" | "reset";
+}
+
+export function BlueActionButton({
+  children,
+  onClick,
+  disabled,
+  icon,
+  className,
+  type = "button",
+}: BlueActionButtonProps) {
+  return (
+    <Button
+      type={type}
+      size="sm"
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "group w-full justify-start gap-2 rounded-xl border border-primary/10 bg-primary text-primary-foreground shadow-sm shadow-primary/15 transition-all hover:bg-primary/90 hover:shadow-md hover:shadow-primary/20 hover:ring-2 hover:ring-primary/25 hover:ring-offset-1 active:scale-[0.99] disabled:opacity-60",
+        className,
+      )}
+    >
+      {icon && (
+        <span className="flex h-5 w-5 items-center justify-center rounded-md bg-primary-foreground/15 text-primary-foreground transition-colors group-hover:bg-primary-foreground/20">
+          {icon}
+        </span>
+      )}
+      <span className="font-medium tracking-tight">{children}</span>
+    </Button>
+  );
+}

--- a/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/item-detail-panel.tsx
+++ b/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/item-detail-panel.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import {
   ChevronLeft,
   ChevronRight,
+  LayoutGrid,
   Eye,
   EyeOff,
   Pencil,
@@ -16,11 +17,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import {
-  moveToolItemListEntryAction,
   removeToolItemListEntryAction,
+  moveToolItemListEntryByIdAction,
   updateToolItemListEntryAmountAction,
 } from "@/app/actions/tools";
 import type { ConversionRate } from "./item-rates-panel";
+import { BlueActionButton } from "./blue-action-button";
 
 function formatMultiplier(toQty: number, fromQty: number): string {
   const m = toQty / fromQty;
@@ -46,6 +48,7 @@ interface ItemDetailPanelProps {
   setName: string | null;
   hiddenRateIds: Set<string>;
   onToggleRate: (rateId: string) => void;
+  onSelectCell: () => void;
   onNavigate?: (direction: "prev" | "next") => void;
   onClose: () => void;
 }
@@ -66,51 +69,24 @@ export function ItemDetailPanel({
   setName,
   hiddenRateIds: initialHidden,
   onToggleRate,
+  onSelectCell,
   onNavigate,
   onClose,
 }: ItemDetailPanelProps) {
   const pageSize = gridCols * gridRows;
-  const initPage = Math.floor(position / pageSize) + 1;
-  const posInPage = position % pageSize;
-  const initRow = Math.floor(posInPage / gridCols) + 1;
-  const initCol = (posInPage % gridCols) + 1;
-
-  const [pageVal, setPageVal] = useState(String(initPage));
-  const [colVal, setColVal] = useState(String(initCol));
-  const [rowVal, setRowVal] = useState(String(initRow));
   const [amountVal, setAmountVal] = useState(String(initialAmount));
   const [hiddenIds, setHiddenIds] = useState(new Set(initialHidden));
   const [search, setSearch] = useState("");
-  const [isMovePending, startMoveTransition] = useTransition();
+  const [pageVal, setPageVal] = useState(String(Math.floor(position / pageSize) + 1));
+  const [colVal, setColVal] = useState(String((position % pageSize) % gridCols + 1));
+  const [rowVal, setRowVal] = useState(String(Math.floor((position % pageSize) / gridCols) + 1));
   const [isDeletePending, startDeleteTransition] = useTransition();
   const [isAmountPending, startAmountTransition] = useTransition();
+  const [isManualMovePending, startManualMoveTransition] = useTransition();
 
-  const parsedPage = Number.parseInt(pageVal);
-  const parsedCol = Number.parseInt(colVal);
-  const parsedRow = Number.parseInt(rowVal);
-  const newPos =
-    !Number.isNaN(parsedPage) &&
-    !Number.isNaN(parsedCol) &&
-    !Number.isNaN(parsedRow)
-      ? (parsedPage - 1) * pageSize + (parsedRow - 1) * gridCols + (parsedCol - 1)
-      : -1;
-  const posChanged = newPos >= 0 && newPos !== position;
   const parsedAmount = Number.parseFloat(amountVal);
   const amountChanged =
     !Number.isNaN(parsedAmount) && parsedAmount > 0 && parsedAmount !== initialAmount;
-
-  function handleMove() {
-    if (!posChanged) return;
-    startMoveTransition(async () => {
-      const result = await moveToolItemListEntryAction(orgId, listId, position, newPos);
-      if (!result.ok) {
-        toast.error("Failed to move item.");
-        return;
-      }
-      toast.success("Item moved.");
-      onClose();
-    });
-  }
 
   function handleDelete() {
     startDeleteTransition(async () => {
@@ -138,6 +114,40 @@ export function ItemDetailPanel({
         return;
       }
       toast.success("Quantity updated.");
+    });
+  }
+
+  function handleManualMove() {
+    if (isManualMovePending) return;
+    const parsedPage = Number.parseInt(pageVal);
+    const parsedCol = Number.parseInt(colVal);
+    const parsedRow = Number.parseInt(rowVal);
+    if (
+      Number.isNaN(parsedPage) ||
+      Number.isNaN(parsedCol) ||
+      Number.isNaN(parsedRow) ||
+      parsedPage < 1 ||
+      parsedCol < 1 ||
+      parsedCol > gridCols ||
+      parsedRow < 1 ||
+      parsedRow > gridRows
+    ) {
+      toast.error("Enter a valid page, column, and row.");
+      return;
+    }
+    const nextPosition = (parsedPage - 1) * pageSize + (parsedRow - 1) * gridCols + (parsedCol - 1);
+    if (nextPosition === position) {
+      toast.error("That is already the current position.");
+      return;
+    }
+    startManualMoveTransition(async () => {
+      const result = await moveToolItemListEntryByIdAction(orgId, listId, entryId, nextPosition);
+      if (!result.ok) {
+        toast.error("Failed to move item.");
+        return;
+      }
+      toast.success("Item moved.");
+      onClose();
     });
   }
 
@@ -211,7 +221,7 @@ export function ItemDetailPanel({
           </div>
 
           {canManage && (
-            <div className="rounded-lg border border-border bg-muted/20 px-3 py-2.5">
+            <div className="border-t border-border pt-3">
               <div className="mb-2 flex items-center justify-between gap-2">
                 <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
                   <Pencil className="h-3 w-3" />
@@ -244,56 +254,71 @@ export function ItemDetailPanel({
 
       {canManage && (
         <div className="border-b border-border px-4 py-3">
-          <div className="rounded-lg border border-border bg-card p-3">
-            <div className="mb-3 flex items-center justify-between gap-2">
-              <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground/60">
-                Position
+          <div className="space-y-3">
+            <div>
+              <div className="mb-3 flex items-center justify-between gap-2">
+                <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground/60">
+                  Position
+                </p>
+                <span className="text-[10px] text-muted-foreground/70">{position + 1} in list</span>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Select a blue cell, or use manual columns below.
               </p>
-              <span className="text-[10px] text-muted-foreground/70">{position + 1} in list</span>
-            </div>
-            <div className="grid grid-cols-3 gap-2">
-              <div className="flex flex-col gap-1">
-                <label className="text-xs text-muted-foreground">Page</label>
-                <Input
-                  type="number"
-                  min="1"
-                  value={pageVal}
-                  onChange={(e) => setPageVal(e.target.value)}
-                  className="h-8 text-sm"
-                />
-              </div>
-              <div className="flex flex-col gap-1">
-                <label className="text-xs text-muted-foreground">Col</label>
-                <Input
-                  type="number"
-                  min="1"
-                  max={gridCols}
-                  value={colVal}
-                  onChange={(e) => setColVal(e.target.value)}
-                  className="h-8 text-sm"
-                />
-              </div>
-              <div className="flex flex-col gap-1">
-                <label className="text-xs text-muted-foreground">Row</label>
-                <Input
-                  type="number"
-                  min="1"
-                  max={gridRows}
-                  value={rowVal}
-                  onChange={(e) => setRowVal(e.target.value)}
-                  className="h-8 text-sm"
-                />
+              <div className="mt-2">
+                <BlueActionButton onClick={onSelectCell} icon={<LayoutGrid className="h-3.5 w-3.5" />}>
+                  Select Cell
+                </BlueActionButton>
               </div>
             </div>
-            <div className="mt-3 flex items-center gap-2">
-              <Button
-                size="sm"
-                className="flex-1"
-                disabled={!posChanged || isMovePending}
-                onClick={handleMove}
+            <div className="border-t border-border pt-3">
+              <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground/60">
+                Manual Position
+              </p>
+              <div className="grid grid-cols-3 gap-2">
+                <div className="flex flex-col gap-1">
+                  <label className="text-xs text-muted-foreground">Page</label>
+                  <Input
+                    type="number"
+                    min="1"
+                    value={pageVal}
+                    onChange={(e) => setPageVal(e.target.value)}
+                    className="h-8 text-sm"
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label className="text-xs text-muted-foreground">Col</label>
+                  <Input
+                    type="number"
+                    min="1"
+                    max={gridCols}
+                    value={colVal}
+                    onChange={(e) => setColVal(e.target.value)}
+                    className="h-8 text-sm"
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label className="text-xs text-muted-foreground">Row</label>
+                  <Input
+                    type="number"
+                    min="1"
+                    max={gridRows}
+                    value={rowVal}
+                    onChange={(e) => setRowVal(e.target.value)}
+                    className="h-8 text-sm"
+                  />
+                </div>
+              </div>
+              <BlueActionButton
+                className="mt-3"
+                disabled={isManualMovePending}
+                onClick={handleManualMove}
+                icon={<LayoutGrid className="h-3.5 w-3.5" />}
               >
                 Move item
-              </Button>
+              </BlueActionButton>
+            </div>
+            <div className="mt-3 flex items-center gap-2">
               <Button
                 size="sm"
                 variant="outline"

--- a/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/list-detail-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/list-detail-client.tsx
@@ -170,6 +170,7 @@ export function ListDetailClient({
 
   function handleDetailMoveCellClick(position: number) {
     if (!pendingDetailMove || isMovingItem) return;
+    if (pendingDetailMove.fromPosition === position) return;
     const { entryId, itemName } = pendingDetailMove;
     setHighlightedPos(position);
     setIsMovingItem(true);

--- a/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/list-detail-client.tsx
+++ b/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/list-detail-client.tsx
@@ -4,11 +4,15 @@ import { useRef, useTransition, useOptimistic, useState, useEffect } from "react
 import { useActionSidebar } from "@/components/layout/action-sidebar-context";
 import { RegisterPageSidebarTitle, RegisterPageSidebarSubContent } from "@/components/layout/page-sidebar-context";
 import { moveToolItemListEntryByIdAction, addToolItemListEntryAtPositionAction } from "@/app/actions/tools";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { useMobileSidebar } from "@/components/layout/mobile-sidebar-context";
+import { usePersistedState } from "@/hooks/use-persisted-state";
 import { ListGridView } from "./list-grid-view";
 import { ListChecklistView } from "./list-checklist-view";
 import { AddItemToListPanel, type PickableItem } from "./add-item-to-list-panel";
 import { ItemDetailPanel } from "./item-detail-panel";
 import { ListDetailSidebarContent } from "./list-detail-sidebar-content";
+import { PlacementStatusBanner } from "./placement-status-banner";
 import type { ConversionRate } from "./item-rates-panel";
 
 // Inferred from getToolItemListDetail return type
@@ -66,6 +70,22 @@ export function ListDetailClient({
   const [hiddenRateIds, setHiddenRateIds] = useState<Set<string>>(new Set());
   const [highlightedPos, setHighlightedPos] = useState<number | undefined>(undefined);
   const [currentView, setCurrentView] = useState(view);
+  const [pendingItem, setPendingItem] = useState<PickableItem | null>(null);
+  const [isPlacingItem, setIsPlacingItem] = useState(false);
+  const [pendingDetailMove, setPendingDetailMove] = useState<{
+    entryId: string;
+    fromPosition: number;
+    itemName: string;
+  } | null>(null);
+  const [isMovingItem, setIsMovingItem] = useState(false);
+  const [addItemMode, setAddItemMode] = usePersistedState<"grid" | "manual">(
+    `item-list-add-item-mode-${orgId}-${list.id}`,
+    "grid",
+  );
+  const [, startPlacingTransition] = useTransition();
+  const [, startMoveDetailTransition] = useTransition();
+  const isMobile = useIsMobile();
+  const { setOpen: setMobileSidebarOpen } = useMobileSidebar();
 
   // Clear highlight whenever the action sidebar is closed (X button or nav)
   useEffect(() => {
@@ -100,7 +120,78 @@ export function ListDetailClient({
         .sort((a, b) => a.position - b.position || a.id.localeCompare(b.id)),
   );
 
+  function handleItemPicked(item: PickableItem) {
+    setPendingItem(item);
+    setPendingDetailMove(null);
+    if (isMobile) close();
+  }
+
+  function cancelPendingDetailMove() {
+    setPendingDetailMove(null);
+    setIsMovingItem(false);
+    setHighlightedPos(undefined);
+  }
+
+  function cancelPendingPlacement() {
+    setPendingItem(null);
+    setHighlightedPos(undefined);
+    setIsPlacingItem(false);
+    if (isMobile) {
+      openAddItemPanel();
+    }
+  }
+
+  function handlePlacementCellClick(position: number) {
+    if (!pendingItem || isPlacingItem) return;
+    const item = pendingItem;
+    setHighlightedPos(position);
+    setIsPlacingItem(true);
+    startPlacingTransition(async () => {
+      const { toast } = await import("sonner");
+      const result = await addToolItemListEntryAtPositionAction(orgId, list.id, item.id, position);
+      if (!result.ok) {
+        toast.error("error" in result ? result.error : "Failed to add item.");
+        setIsPlacingItem(false);
+        return;
+      } else {
+        toast.success(`"${item.name}" added.`);
+      }
+      setPendingItem(null);
+      setIsPlacingItem(false);
+      if (isMobile) openAddItemPanel();
+    });
+  }
+
+  function armItemDetailMove(entryId: string, fromPosition: number, itemName: string) {
+    setPendingItem(null);
+    setPendingDetailMove({ entryId, fromPosition, itemName });
+    setHighlightedPos(fromPosition);
+  }
+
+  function handleDetailMoveCellClick(position: number) {
+    if (!pendingDetailMove || isMovingItem) return;
+    const { entryId, itemName } = pendingDetailMove;
+    setHighlightedPos(position);
+    setIsMovingItem(true);
+    startMoveDetailTransition(async () => {
+      const { toast } = await import("sonner");
+      const result = await moveToolItemListEntryByIdAction(orgId, list.id, entryId, position);
+      if (!result.ok) {
+        toast.error("Failed to move item.");
+        setIsMovingItem(false);
+        return;
+      }
+      toast.success(`"${itemName}" moved.`);
+      setIsMovingItem(false);
+      setPendingDetailMove(null);
+      close();
+    });
+  }
+
   function openAddItemPanel(targetPosition?: number) {
+    setPendingItem(null);
+    setPendingDetailMove(null);
+    if (isMobile) setMobileSidebarOpen(false);
     const cols = list.gridConfig?.gridCols ?? 4;
     const rows = list.gridConfig?.gridRows ?? 4;
     const pageSize = cols * rows;
@@ -125,9 +216,11 @@ export function ListDetailClient({
         defaultRow={defaultRow}
         gridCols={cols}
         gridRows={rows}
+        onModeChange={setAddItemMode}
         onAdded={() => {}}
         onClose={() => { setHighlightedPos(undefined); close(); }}
         onPositionChange={(pos) => setHighlightedPos(pos)}
+        onItemPicked={handleItemPicked}
       />,
     );
   }
@@ -154,10 +247,9 @@ export function ListDetailClient({
   }
 
   function openItemDetailPanel(entry: { entryId: string; item: { id: string; name: string; unit: string; imageSignedUrl: string | null }; position: number; subIndex: number; totalInCell: number }) {
-    const cols = list.gridConfig?.gridCols ?? 4;
-    const rows = list.gridConfig?.gridRows ?? 4;
     const k = ++keyRef.current;
     setHighlightedPos(entry.position);
+    setPendingDetailMove(null);
     // Siblings at the same position, sorted oldest-first (by id, matching DB order)
     const siblings = optimisticEntries
       .filter((e) => e.position === entry.position)
@@ -174,12 +266,13 @@ export function ListDetailClient({
         position={entry.position}
         subIndex={entry.subIndex}
         totalInCell={entry.totalInCell}
-        gridCols={cols}
-        gridRows={rows}
+        gridCols={list.gridConfig?.gridCols ?? 4}
+        gridRows={list.gridConfig?.gridRows ?? 4}
         canManage={!!canManage}
         rates={activeSetRates}
         setName={activeSetName}
         hiddenRateIds={hiddenRateIds}
+        onSelectCell={() => armItemDetailMove(entry.entryId, entry.position, entry.item.name)}
         onToggleRate={(rateId) =>
           setHiddenRateIds((prev) => {
             const next = new Set(prev);
@@ -200,7 +293,7 @@ export function ListDetailClient({
             totalInCell: siblings.length,
           });
         }}
-        onClose={() => { setHighlightedPos(undefined); close(); }}
+        onClose={() => { cancelPendingDetailMove(); close(); }}
       />,
     );
   }
@@ -240,26 +333,57 @@ export function ListDetailClient({
     <>
       <RegisterPageSidebarTitle title={list.name} />
       <RegisterPageSidebarSubContent content={sidebarContent} />
+      {pendingItem && (
+        <PlacementStatusBanner
+          title="Select a blue cell"
+          itemName={pendingItem.name}
+          message="Tap any blue cell to place the item."
+          onCancel={cancelPendingPlacement}
+        />
+      )}
+      {pendingDetailMove && (
+        <PlacementStatusBanner
+          title="Select a blue cell"
+          itemName={pendingDetailMove.itemName}
+          message="Tap any blue cell to place the item."
+          onCancel={cancelPendingDetailMove}
+        />
+      )}
       <ListGridView
         orgId={orgId}
         listId={list.id}
         list={{ ...list, entries: optimisticEntries }}
         canManage={canManage}
-        onCellClick={canManage ? openAddItemPanel : undefined}
-        onMoveEntry={canManage ? handleMoveEntry : undefined}
-        onDropNewItem={canManage ? handleDropNewItem : undefined}
+        onCellClick={
+          canManage
+            ? (pendingItem
+                ? handlePlacementCellClick
+                : pendingDetailMove
+                  ? handleDetailMoveCellClick
+                  : activeTitle === "Add Item" && addItemMode === "manual"
+                  ? openAddItemPanel
+                  : undefined)
+            : undefined
+        }
+        onMoveEntry={!pendingItem && canManage ? handleMoveEntry : undefined}
+        onDropNewItem={!pendingItem && canManage ? handleDropNewItem : undefined}
         activeSetRates={activeSetRates}
         hiddenRateIds={hiddenRateIds}
         showRates={showRates}
         highlightedPosition={highlightedPos}
+        placementMode={!!pendingItem || !!pendingDetailMove}
         onItemClick={
-          activeTitle === "Add Item"
-            ? (entry) => openAddItemPanel(entry.position)
-            : canManage || activeSetId
-              ? openItemDetailPanel
-              : undefined
+          pendingItem
+            ? undefined
+            : activeTitle === "Add Item"
+              ? addItemMode === "manual"
+                ? (entry) => openAddItemPanel(entry.position)
+                : (entry) => openItemDetailPanel(entry)
+              : canManage || activeSetId
+                ? openItemDetailPanel
+                : undefined
         }
-        onSubIndexChange={activeTitle !== null && activeTitle !== "Add Item" ? openItemDetailPanel : undefined}
+        onSubIndexChange={!pendingItem && activeTitle !== null && activeTitle !== "Add Item" ? openItemDetailPanel : undefined}
       />
     </>
   );

--- a/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/list-grid-view.tsx
+++ b/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/list-grid-view.tsx
@@ -40,6 +40,8 @@ interface ListGridViewProps {
   onItemClick?: (entry: { entryId: string; item: { id: string; name: string; unit: string; imageSignedUrl: string | null }; position: number; subIndex: number; totalInCell: number }) => void;
   /** Called when prev/next arrows cycle through stacked items in a cell, so parent can update the open sidebar. */
   onSubIndexChange?: (entry: { entryId: string; item: { id: string; name: string; unit: string; imageSignedUrl: string | null }; position: number; subIndex: number; totalInCell: number }) => void;
+  /** When true, all cells (including occupied) fire onCellClick — used for pending item placement. */
+  placementMode?: boolean;
 }
 
 export function ListGridView({
@@ -57,6 +59,7 @@ export function ListGridView({
   highlightedPosition,
   onItemClick,
   onSubIndexChange,
+  placementMode,
 }: ListGridViewProps) {
   const supportsHover = useSupportsHover();
   const cols = list.gridConfig?.gridCols ?? 4;
@@ -219,7 +222,7 @@ export function ListGridView({
           return (
             <div
               key={absPos}
-              draggable={!!entry && !!canManage && !isEditingThisAmount}
+              draggable={!!entry && !!canManage && !isEditingThisAmount && !placementMode}
               onDragStart={
                 entry && !isEditingThisAmount
                   ? () => setDragFromPos(absPos)
@@ -269,6 +272,10 @@ export function ListGridView({
               }}
               onClick={() => {
                 if (isEditingThisAmount) return;
+                if (placementMode) {
+                  onCellClick?.(absPos);
+                  return;
+                }
                 if (!entry && canManage) {
                   onCellClick?.(absPos);
                 } else if (entry && onItemClick) {
@@ -278,7 +285,14 @@ export function ListGridView({
               style={{ aspectRatio: "1 / 1" }}
               className={cn(
                 "relative group @container/cell rounded-lg border flex flex-col overflow-hidden transition-all select-none",
-                entry
+                placementMode
+                  ? [
+                      "cursor-pointer",
+                      entry
+                        ? "bg-sky-50/70 border-sky-200/70 hover:bg-sky-100/80 hover:ring-2 hover:ring-sky-500/60 hover:ring-offset-1"
+                        : "bg-sky-50/60 border-sky-200/70 hover:bg-sky-100/90 hover:ring-2 hover:ring-sky-500/70 hover:ring-offset-1",
+                    ]
+                  : entry
                   ? [
                       "bg-card",
                       canManage && !isEditingThisAmount && "cursor-grab active:cursor-grabbing",
@@ -290,7 +304,7 @@ export function ListGridView({
                     ],
                 isDragSource && "opacity-40 scale-95",
                 externalDragTargetPos === absPos && "ring-2 ring-green-500 ring-offset-1 bg-green-500/5",
-                highlightedPosition === absPos && !isDragTarget && !isDragSource && "ring-2 ring-primary ring-offset-1 bg-primary/10 border-primary/40",
+                highlightedPosition === absPos && !isDragTarget && !isDragSource && "ring-2 ring-sky-500 ring-offset-1 bg-sky-100/80 border-sky-400",
               )}
             >
               {entry ? (

--- a/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/placement-status-banner.tsx
+++ b/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/placement-status-banner.tsx
@@ -25,6 +25,7 @@ export function PlacementStatusBanner({ title, itemName, message, onCancel }: Pl
       </div>
       <div className="mt-2 flex justify-end">
         <button
+          type="button"
           onClick={onCancel}
           className="inline-flex items-center gap-1 rounded-md border border-primary/20 bg-background/60 px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-background"
           aria-label="Cancel placement"

--- a/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/placement-status-banner.tsx
+++ b/app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/placement-status-banner.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { X } from "lucide-react";
+
+interface PlacementStatusBannerProps {
+  title: string;
+  itemName: string;
+  message: string;
+  onCancel: () => void;
+}
+
+export function PlacementStatusBanner({ title, itemName, message, onCancel }: PlacementStatusBannerProps) {
+  return (
+    <div className="mb-2 rounded-lg border border-primary/20 bg-primary/10 px-3 py-2 text-sm text-primary shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-2">
+          <div className="mt-0.5 h-3.5 w-3.5 rounded-full border-2 border-primary/30 border-t-primary animate-spin" />
+          <div className="min-w-0">
+            <div className="truncate font-medium">
+              {title} &ldquo;{itemName}&rdquo;
+            </div>
+            <div className="mt-0.5 text-xs text-primary/75">{message}</div>
+          </div>
+        </div>
+      </div>
+      <div className="mt-2 flex justify-end">
+        <button
+          onClick={onCancel}
+          className="inline-flex items-center gap-1 rounded-md border border-primary/20 bg-background/60 px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-background"
+          aria-label="Cancel placement"
+        >
+          <X className="h-3.5 w-3.5" />
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/docs/item-list-ui-change-log.md
+++ b/docs/item-list-ui-change-log.md
@@ -1,0 +1,49 @@
+# Item List UI Change Log
+
+This file documents the item-list refactor files currently changed in the workspace and what each one now does.
+
+## Changed Files
+
+### `app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/add-item-to-list-panel.tsx`
+- Keeps the add-item flow split into grid selection and manual entry.
+- Uses the persisted mode preference so the last selected mode is remembered.
+- In grid mode, selecting an item arms placement rather than immediately moving it.
+- In manual mode, the user can still enter a position directly and add the item immediately.
+
+### `app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/item-detail-panel.tsx`
+- Shows item details, quantity editing, and position editing in a flatter layout.
+- Uses a shared blue action button for the position actions.
+- Supports both grid selection and manual page/column/row input for moving the item.
+- Keeps the move UI visually aligned with the add-item flow.
+
+### `app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/list-detail-client.tsx`
+- Coordinates the add-item and item-move armed states.
+- Shows the shared placement banner while the user is selecting a cell.
+- Routes page-grid clicks to either add-item placement or item-detail relocation.
+- Keeps the highlighted grid cell in sync with the currently armed action.
+
+### `app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/list-grid-view.tsx`
+- Highlights the grid blue while placement mode is active.
+- Makes every cell feel selectable during add-item or move selection.
+- Preserves existing drag/drop, highlighting, and stack navigation behavior outside placement mode.
+
+### `app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/blue-action-button.tsx`
+- Shared blue CTA component for the item-list detail UI.
+- Keeps the original brand color while giving the action buttons a more polished treatment.
+- Used for the item-detail panel's select and move actions.
+
+### `app/(app)/orgs/[orgId]/tools/item-list/lists/[listId]/_components/placement-status-banner.tsx`
+- Shared placement banner for both add-item and item-select states.
+- Shows the active item name and a short instruction message.
+- Provides the cancel action in a consistent layout.
+
+### `hooks/use-persisted-state.ts`
+- Persists mode state in localStorage.
+- Broadcasts same-tab updates so sidebar and panel state stays in sync immediately.
+- Skips redundant writes to avoid echo loops and update-depth issues.
+
+## Notes
+
+- The shared visual pieces are now split into two reusable components: a blue CTA button and a placement banner.
+- The grid itself still owns the blue selectable-cell styling, while the parent controller owns the selection state and routing logic.
+- The add-item and item-move flows are intentionally aligned so they read as the same interaction pattern.

--- a/hooks/use-persisted-state.ts
+++ b/hooks/use-persisted-state.ts
@@ -20,19 +20,35 @@ export function usePersistedState<T>(
   // first render because the read effect hasn't restored the stored value yet,
   // so writing would overwrite localStorage with the blank initialValue.
   const canWrite = useRef(false);
+  const lastSerializedRef = useRef<string | null>(null);
 
   // Read from localStorage after mount (client-side only)
   useEffect(() => {
     if (typeof window === "undefined") return;
-    try {
-      const raw = localStorage.getItem(key);
-      if (raw !== null) {
-        setState(JSON.parse(raw) as T);
+    const eventName = `persisted-state-change:${key}`;
+
+    const syncFromStorage = () => {
+      try {
+        const raw = localStorage.getItem(key);
+        if (raw !== null) {
+          lastSerializedRef.current = raw;
+          setState(JSON.parse(raw) as T);
+        }
+      } catch {
+        // Ignore parse errors
       }
+    };
+
+    const onCustomChange = () => syncFromStorage();
+
+    window.addEventListener(eventName, onCustomChange as EventListener);
+    try {
+      syncFromStorage();
     } catch {
       // Ignore parse errors
     }
     setHydrated(true);
+    return () => window.removeEventListener(eventName, onCustomChange as EventListener);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Run once after mount
 
@@ -44,8 +60,12 @@ export function usePersistedState<T>(
       return;
     }
     if (typeof window === "undefined") return;
+    const serialized = JSON.stringify(state);
+    if (lastSerializedRef.current === serialized) return;
     try {
-      localStorage.setItem(key, JSON.stringify(state));
+      localStorage.setItem(key, serialized);
+      lastSerializedRef.current = serialized;
+      window.dispatchEvent(new CustomEvent(`persisted-state-change:${key}`));
     } catch {
       // Ignore quota exceeded / private browsing errors
     }

--- a/hooks/use-persisted-state.ts
+++ b/hooks/use-persisted-state.ts
@@ -41,14 +41,22 @@ export function usePersistedState<T>(
 
     const onCustomChange = () => syncFromStorage();
 
+    const onStorageChange = (event: StorageEvent) => {
+      if (event.key === key) syncFromStorage();
+    };
+
     window.addEventListener(eventName, onCustomChange as EventListener);
+    window.addEventListener("storage", onStorageChange as EventListener);
     try {
       syncFromStorage();
     } catch {
       // Ignore parse errors
     }
     setHydrated(true);
-    return () => window.removeEventListener(eventName, onCustomChange as EventListener);
+    return () => {
+      window.removeEventListener(eventName, onCustomChange as EventListener);
+      window.removeEventListener("storage", onStorageChange as EventListener);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Run once after mount
 


### PR DESCRIPTION
## What Changed

Unified the item-list add and move flows around a shared placement state. The detail panel now uses reusable blue CTA styling, the placement banner is shared, the grid highlights more clearly in placement mode, and persisted state sync is kept stable.

## Why

This makes it much clearer when the user is selecting a grid cell to place or move an item, and keeps the add-item and item-detail experiences visually consistent.

Closes #

## Type

- [ ] 🐛 Bug fix
- [x] ✨ Enhancement / Feature
- [x] 🔧 Refactor
- [x] 📝 Documentation
- [x] 🎨 UI / Styling

## How to Test

1. Open an item list and start add-item placement.
2. Open an item detail panel and press Select Cell.
3. Confirm the banner, blue grid highlight, and manual position inputs behave as expected.
4. Verify persisted mode state still restores correctly.

## Screenshots / Recordings

<!-- Before & after if UI changed -->

## Checklist

- [ ] Tested on desktop (Chrome)
- [ ] Tested on mobile (iPhone Safari)
- [x] No lint errors (`pnpm lint`)
- [x] Build passes (`pnpm build`)
- [x] Smoke test updated (if applicable)

## Smoke Test Issues Resolved

- [ ] #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grid/manual mode toggle for adding items, persisted per list
  * Option to pick items in grid mode (parent receives selection) or place manually via page/col/row
  * Visual placement/move flow with cancellable status banner and mobile-aware placement controls
  * New reusable blue action button and refined cell selection/placement styling

* **Documentation**
  * Added item-list UI refactor changelog detailing the new flows and components
<!-- end of auto-generated comment: release notes by coderabbit.ai -->