### PR TITLE
Refactor admin growth chart and navigation

### DIFF
--- a/app/admin/_components/admin-growth-chart.tsx
+++ b/app/admin/_components/admin-growth-chart.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+type GrowthPoint = {
+  key: string;
+  label: string;
+  total: number;
+  demo: number;
+};
+
+type AdminGrowthChartProps = {
+  points: GrowthPoint[];
+  maxValue: number;
+  totalPath: string;
+  demoPath: string;
+  yTicks: number[];
+  xLabelIndexes: number[];
+  xAxisLabel: string;
+};
+
+export function AdminGrowthChart({
+  points,
+  maxValue,
+  totalPath,
+  demoPath,
+  yTicks,
+  xLabelIndexes,
+  xAxisLabel,
+}: AdminGrowthChartProps) {
+  const hasData = points.length > 0;
+
+  return (
+    <div className="rounded-2xl border border-border/70 bg-linear-to-b from-primary/6 via-background to-background p-3 sm:p-4">
+      <div className="grid grid-cols-[3rem_minmax(0,1fr)] gap-3 sm:grid-cols-[3.5rem_minmax(0,1fr)]">
+        <div className="relative h-64 text-[10px] font-medium text-muted-foreground">
+          {yTicks.map((tick, index) => {
+            const top = yTicks.length === 1 ? 50 : (index / (yTicks.length - 1)) * 100;
+            return (
+              <span
+                key={tick}
+                className="absolute right-0 -translate-y-1/2 pr-1 text-right tabular-nums"
+                style={{ top: `${100 - top}%` }}
+              >
+                {tick}
+              </span>
+            );
+          })}
+          <span className="absolute bottom-0 right-0 pr-1 text-right uppercase tracking-[0.16em] text-[9px] text-muted-foreground/80">
+            Signups
+          </span>
+        </div>
+
+        <div className="relative h-64 overflow-hidden rounded-xl border border-border/60 bg-background/80">
+          <svg viewBox="0 0 100 40" className="h-full w-full overflow-visible">
+            <defs>
+              <linearGradient id="admin-growth-fill" x1="0" x2="0" y1="0" y2="1">
+                <stop offset="0%" stopColor="rgb(59 130 246)" stopOpacity="0.30" />
+                <stop offset="100%" stopColor="rgb(59 130 246)" stopOpacity="0.03" />
+              </linearGradient>
+              <linearGradient id="admin-growth-demo-fill" x1="0" x2="0" y1="0" y2="1">
+                <stop offset="0%" stopColor="rgb(245 158 11)" stopOpacity="0.18" />
+                <stop offset="100%" stopColor="rgb(245 158 11)" stopOpacity="0.01" />
+              </linearGradient>
+            </defs>
+            {yTicks.map((tick) => {
+              const y = 34 - (tick / maxValue) * 28;
+              return (
+                <line
+                  key={tick}
+                  x1="0"
+                  x2="100"
+                  y1={y}
+                  y2={y}
+                  stroke="currentColor"
+                  strokeOpacity="0.08"
+                  strokeDasharray="1.5 2.5"
+                />
+              );
+            })}
+            {totalPath && <path d={`${totalPath} L 100 34 L 0 34 Z`} fill="url(#admin-growth-fill)" />}
+            {demoPath && <path d={`${demoPath} L 100 34 L 0 34 Z`} fill="url(#admin-growth-demo-fill)" />}
+            {totalPath && (
+              <path
+                d={totalPath}
+                fill="none"
+                stroke="rgb(59 130 246)"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            )}
+            {demoPath && (
+              <path
+                d={demoPath}
+                fill="none"
+                stroke="rgb(245 158 11)"
+                strokeWidth="1.7"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeDasharray="3 2"
+              />
+            )}
+            {hasData &&
+              points.map((point, index) => {
+                const x = points.length === 1 ? 50 : (index / (points.length - 1)) * 100;
+                const totalY = 34 - (point.total / maxValue) * 28;
+                const demoY = 34 - (point.demo / maxValue) * 28;
+                return (
+                  <g key={point.key}>
+                    <circle
+                      cx={x}
+                      cy={totalY}
+                      r="1.6"
+                      fill="rgb(59 130 246)"
+                      stroke="white"
+                      strokeWidth="0.6"
+                      opacity={point.total > 0 ? 1 : 0.15}
+                    />
+                    {point.demo > 0 && (
+                      <circle
+                        cx={x}
+                        cy={demoY}
+                        r="1.3"
+                        fill="rgb(245 158 11)"
+                        stroke="white"
+                        strokeWidth="0.6"
+                        opacity={1}
+                      />
+                    )}
+                  </g>
+                );
+              })}
+          </svg>
+        </div>
+      </div>
+
+      <div className="mt-2 grid grid-cols-[3rem_minmax(0,1fr)] gap-3 sm:grid-cols-[3.5rem_minmax(0,1fr)]">
+        <div />
+        <div className="space-y-1">
+          <div className="flex items-center justify-between text-[10px] uppercase tracking-[0.16em] text-muted-foreground/80 sm:text-[11px]">
+            <span>{xAxisLabel}</span>
+            <span className="hidden sm:inline">Selected range</span>
+          </div>
+          <div className="flex gap-2 text-[10px] leading-tight text-muted-foreground sm:text-xs">
+          {points.map((point, index) => (
+            <div key={point.key} className="min-w-0 flex-1 text-center">
+              {xLabelIndexes.includes(index) ? (
+                <span className="block truncate">{point.label}</span>
+              ) : (
+                <span className="block opacity-0">.</span>
+              )}
+            </div>
+          ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/_components/admin-nav-tabs.tsx
+++ b/app/admin/_components/admin-nav-tabs.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { ImageIcon, MessageSquareMore, LayoutDashboard } from "lucide-react";
+
+const NAV_ITEMS = [
+  {
+    href: "/admin",
+    label: "Overview",
+    icon: LayoutDashboard,
+    exact: true,
+  },
+  {
+    href: "/admin/feedback",
+    label: "Feedback",
+    icon: MessageSquareMore,
+  },
+  {
+    href: "/admin/photos",
+    label: "Photos",
+    icon: ImageIcon,
+  },
+] as const;
+
+export function AdminNavTabs() {
+  const pathname = usePathname();
+
+  return (
+    <div className="flex flex-col gap-2">
+      {NAV_ITEMS.map((item) => {
+        const isActive = item.exact
+          ? pathname === item.href
+          : pathname === item.href || pathname.startsWith(`${item.href}/`);
+        const Icon = item.icon;
+
+        return (
+          <Button
+            key={item.href}
+            variant={isActive ? "default" : "outline"}
+            asChild
+            className={cn(
+              "justify-start gap-2.5 rounded-xl",
+              isActive && "shadow-sm",
+            )}
+            aria-current={isActive ? "page" : undefined}
+          >
+            <Link href={item.href}>
+              <Icon className="h-4 w-4" />
+              {item.label}
+            </Link>
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/admin/_components/admin-nav-tabs.tsx
+++ b/app/admin/_components/admin-nav-tabs.tsx
@@ -31,7 +31,7 @@ export function AdminNavTabs() {
   return (
     <div className="flex flex-col gap-2">
       {NAV_ITEMS.map((item) => {
-        const isActive = item.exact
+        const isActive = item.exact?
           ? pathname === item.href
           : pathname === item.href || pathname.startsWith(`${item.href}/`);
         const Icon = item.icon;

--- a/app/admin/_components/admin-user-growth-card.tsx
+++ b/app/admin/_components/admin-user-growth-card.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { CalendarRange, LineChart, Users, UserRound } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { AdminGrowthChart } from "./admin-growth-chart";
+
+export type UserGrowthRecord = {
+  createdAt: string;
+  isDemo: boolean;
+};
+
+type RangeKey = "day" | "7d" | "month" | "6m" | "year" | "lifetime";
+type Granularity = "hour" | "day" | "month";
+
+type Bucket = {
+  key: string;
+  label: string;
+  total: number;
+  demo: number;
+};
+
+const RANGE_OPTIONS: Array<{ key: RangeKey; label: string }> = [
+  { key: "day", label: "Last day" },
+  { key: "7d", label: "7 days" },
+  { key: "month", label: "Month" },
+  { key: "6m", label: "6 months" },
+  { key: "year", label: "Year" },
+  { key: "lifetime", label: "Lifetime" },
+];
+
+function startOfDay(date: Date) {
+  const next = new Date(date);
+  next.setHours(0, 0, 0, 0);
+  return next;
+}
+
+function startOfHour(date: Date) {
+  const next = new Date(date);
+  next.setMinutes(0, 0, 0);
+  return next;
+}
+
+function startOfMonth(date: Date) {
+  const next = new Date(date);
+  next.setDate(1);
+  next.setHours(0, 0, 0, 0);
+  return next;
+}
+
+function addHours(date: Date, hours: number) {
+  const next = new Date(date);
+  next.setHours(next.getHours() + hours);
+  return next;
+}
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function addMonths(date: Date, months: number) {
+  const next = new Date(date);
+  next.setMonth(next.getMonth() + months);
+  return next;
+}
+
+function bucketKey(date: Date, granularity: Granularity) {
+  if (granularity === "hour") {
+    return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}-${date.getHours()}`;
+  }
+  if (granularity === "day") {
+    return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+  }
+  return `${date.getFullYear()}-${date.getMonth()}`;
+}
+
+function formatHourLabel(date: Date) {
+  return date.toLocaleTimeString("en-AU", { hour: "numeric" }).replace(/^0/, "");
+}
+
+function formatDayLabel(date: Date) {
+  return date.toLocaleDateString("en-AU", {
+    weekday: "short",
+    day: "numeric",
+  });
+}
+
+function formatMonthLabel(date: Date, long = false) {
+  return date.toLocaleDateString("en-AU", {
+    month: "short",
+    year: long ? "numeric" : undefined,
+  });
+}
+
+function getRangeConfig(records: UserGrowthRecord[], range: RangeKey) {
+  const now = new Date();
+  let granularity: Granularity;
+  let buckets: Bucket[] = [];
+
+  if (range === "day") {
+    granularity = "hour";
+    const start = startOfHour(addHours(now, -23));
+    buckets = Array.from({ length: 24 }, (_, index) => {
+      const bucketStart = addHours(start, index);
+      return {
+        key: bucketKey(bucketStart, granularity),
+        label: formatHourLabel(bucketStart),
+        total: 0,
+        demo: 0,
+      };
+    });
+  } else if (range === "7d") {
+    granularity = "day";
+    const start = startOfDay(addDays(now, -6));
+    buckets = Array.from({ length: 7 }, (_, index) => {
+      const bucketStart = addDays(start, index);
+      return {
+        key: bucketKey(bucketStart, granularity),
+        label: formatDayLabel(bucketStart),
+        total: 0,
+        demo: 0,
+      };
+    });
+  } else if (range === "month") {
+    granularity = "day";
+    const start = startOfDay(addDays(now, -29));
+    buckets = Array.from({ length: 30 }, (_, index) => {
+      const bucketStart = addDays(start, index);
+      return {
+        key: bucketKey(bucketStart, granularity),
+        label: formatDayLabel(bucketStart),
+        total: 0,
+        demo: 0,
+      };
+    });
+  } else if (range === "6m") {
+    granularity = "month";
+    const start = startOfMonth(addMonths(now, -5));
+    buckets = Array.from({ length: 6 }, (_, index) => {
+      const bucketStart = addMonths(start, index);
+      return {
+        key: bucketKey(bucketStart, granularity),
+        label: formatMonthLabel(bucketStart),
+        total: 0,
+        demo: 0,
+      };
+    });
+  } else if (range === "year") {
+    granularity = "month";
+    const start = startOfMonth(addMonths(now, -11));
+    buckets = Array.from({ length: 12 }, (_, index) => {
+      const bucketStart = addMonths(start, index);
+      return {
+        key: bucketKey(bucketStart, granularity),
+        label: formatMonthLabel(bucketStart),
+        total: 0,
+        demo: 0,
+      };
+    });
+  } else {
+    granularity = "month";
+    const firstRecord = records[0];
+    const start = firstRecord ? startOfMonth(new Date(firstRecord.createdAt)) : startOfMonth(now);
+    const current = startOfMonth(now);
+    const cursor = new Date(start);
+
+    while (cursor <= current) {
+      buckets.push({
+        key: bucketKey(cursor, granularity),
+        label: formatMonthLabel(cursor, false),
+        total: 0,
+        demo: 0,
+      });
+      cursor.setMonth(cursor.getMonth() + 1);
+    }
+  }
+
+  const bucketIndex = new Map<string, number>();
+  buckets.forEach((bucket, index) => bucketIndex.set(bucket.key, index));
+
+  for (const record of records) {
+    const createdAt = new Date(record.createdAt);
+    const key = bucketKey(createdAt, granularity);
+    const bucket = bucketIndex.get(key);
+    if (bucket === undefined) continue;
+    buckets[bucket].total += 1;
+    if (record.isDemo) buckets[bucket].demo += 1;
+  }
+
+  return buckets;
+}
+
+// Computes a nice y-axis ceiling and evenly-spaced tick values.
+function computeYScale(dataMax: number): { scale: number; ticks: number[] } {
+  if (dataMax === 0) return { scale: 5, ticks: [0, 1, 2, 3, 4, 5] };
+  if (dataMax <= 5) {
+    return { scale: dataMax, ticks: Array.from({ length: dataMax + 1 }, (_, i) => i) };
+  }
+  const rawStep = dataMax / 4;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(rawStep)));
+  let step = magnitude;
+  const norm = rawStep / magnitude;
+  if (norm > 5) step = 10 * magnitude;
+  else if (norm > 2) step = 5 * magnitude;
+  else if (norm > 1) step = 2 * magnitude;
+  const scale = Math.ceil(dataMax / step) * step;
+  const ticks: number[] = [];
+  for (let v = 0; v <= scale; v += step) ticks.push(v);
+  return { scale, ticks };
+}
+
+// Returns which bucket indexes should show an x-axis label, tuned per range.
+function getXLabelIndexes(range: RangeKey, pointCount: number): number[] {
+  if (pointCount === 0) return [];
+  const all = Array.from({ length: pointCount }, (_, i) => i);
+  switch (range) {
+    case "day":
+      // 24 hour buckets — label every 4 hours
+      return all.filter((i) => i % 4 === 0 || i === pointCount - 1);
+    case "7d":
+      // 7 day buckets — label all
+      return all;
+    case "month":
+      // 30 day buckets — label every 7 days
+      return all.filter((i) => i % 7 === 0 || i === pointCount - 1);
+    case "6m":
+    case "year":
+      // 6 or 12 month buckets — label all
+      return all;
+    default: {
+      // lifetime — cap at ~8 labels
+      if (pointCount <= 8) return all;
+      const step = Math.ceil(pointCount / 7);
+      return all.filter((i) => i % step === 0 || i === pointCount - 1);
+    }
+  }
+}
+
+// Uses the shared chart scale so lines, grid lines, and dots all align.
+function linePath(points: Bucket[], selector: "total" | "demo", scale: number) {
+  if (points.length === 0) return "";
+  const step = points.length > 1 ? 100 / (points.length - 1) : 0;
+  return points
+    .map((point, index) => {
+      const x = points.length === 1 ? 50 : index * step;
+      const y = 34 - (point[selector] / scale) * 28;
+      return `${index === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`;
+    })
+    .join(" ");
+}
+
+export function AdminUserGrowthCard({ records }: { records: UserGrowthRecord[] }) {
+  const [range, setRange] = useState<RangeKey>("month");
+
+  const points = useMemo(() => getRangeConfig(records, range), [records, range]);
+  const selectedTotals = useMemo(
+    () =>
+      points.reduce(
+        (acc, point) => {
+          acc.total += point.total;
+          acc.demo += point.demo;
+          return acc;
+        },
+        { total: 0, demo: 0 },
+      ),
+    [points],
+  );
+
+  const dataMax = Math.max(0, ...points.map((point) => Math.max(point.total, point.demo)));
+  const { scale: chartScale, ticks: yTicks } = useMemo(() => computeYScale(dataMax), [dataMax]);
+  const totalPath = useMemo(() => linePath(points, "total", chartScale), [points, chartScale]);
+  const demoPath = useMemo(() => linePath(points, "demo", chartScale), [points, chartScale]);
+  const activeBuckets = points.filter((point) => point.total > 0);
+  const peakBucket = activeBuckets.reduce<Bucket | null>((peak, point) => {
+    if (!peak) return point;
+    return point.total > peak.total ? point : peak;
+  }, null);
+  const totalSeries = points.map((point) => point.total);
+  const lastTotal = totalSeries[totalSeries.length - 1] ?? 0;
+  const previousTotal = totalSeries.length > 1 ? totalSeries[totalSeries.length - 2] ?? 0 : 0;
+  const delta = lastTotal - previousTotal;
+  const deltaLabel = delta === 0 ? "Flat" : delta > 0 ? `+${delta}` : `${delta}`;
+  const xAxisLabel = range === "day" ? "Hours" : range === "7d" || range === "month" ? "Days" : "Months";
+  const xLabelIndexes = useMemo(() => getXLabelIndexes(range, points.length), [range, points.length]);
+
+  return (
+    <Card className="overflow-hidden border-border/70 bg-card/90 shadow-sm backdrop-blur-xl">
+      <CardHeader className="gap-3 border-b border-border/60 bg-muted/30">
+        <div className="inline-flex w-fit items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-primary">
+          <LineChart className="h-3.5 w-3.5" />
+          User growth
+        </div>
+        <CardTitle className="text-2xl sm:text-3xl">New users over time</CardTitle>
+        <CardDescription className="max-w-3xl text-sm sm:text-base">
+          Based on account creation dates. Demo accounts are counted separately using the demo email suffix because IP addresses are not stored in the schema.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-5 p-4 sm:p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-wrap gap-2">
+            {RANGE_OPTIONS.map((option) => (
+              <Button
+                key={option.key}
+                size="sm"
+                variant={range === option.key ? "default" : "outline"}
+                onClick={() => setRange(option.key)}
+                className="rounded-full"
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-background/80 px-2.5 py-1">
+              <span className="h-2 w-2 rounded-full bg-primary" />
+              Peak {peakBucket?.total ?? 0}
+            </span>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-background/80 px-2.5 py-1">
+              <span className="h-2 w-2 rounded-full bg-amber-500" />
+              Latest {deltaLabel}
+            </span>
+          </div>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="rounded-2xl border border-border/70 bg-background/80 p-4 shadow-sm">
+            <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              <Users className="h-3.5 w-3.5" />
+              New users
+            </div>
+            <p className="mt-3 text-3xl font-semibold tracking-tight">{selectedTotals.total}</p>
+            <p className="mt-1 text-sm text-muted-foreground">Joined in the selected range.</p>
+          </div>
+
+          <div className="rounded-2xl border border-border/70 bg-background/80 p-4 shadow-sm">
+            <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              <UserRound className="h-3.5 w-3.5" />
+              Demo users
+            </div>
+            <p className="mt-3 text-3xl font-semibold tracking-tight">{selectedTotals.demo}</p>
+            <p className="mt-1 text-sm text-muted-foreground">Demo signups in the selected range.</p>
+          </div>
+
+          <div className="rounded-2xl border border-border/70 bg-background/80 p-4 shadow-sm">
+            <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              <CalendarRange className="h-3.5 w-3.5" />
+              Lifetime total
+            </div>
+            <p className="mt-3 text-3xl font-semibold tracking-tight">{records.length}</p>
+            <p className="mt-1 text-sm text-muted-foreground">All created user accounts.</p>
+          </div>
+        </div>
+
+        <div className="rounded-3xl border border-border/70 bg-background/90 p-4 shadow-sm">
+          {points.length === 0 ? (
+            <div className="flex min-h-56 items-center justify-center rounded-2xl border border-dashed border-border/70 text-sm text-muted-foreground">
+              No user signups yet.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="grid gap-2 sm:grid-cols-[1fr_auto] sm:items-center">
+                <div>
+                  <p className="text-sm font-medium text-foreground">Signup trend</p>
+                  <p className="text-xs text-muted-foreground">
+                    Left to right is the selected date range. Blue is total signups, amber is demo signups.
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="h-2.5 w-2.5 rounded-full bg-primary" />
+                    New users
+                  </span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="h-2.5 w-2.5 rounded-full bg-amber-500" />
+                    Demo users
+                  </span>
+                </div>
+              </div>
+
+              <AdminGrowthChart
+                points={points}
+                maxValue={chartScale}
+                totalPath={totalPath}
+                demoPath={demoPath}
+                yTicks={yTicks}
+                xLabelIndexes={xLabelIndexes}
+                xAxisLabel={xAxisLabel}
+              />
+
+              <div className="grid gap-2 sm:grid-cols-3">
+                <div className="rounded-2xl border border-border/70 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                  <p className="font-medium text-foreground">Active buckets</p>
+                  <p className="mt-1">{activeBuckets.length} with at least one signup.</p>
+                </div>
+                <div className="rounded-2xl border border-border/70 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                  <p className="font-medium text-foreground">Highest bucket</p>
+                  <p className="mt-1">{peakBucket ? `${peakBucket.label} · ${peakBucket.total}` : "No signups"}</p>
+                </div>
+                <div className="rounded-2xl border border-border/70 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                  <p className="font-medium text-foreground">Demo share</p>
+                  <p className="mt-1">{records.length > 0 ? `${Math.round((selectedTotals.demo / records.length) * 100)}%` : "0%"}</p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/admin/_components/admin-user-growth-card.tsx
+++ b/app/admin/_components/admin-user-growth-card.tsx
@@ -403,7 +403,7 @@ export function AdminUserGrowthCard({ records }: { records: UserGrowthRecord[] }
                 </div>
                 <div className="rounded-2xl border border-border/70 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
                   <p className="font-medium text-foreground">Demo share</p>
-                  <p className="mt-1">{records.length > 0 ? `${Math.round((selectedTotals.demo / records.length) * 100)}%` : "0%"}</p>
+                  <p className="mt-1">{selectedTotals.total > 0 ? `${Math.round((selectedTotals.demo / selectedTotals.total) * 100)}%` : "0%"}</p>
                 </div>
               </div>
             </div>

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
-import { ArrowLeft, ImageIcon, Shield, MessageSquareMore, PanelLeft } from "lucide-react";
+import { ArrowLeft, Shield, MessageSquareMore, PanelLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { AdminNavTabs } from "./_components/admin-nav-tabs";
 
 export default function AdminLayout({
   children,
@@ -9,8 +10,8 @@ export default function AdminLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-full bg-linear-to-br from-violet-500/10 via-background to-sky-500/10">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
+    <div className="h-dvh overflow-hidden bg-linear-to-br from-violet-500/10 via-background to-sky-500/10">
+      <div className="mx-auto flex h-full w-full max-w-7xl flex-col gap-6 overflow-y-auto overflow-x-hidden px-4 py-6 sm:px-6 lg:px-8">
         <header className="rounded-3xl border border-border/70 bg-card/90 p-4 shadow-sm backdrop-blur-xl sm:p-5">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-stretch lg:gap-5">
             <div className="flex flex-1 items-center gap-3">
@@ -60,19 +61,8 @@ export default function AdminLayout({
                   Jump between the admin overview, feedback, and photos.
                 </CardDescription>
               </CardHeader>
-              <CardContent className="flex flex-col gap-2">
-                <Button variant="outline" asChild className="justify-start">
-                  <Link href="/admin">Overview</Link>
-                </Button>
-                <Button variant="outline" asChild className="justify-start">
-                  <Link href="/admin/feedback">Feedback</Link>
-                </Button>
-                <Button variant="outline" asChild className="justify-start">
-                  <Link href="/admin/photos">
-                    <ImageIcon className="h-4 w-4" />
-                    Photos
-                  </Link>
-                </Button>
+              <CardContent>
+                <AdminNavTabs />
               </CardContent>
             </Card>
 
@@ -87,7 +77,9 @@ export default function AdminLayout({
             </Card>
           </aside>
 
-          <main>{children}</main>
+          <main className="pb-2">
+            {children}
+          </main>
         </div>
       </div>
     </div>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { FeedbackType } from "@prisma/client";
 import { ArrowRight, CheckCheck, ImageIcon, Lightbulb, MessageSquareWarning, ShieldAlert } from "lucide-react";
+import { prisma } from "@/lib/prisma";
+import { isDemoEmail } from "@/lib/demo";
 import { requireSuperAdminPage } from "@/lib/authz";
 import { getAllFeedback } from "@/lib/services/feedback";
 import { Button } from "@/components/ui/button";
@@ -11,17 +13,36 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { AdminUserGrowthCard, type UserGrowthRecord } from "./_components/admin-user-growth-card";
 
 export default async function AdminHomePage() {
   await requireSuperAdminPage();
 
-  const feedback = await getAllFeedback();
+  const [feedback, users] = await Promise.all([
+    getAllFeedback(),
+    prisma.user.findMany({
+      select: {
+        createdAt: true,
+        email: true,
+      },
+      orderBy: {
+        createdAt: "asc",
+      },
+    }),
+  ]);
   const unreviewed = feedback.filter((item) => !item.reviewed);
   const issues = feedback.filter((item) => item.type === FeedbackType.ISSUE);
   const ideas = feedback.filter((item) => item.type === FeedbackType.IDEA);
+  const userGrowthRecords: UserGrowthRecord[] = users.map((user) => ({
+    createdAt: user.createdAt.toISOString(),
+    isDemo: isDemoEmail(user.email),
+  }));
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[1.4fr_0.9fr]">
+    <div className="grid gap-6">
+      <AdminUserGrowthCard records={userGrowthRecords} />
+
+      <div className="grid gap-6 lg:grid-cols-[1.4fr_0.9fr]">
       <Card className="overflow-hidden border-border/70 bg-card/90 shadow-sm backdrop-blur-xl">
         <CardHeader className="gap-3 border-b border-border/60 bg-muted/30">
           <div className="inline-flex w-fit items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-primary">
@@ -117,6 +138,7 @@ export default async function AdminHomePage() {
             <p>• More admin sections can be added beside it later</p>
           </CardContent>
         </Card>
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## What Changed

- Split the admin user-growth chart into its own component file.
- Improved the graph readability with clearer axis labeling and stronger point markers.
- Added active-state admin navigation tabs in the admin layout.

## Why

- The chart was hard to read and the axis interpretation was unclear.
- The admin navigation needed an obvious active tab state.

Closes #

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ Enhancement / Feature
- [x] 🔧 Refactor
- [ ] 📝 Documentation
- [x] 🎨 UI / Styling

## How to Test

1. Open the admin panel overview page.
2. Switch between the user-growth ranges and confirm the x-axis labels change appropriately.
3. Navigate between admin sections and confirm the active tab is highlighted.

## Screenshots / Recordings

<!-- Before & after if UI changed -->

## Checklist

- [ ] Tested on desktop (Chrome)
- [ ] Tested on mobile (iPhone Safari)
- [x] No lint errors (`pnpm lint`)
- [ ] Build passes (`pnpm build`)
- [ ] Smoke test updated (if applicable)

## Smoke Test Issues Resolved

<!-- List any smoke test issues this PR fixes -->

- [ ] #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added an admin user growth dashboard with time-range filtering (day, week, month, 6 months, year, lifetime)
* Introduced visual growth charts showing total and demo user trends over time (with chart points and axis/grid)
* Implemented a vertical admin navigation sidebar with active-state styling and route-aware tab selection
* Added new “New users over time” metrics cards and KPIs (new users, demo users, lifetime totals)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->